### PR TITLE
fix: allow not overriding env, and allow disabling prefix

### DIFF
--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -5,12 +5,12 @@ import { snakeCase } from 'scule'
 const _runtimeConfig = process.env.RUNTIME_CONFIG as any
 
 const ENV_PREFIX = 'NITRO_'
-const ENV_PREFIX_ALT = _runtimeConfig.NITRO_ENV_PREFIX_ALT || process.env.NITRO_ENV_PREFIX_ALT || '_'
+const ENV_PREFIX_ALT = _runtimeConfig.NITRO_ENV_PREFIX_ALT ?? process.env.NITRO_ENV_PREFIX_ALT ?? '_'
 
 // Allow override from process.env and deserialize
-const getEnv = (key) => {
+const getEnv = (key: string) => {
   const envKey = snakeCase(key).toUpperCase()
-  return destr(process.env[ENV_PREFIX + envKey] ?? (ENV_PREFIX_ALT && process.env[ENV_PREFIX_ALT + envKey]))
+  return destr(process.env[ENV_PREFIX + envKey] ?? process.env[ENV_PREFIX_ALT + envKey])
 }
 
 for (const key in _runtimeConfig) {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were _always_ overriding variables with `false` if there was no `ENV_PREFIX_ALT`. This PR changes that and also makes it possible to pass an empty string in to disable prefix pattern (as an advanced use-case). (Happy to revert that last bit if it was intentional.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

