### PR TITLE
feat: allow setting `rewrite` option for devProxy

### DIFF
--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -278,6 +278,7 @@ You can use this option to override development server routes and proxy-pass req
   devProxy: {
     '/proxy/test': 'http://localhost:3001',
     '/proxy/example': { target: 'https://example.com', changeOrigin: true }
+    '/api': { target: 'https://example.com', changeOrigin: true, rewrite: (path) => path.replace(/^\/api/, '') }
   }
 }
 ```

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -5,7 +5,6 @@ import {
   App,
   createApp,
   eventHandler,
-  getRequestPath,
   fromNodeMiddleware,
   H3Error,
   H3Event,
@@ -171,8 +170,8 @@ export function createDevServer(nitro: Nitro): NitroDevServer {
       eventHandler(async (event) => {
         const { rewrite } = opts;
         if (rewrite) {
-          const path = getRequestPath(event);
-          event.node.req.url = rewrite(path);
+          event.path = rewrite(event.path);
+          event.node.req.url = event.path;
         }
         await proxy.handle(event);
       })

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -5,6 +5,7 @@ import {
   App,
   createApp,
   eventHandler,
+  getRequestPath,
   fromNodeMiddleware,
   H3Error,
   H3Event,
@@ -168,6 +169,11 @@ export function createDevServer(nitro: Nitro): NitroDevServer {
     app.use(
       route,
       eventHandler(async (event) => {
+        const { rewrite } = opts;
+        if (rewrite) {
+          const path = getRequestPath(event);
+          event.node.req.url = rewrite(path);
+        }
         await proxy.handle(event);
       })
     );

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -279,7 +279,9 @@ export interface NitroOptions extends PresetOptions {
   dev: boolean;
   devServer: DevServerOptions;
   watchOptions: WatchOptions;
-  devProxy: Record<string, string | ProxyServerOptions>;
+  devProxy: Record<string, string | ProxyServerOptions & {
+    rewrite?: (string) => string;
+  }>;
 
   // Logging
   logging: {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/1892

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a path rewrite option to devProxy config.
This is useful in case that user wants to change request path, before the request is sent to upstream server.

Resolves #1892 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
