### PR TITLE
feat(node-server): add env variables for timeout setting in node-server runtimes

### DIFF
--- a/docs/content/2.deploy/10.runtimes/node.md
+++ b/docs/content/2.deploy/10.runtimes/node.md
@@ -44,6 +44,9 @@ You can customize server behavior using following environment variables:
 - `NITRO_SHUTDOWN_SIGNALS` - Allows you to specify which signals should be handled. Each signal should be separated with a space. Defaults to `'SIGINT SIGTERM'`.
 - `NITRO_SHUTDOWN_TIMEOUT` - Sets the amount of time (in milliseconds) before a forced shutdown occurs. Defaults to `'30000'` milliseconds.
 - `NITRO_SHUTDOWN_FORCE` - When set to true, it triggers `process.exit()` at the end of the shutdown process. If it's set to `'false'`, the process will simply let the event loop clear. Defaults to `'true'`.
+- `NITRO_NODE_REQUEST_TIMEOUT` - Sets the timeout value in milliseconds for receiving the entire request from the client. Defaults to `'300000'` milliseconds.
+- `NITRO_NODE_KEEPALIVE_TIMEOUT` - The number of milliseconds of inactivity a server needs to wait for additional incoming data, after it has finished writing the last response, before a socket will be destroyed. If the server receives new data before the keep-alive timeout has fired, it will reset the regular inactivity timeout, i.e., server.timeout. Defaults to `'5000'` milliseconds.
+- `NITRO_NODE_HEADERS_TIMEOUT` - Limit the amount of time the parser will wait to receive the complete HTTP headers. Defaults to minimum between `'60000'` or `NITRO_NODE_REQUEST_TIMEOUT` milliseconds.
 
 ## Cluster mode
 

--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -23,6 +23,14 @@ const host = process.env.NITRO_HOST || process.env.HOST;
 
 const path = process.env.NITRO_UNIX_SOCKET;
 
+const requestTimeout = (destr(process.env.NITRO_NODE_REQUEST_TIMEOUT) || 300000) as number
+const keepAliveTimeout = (destr(process.env.NITRO_NODE_KEEPALIVE_TIMEOUT) || 5000) as number
+const headersTimeout = Math.min(destr(process.env.NITRO_NODE_HEADERS_TIMEOUT) || 60000, requestTimeout)
+
+server.requestTimeout = requestTimeout
+server.keepAliveTimeout = keepAliveTimeout
+server.headersTimeout = headersTimeout
+
 // @ts-ignore
 const listener = server.listen(path ? { path } : { port, host }, (err) => {
   if (err) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
When deploy node runtime to behind AWS ELB, timeout missmatching can leads to 502 error.
For resolve this error, we have to set timeout values in HttpServer.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
