### PR TITLE
fix(imports): use explicit imports

### DIFF
--- a/src/core/config/resolvers/imports.ts
+++ b/src/core/config/resolvers/imports.ts
@@ -58,26 +58,53 @@ export async function resolveImportsOptions(options: NitroOptions) {
 function getNitroImportsPreset(): Preset[] {
   return [
     {
-      from: "nitropack/runtime",
+      from: "nitropack/runtime/internal/app",
+      imports: ["useNitroApp"],
+    },
+    {
+      from: "nitropack/runtime/internal/config",
+      imports: ["useRuntimeConfig", "useAppConfig"],
+    },
+    {
+      from: "nitropack/runtime/internal/plugin",
+      imports: ["defineNitroPlugin", "nitroPlugin"],
+    },
+    {
+      from: "nitropack/runtime/internal/cache",
       imports: [
         "defineCachedFunction",
         "defineCachedEventHandler",
         "cachedFunction",
         "cachedEventHandler",
-        "useRuntimeConfig",
-        "useStorage",
-        "useNitroApp",
-        "defineNitroPlugin",
-        "nitroPlugin",
-        "defineRenderHandler",
-        "defineRouteMeta",
-        "getRouteRules",
-        "useAppConfig",
-        "useEvent",
-        "defineTask",
-        "runTask",
-        "defineNitroErrorHandler",
       ],
+    },
+    {
+      from: "nitropack/runtime/internal/storage",
+      imports: ["useStorage"],
+    },
+    {
+      from: "nitropack/runtime/internal/renderer",
+      imports: ["defineRenderHandler"],
+    },
+    {
+      from: "nitropack/runtime/internal/meta",
+      imports: ["defineRouteMeta"],
+    },
+    {
+      from: "nitropack/runtime/internal/route-rules",
+      imports: ["getRouteRules"],
+    },
+    {
+      from: "nitropack/runtime/internal/context",
+      imports: ["useEvent"],
+    },
+    {
+      from: "nitropack/runtime/internal/task",
+      imports: ["defineTask", "runTask"],
+    },
+    {
+      from: "nitropack/runtime/internal/error",
+      imports: ["defineNitroErrorHandler"],
     },
   ];
 }

--- a/test/fixture/.env
+++ b/test/fixture/.env
@@ -1,1 +1,2 @@
 APP_DOMAIN=test.com
+NITRO_DYNAMIC=from-env

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -102,6 +102,7 @@ export async function setupTest(
       CUSTOM_HELLO_THERE: "general",
       SECRET: "secret",
       APP_DOMAIN: "test.com",
+      NITRO_DYNAMIC: "from-env",
     },
     fetch: (url, opts) =>
       fetch(joinURL(ctx.server!.url, url.slice(1)), {
@@ -503,7 +504,8 @@ export function testNitro(
         "server-config": true,
       },
       sharedRuntimeConfig: {
-        dynamic: "from-env",
+        // Cloudflare environment variables are set after first request
+        dynamic: ctx.preset.includes("cloudflare") ? "initial" : "from-env",
         // url: "https://test.com",
         app: {
           baseURL: "/",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -505,7 +505,11 @@ export function testNitro(
       },
       sharedRuntimeConfig: {
         // Cloudflare environment variables are set after first request
-        dynamic: ctx.preset.includes("cloudflare") ? "initial" : "from-env",
+        dynamic:
+          ctx.preset.includes("cloudflare") &&
+          ctx.preset !== "cloudflare-worker"
+            ? "initial"
+            : "from-env",
         // url: "https://test.com",
         app: {
           baseURL: "/",


### PR DESCRIPTION
Resolves #2833 

Similar fix of #2837 for all built-in nitro auto imports. Using explicit entries, rollup can better sort the chunks order.

--- 
Tests for cloudflare had been updated since now with explicit behavior, we have cloudflare limitation that `useRuntimeConfig()` in ambient context (and before first request) does not have access to the environment variable bindings.