### PR TITLE
fix(rollup): check raw extensions against resolved id

### DIFF
--- a/src/rollup/plugins/raw.ts
+++ b/src/rollup/plugins/raw.ts
@@ -29,15 +29,9 @@ export function raw(opts: RawOptions = {}): Plugin {
         return;
       }
 
-      let isRawId = id.startsWith("raw:");
-      if (isRawId) {
+      const withRawSpecifier = id.startsWith("raw:");
+      if (withRawSpecifier) {
         id = id.slice(4);
-      } else if (extensions.has(extname(id))) {
-        isRawId = true;
-      }
-
-      if (!isRawId) {
-        return;
       }
 
       const resolvedId = (await this.resolve(id, importer, { skipSelf: true }))
@@ -45,6 +39,10 @@ export function raw(opts: RawOptions = {}): Plugin {
 
       if (!resolvedId || resolvedId.startsWith("\0")) {
         return resolvedId;
+      }
+
+      if (!withRawSpecifier && !extensions.has(extname(resolvedId))) {
+        return;
       }
 
       return { id: "\0raw:" + resolvedId };


### PR DESCRIPTION
Resolves #2836

Raw plugin tries to guess type of raw asset imports based on known extensions (like `.sql` and `.pdf`)

There was an issue where we are checking the extension before full resolution. If there is a ts import like `../foo.sql` (which actually resolves to `../foo.sql.ts`) we were wrongly picking it as raw asset. 