### PR TITLE
fix(imports): use explicit import for `useDatabase`

### DIFF
--- a/src/core/config/resolvers/database.ts
+++ b/src/core/config/resolvers/database.ts
@@ -3,7 +3,7 @@ import type { NitroOptions } from "nitropack/types";
 export async function resolveDatabaseOptions(options: NitroOptions) {
   if (options.experimental.database && options.imports) {
     options.imports.presets.push({
-      from: "nitropack/runtime",
+      from: "nitropack/runtime/internal/database",
       imports: ["useDatabase"],
     });
     if (options.dev && !options.database && !options.devDatabase) {

--- a/src/core/config/resolvers/imports.ts
+++ b/src/core/config/resolvers/imports.ts
@@ -58,26 +58,53 @@ export async function resolveImportsOptions(options: NitroOptions) {
 function getNitroImportsPreset(): Preset[] {
   return [
     {
-      from: "nitropack/runtime",
+      from: "nitropack/runtime/internal/app",
+      imports: ["useNitroApp"],
+    },
+    {
+      from: "nitropack/runtime/internal/config",
+      imports: ["useRuntimeConfig", "useAppConfig"],
+    },
+    {
+      from: "nitropack/runtime/internal/plugin",
+      imports: ["defineNitroPlugin", "nitroPlugin"],
+    },
+    {
+      from: "nitropack/runtime/internal/cache",
       imports: [
         "defineCachedFunction",
         "defineCachedEventHandler",
         "cachedFunction",
         "cachedEventHandler",
-        "useRuntimeConfig",
-        "useStorage",
-        "useNitroApp",
-        "defineNitroPlugin",
-        "nitroPlugin",
-        "defineRenderHandler",
-        "defineRouteMeta",
-        "getRouteRules",
-        "useAppConfig",
-        "useEvent",
-        "defineTask",
-        "runTask",
-        "defineNitroErrorHandler",
       ],
+    },
+    {
+      from: "nitropack/runtime/internal/storage",
+      imports: ["useStorage"],
+    },
+    {
+      from: "nitropack/runtime/internal/renderer",
+      imports: ["defineRenderHandler"],
+    },
+    {
+      from: "nitropack/runtime/internal/meta",
+      imports: ["defineRouteMeta"],
+    },
+    {
+      from: "nitropack/runtime/internal/route-rules",
+      imports: ["getRouteRules"],
+    },
+    {
+      from: "nitropack/runtime/internal/context",
+      imports: ["useEvent"],
+    },
+    {
+      from: "nitropack/runtime/internal/task",
+      imports: ["defineTask", "runTask"],
+    },
+    {
+      from: "nitropack/runtime/internal/error",
+      imports: ["defineNitroErrorHandler"],
     },
   ];
 }

--- a/src/core/config/resolvers/imports.ts
+++ b/src/core/config/resolvers/imports.ts
@@ -58,53 +58,26 @@ export async function resolveImportsOptions(options: NitroOptions) {
 function getNitroImportsPreset(): Preset[] {
   return [
     {
-      from: "nitropack/runtime/internal/app",
-      imports: ["useNitroApp"],
-    },
-    {
-      from: "nitropack/runtime/internal/config",
-      imports: ["useRuntimeConfig", "useAppConfig"],
-    },
-    {
-      from: "nitropack/runtime/internal/plugin",
-      imports: ["defineNitroPlugin", "nitroPlugin"],
-    },
-    {
-      from: "nitropack/runtime/internal/cache",
+      from: "nitropack/runtime",
       imports: [
         "defineCachedFunction",
         "defineCachedEventHandler",
         "cachedFunction",
         "cachedEventHandler",
+        "useRuntimeConfig",
+        "useStorage",
+        "useNitroApp",
+        "defineNitroPlugin",
+        "nitroPlugin",
+        "defineRenderHandler",
+        "defineRouteMeta",
+        "getRouteRules",
+        "useAppConfig",
+        "useEvent",
+        "defineTask",
+        "runTask",
+        "defineNitroErrorHandler",
       ],
-    },
-    {
-      from: "nitropack/runtime/internal/storage",
-      imports: ["useStorage"],
-    },
-    {
-      from: "nitropack/runtime/internal/renderer",
-      imports: ["defineRenderHandler"],
-    },
-    {
-      from: "nitropack/runtime/internal/meta",
-      imports: ["defineRouteMeta"],
-    },
-    {
-      from: "nitropack/runtime/internal/route-rules",
-      imports: ["getRouteRules"],
-    },
-    {
-      from: "nitropack/runtime/internal/context",
-      imports: ["useEvent"],
-    },
-    {
-      from: "nitropack/runtime/internal/task",
-      imports: ["defineTask", "runTask"],
-    },
-    {
-      from: "nitropack/runtime/internal/error",
-      imports: ["defineNitroErrorHandler"],
     },
   ];
 }


### PR DESCRIPTION
Resolves #2832

Using explicit import paths for generated `#imports`, helps rollup to sort order of dependencies properly.

This PR fixes `useDatabase` issue.

(we might have similar ordering issues for other auto imports)