### PR TITLE
fix(cache): respect staleMaxAge option

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -145,7 +145,13 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       event.waitUntil(_resolvePromise);
     }
 
-    if (opts.swr && validate(entry) !== false) {
+    const staleTtl = (opts.staleMaxAge ?? 0) * 1000;
+    const staleExpired =
+      shouldInvalidateCache ||
+      entry.integrity !== integrity ||
+      (staleTtl && Date.now() - (entry.mtime || 0) > staleTtl) ||
+      validate(entry) === false;
+    if (opts.swr && !staleExpired) {
       _resolvePromise.catch((error) => {
         console.error(`[cache] SWR handler error.`, error);
         useNitroApp().captureError(error, { event, tags: ["cache"] });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#2164 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change ensures that stale responses are only used if they have not exceeded the period defined in `staleMaxAge`. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
