### PR TITLE
test: update custom handlers

### DIFF
--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'pathe'
 import { Miniflare } from 'miniflare'
+import destr from 'destr'
 import { describe } from 'vitest'
 
 import { setupTest, testNitro } from '../utils'
@@ -15,7 +16,7 @@ describe('nitro:preset:cloudflare', () => {
         body
       })
       return {
-        data: await res.text(),
+        data: destr(await res.text()),
         status: res.status
       }
     }

--- a/test/presets/lambda.test.ts
+++ b/test/presets/lambda.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'pathe'
 import { describe } from 'vitest'
+import destr from 'destr'
 import type { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from 'aws-lambda'
 import { setupTest, testNitro } from '../utils'
 
@@ -22,7 +23,7 @@ describe('nitro:preset:lambda', () => {
       }
       const res = await handler(event)
       return {
-        data: res.body,
+        data: destr(res.body),
         status: res.statusCode
       }
     }
@@ -51,7 +52,7 @@ describe('nitro:preset:lambda', () => {
       }
       const res = await handler(event)
       return {
-        data: res.body,
+        data: destr(res.body),
         status: res.statusCode
       }
     }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -69,7 +69,15 @@ export function testNitro (_ctx, getHandler) {
 
   it('handles errors', async () => {
     const { data, status } = await handler({ url: '/api/error' })
-    expect(data).toMatchInlineSnapshot('"{\\"url\\":\\"/\\",\\"statusCode\\":503,\\"statusMessage\\":\\"Service Unavailable\\",\\"message\\":\\"Service Unavailable\\",\\"description\\":\\"\\"}"')
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "description": "",
+        "message": "Service Unavailable",
+        "statusCode": 503,
+        "statusMessage": "Service Unavailable",
+        "url": "/",
+      }
+      `)
     expect(status).toBe(503)
     const { data: heyData } = await handler({ url: '/api/hey' })
     expect(heyData).to.have.string('Hey API')


### PR DESCRIPTION
if we wish to follow this pattern: [`a64f653` (#31)](https://github.com/unjs/nitropack/pull/31/commits/a64f653ea9a43777140b0ca186e03d3ecb64d622)

then we should also apply destr on the custom handlers for lambda & cloudflare.