### PR TITLE
feat(edgio): support v7 edgio application

### DIFF
--- a/docs/content/2.deploy/20.providers/edgio.md
+++ b/docs/content/2.deploy/20.providers/edgio.md
@@ -24,10 +24,11 @@ You can use Nitropack to test your app's developement experience locally:
 NITRO_PRESET=edgio npx nitropack build
 ```
 
-To simulate on local how your app would run in production with Edgio, run the following command:
+To simulate on local how your app would run in production with Edgio, locate the output directory and run the following command:
 
 ```bash
-edgio build && edgio run --production
+# cd `.output` dir and install dependencies before then
+npm run preview
 ```
 
 ## Deploying from your local machine
@@ -35,7 +36,7 @@ edgio build && edgio run --production
 Once you have tested your application locally, you may deploy using:
 
 ```bash
-edgio deploy
+npm run deploy
 ```
 
 ## Deploying using CI/CD
@@ -43,5 +44,5 @@ edgio deploy
 If you are deploying from a non-interactive environment, you will need to create an account on [Edgio Developer Console](https://app.layer0.co) first and setup a [deploy token](https://docs.edg.io/guides/basics/deployments#deploy-from-ci). Once the deploy token is created, save it as a secret to your environment. You can start the deploy by running:
 
 ```bash
