### PR TITLE
fix: encode buffer responses from cached event handler

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -44,16 +44,6 @@ const defaultCacheOptions = {
   maxAge: 1,
 };
 
-function base64ToArray(base64: string) {
-  const str = atob(base64);
-  const bytes = new Uint8Array(str.length);
-  for (let i = 0; i < str.length; i++) {
-    // eslint-disable-next-line unicorn/prefer-code-point
-    bytes[i] = str.charCodeAt(i);
-  }
-  return bytes;
-}
-
 export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
   fn: (...args: ArgsT) => T | Promise<T>,
   opts: CacheOptions<T> = {}
@@ -245,10 +235,9 @@ export function defineCachedEventHandler<
   const _opts: CacheOptions<ResponseCacheEntry<Response>> = {
     ...opts,
     transform(entry) {
+      // TODO use unstorage raw API https://github.com/unjs/unstorage/issues/142
       if (entry.value._base64Encoded) {
-        entry.value.body = Buffer.from(
-          base64ToArray(entry.value.body as any as string)
-        ) as Response;
+        entry.value.body = Buffer.from(entry.value.body as any as string, 'base64') as Response;
         delete entry.value._base64Encoded;
       }
     },
@@ -404,6 +393,7 @@ export function defineCachedEventHandler<
         headers,
         body,
       };
+      // TODO use unstorage raw API https://github.com/unjs/unstorage/issues/142
       if (cacheEntry.body instanceof Buffer) {
         cacheEntry.body = Buffer.from(body as ArrayBuffer).toString(
           "base64"

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -237,7 +237,10 @@ export function defineCachedEventHandler<
     transform(entry) {
       // TODO use unstorage raw API https://github.com/unjs/unstorage/issues/142
       if (entry.value._base64Encoded) {
-        entry.value.body = Buffer.from(entry.value.body as any as string, 'base64') as Response;
+        entry.value.body = Buffer.from(
+          entry.value.body as any as string,
+          "base64"
+        ) as Response;
         delete entry.value._base64Encoded;
       }
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/unjs/nitro/issues/1894

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Caching an endpoint that returns a buffer will break the endpoint. As an easy fix, we just base 64 encode whatever the result is and mark it as so.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
