### PR TITLE
fix: export runtime types directly from `nitropack`

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,3 @@
+export type { NitroApp } from './app'
+export type { CacheEntry, CacheOptions, ResponseCacheEntry } from './cache'
+export type { NitroAppPlugin } from './plugin'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,4 @@
 export * from './fetch'
 export * from './nitro'
 export * from './handler'
-export type { NitroApp } from '../runtime/app'
-export type { CacheEntry, CacheOptions, ResponseCacheEntry } from '../runtime/cache'
-export type { NitroAppPlugin } from '../runtime/plugin'
+export * from '../runtime/types'


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Otherwise users wanting to use a type like `NitroApp` or `NitroAppPlugin` would have to do something like:

```js
import { NitroApp } from 'nitropack/dist/runtime/app'
```

...or use an internal nitro alias.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