-edgio deploy --token=XXX
+npm run deploy --token=XXX
 ```

--- a/src/presets/edgio.ts
+++ b/src/presets/edgio.ts
@@ -27,12 +27,8 @@ export const edgio = defineNitroPreset({
         resolve(nitro.options.output.dir, "edgio.config.js"),
         `module.exports = ${JSON.stringify(
           {
-            connector: "./edgio",
+            connector: "@edgio/nitropack",
             routes: "./routes.js",
-            backends: {},
-            includeFiles: {
-              "server/**": true,
-            },
           },
           null,
           2
@@ -43,32 +39,18 @@ export const edgio = defineNitroPreset({
       await writeFile(
         resolve(nitro.options.output.dir, "routes.js"),
         `
-import { Router } from '@edgio/core/router'
-import { isProductionBuild } from '@edgio/core/environment'
+import { isProductionBuild } from "@edgio/core/environment";
+import { Router } from "@edgio/core/router";
+import { nitropackRoutes } from "@edgio/nitropack";
 
-const router = new Router()
+const router = new Router().use(nitropackRoutes);
 
 if (isProductionBuild()) {
-  router.static('public')
+  router.static("public");
 }
 
-router.fallback(({ renderWithApp }) => { renderWithApp() })
-
-export default router
+export default router;
     `.trim()
-      );
-
-      // Write edgio/prod.js
-      await writeFile(
-        resolve(nitro.options.output.dir, "edgio/prod.js"),
-        `
-module.exports = async function entry (port) {
-  process.env.PORT = process.env.NITRO_PORT = port.toString()
-  console.log('Starting Edgio server on port', port)
-  await import('../server/index.mjs')
-  console.log('Edgio server started')
-}
-      `.trim()
       );
 
       // Write and prepare package.json for deployment
@@ -86,8 +68,9 @@ module.exports = async function entry (port) {
               preview: "npm i && edgio build && edgio run --production",
             },
             devDependencies: {
-              "@edgio/cli": "^6",
-              "@edgio/core": "^6",
+              "@edgio/cli": "^7",
+              "@edgio/core": "^7",
+              "@edgio/nitropack": "^7",
             },
           },
           null,

--- a/src/presets/edgio.ts
+++ b/src/presets/edgio.ts
@@ -27,7 +27,7 @@ export const edgio = defineNitroPreset({
         resolve(nitro.options.output.dir, "edgio.config.js"),
         `module.exports = ${JSON.stringify(
           {
-            connector: "@edgio/nitropack",
+            connector: "./edgio",
             routes: "./routes.js",
           },
           null,
@@ -39,18 +39,117 @@ export const edgio = defineNitroPreset({
       await writeFile(
         resolve(nitro.options.output.dir, "routes.js"),
         `
+import { edgioRoutes } from "@edgio/core";
 import { isProductionBuild } from "@edgio/core/environment";
 import { Router } from "@edgio/core/router";
-import { nitropackRoutes } from "@edgio/nitropack";
 
-const router = new Router().use(nitropackRoutes);
-
+const router = new Router();
+router.match("/:path*", ({ renderWithApp }) => {
+  renderWithApp();
+});
 if (isProductionBuild()) {
   router.static("public");
 }
+router.use(edgioRoutes);
 
 export default router;
-    `.trim()
+        `.trim()
+      );
+
+      // Write edgio/build.js
+      await writeFile(
+        resolve(nitro.options.output.dir, "edgio/build.js"),
+        `
+const path = require("path");
+const deploy = require("@edgio/core/deploy");
+const FrameworkBuildError = require("@edgio/core/errors/FrameworkBuildError");
+
+function _interopDefaultCompat(e) {
+  return e && typeof e === "object" && "default" in e ? e.default : e;
+}
+
+const FrameworkBuildError__default =
+  /*#__PURE__*/ _interopDefaultCompat(FrameworkBuildError);
+
+const appDir = process.cwd();
+async function build(options) {
+  const builder = new deploy.DeploymentBuilder();
+  builder.clearPreviousBuildOutput();
+  if (!options.skipFramework) {
+    const command = "node ./server/index.mjs";
+    try {
+      await builder.exec(command);
+    } catch (e) {
+      throw new FrameworkBuildError__default("Nitropack", command, e);
+    }
+  }
+  builder.addJSAsset(path.join(appDir, "server"));
+  await builder.build();
+}
+
+module.exports = build;
+        `.trim()
+      );
+
+      // Write edgio/dev.js
+      await writeFile(
+        resolve(nitro.options.output.dir, "edgio/dev.js"),
+        `
+const dev$1 = require("@edgio/core/dev");
+
+function dev() {
+  const isWin = process.platform === "win32";
+  return dev$1.createDevServer({
+    label: "Nitropack",
+    command: (port) =>
+      isWin
+        ? ${"`set PORT=${port} && node ./server/index.mjs`"}
+        : ${"`PORT=${port} node ./server/index.mjs`"},
+    ready: [/localhost:/i],
+  });
+}
+
+module.exports = dev;
+        `.trim()
+      );
+
+      // Write edgio/init.js
+      await writeFile(
+        resolve(nitro.options.output.dir, "edgio/init.js"),
+        `
+const path = require("path");
+const deploy = require("@edgio/core/deploy");
+
+function init() {
+  new deploy.DeploymentBuilder(process.cwd())
+    .addDefaultAppResources(path.join(__dirname, "default-app"))
+    .addDefaultEdgioScripts();
+}
+
+module.exports = init;
+        `.trim()
+      );
+
+      // Write edgio/prod.js
+      await writeFile(
+        resolve(nitro.options.output.dir, "edgio/prod.js"),
+        `
+const path = require("path");
+const fs = require("fs");
+
+async function prod(port) {
+  const appFilePath = path.resolve("server", "index.mjs");
+  if (fs.existsSync(appFilePath)) {
+    process.env.NITRO_PORT = port.toString();
+    return await import(
+      /* webpackIgnore: true */
+      appFilePath
+    );
+  }
+}
+
+module.exports = prod;
+        `.trim()
       );
 
       // Write and prepare package.json for deployment
@@ -70,7 +169,6 @@ export default router;
             devDependencies: {
               "@edgio/cli": "^7",
               "@edgio/core": "^7",
-              "@edgio/nitropack": "^7",
             },
           },
           null,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Fixed: https://github.com/unjs/nitro/issues/1405

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The edgio application has been migrated to the v7 platform and the old edgio presets are no longer available, fixed and replaced with the official connector `@edgio/nitropack`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
