### PR TITLE
fix(iis-node): pass `PORT` as `NITRO_UNIX_SOCKET`

### DIFF
--- a/src/presets/iis.ts
+++ b/src/presets/iis.ts
@@ -27,7 +27,13 @@ export const iisNode = defineNitroPreset({
 
       await writeFile(
         resolve(nitro.options.output.dir, "index.js"),
-        "import('./server/index.mjs');"
+        `
+        if (process.env.PORT.startsWith('\\')) {
+          process.env.NITRO_UNIX_SOCKET = process.env.PORT
+          delete process.env.PORT
+        }
+        import('./server/index.mjs');
+        `
       );
     },
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22961 

(alternative rework of #1697 by @tidan-16)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`iis-node` runtime passes unix socket as `PORT` environment variable this makes issue for Nitro node listener (Note: this issue only related to `iisnode`, `iis` handler passes a valid port.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
