### PR TITLE
fix(rollup): pass options to `resolve`

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -407,14 +407,14 @@ export const plugins = [
   if (nitro.options.noExternals) {
     rollupConfig.plugins.push({
       name: "no-externals",
-      async resolveId(id, from, options) {
+      async resolveId(id, from, resolveOpts) {
         if (
           nitro.options.node &&
           (id.startsWith("node:") || builtinModules.includes(id))
         ) {
           return { id, external: true };
         }
-        const resolved = await this.resolve(id, from, options);
+        const resolved = await this.resolve(id, from, resolveOpts);
         if (!resolved) {
           const _resolved = await resolvePath(id, {
             url: nitro.options.nodeModulesDirs,

--- a/src/rollup/plugins/externals-legacy.ts
+++ b/src/rollup/plugins/externals-legacy.ts
@@ -52,7 +52,7 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
   return {
     name: "node-externals",
-    async resolveId(originalId, importer, options) {
+    async resolveId(originalId, importer, resolveOpts) {
       // Skip internals
       if (
         !originalId ||
@@ -86,7 +86,11 @@ export function externals(opts: NodeExternalsOptions): Plugin {
       }
 
       // Resolve id using rollup resolver
-      const resolved = (await this.resolve(originalId, importer, options)) || {
+      const resolved = (await this.resolve(
+        originalId,
+        importer,
+        resolveOpts
+      )) || {
         id,
       };
 

--- a/src/rollup/plugins/handlers-meta.ts
+++ b/src/rollup/plugins/handlers-meta.ts
@@ -18,12 +18,16 @@ const esbuildLoaders = {
 export function handlersMeta(nitro: Nitro) {
   return {
     name: "nitro:handlers-meta",
-    async resolveId(id) {
+    async resolveId(id, importer, options) {
       if (id.startsWith("\0")) {
         return;
       }
       if (id.endsWith(`?meta`)) {
-        const resolved = await this.resolve(id.replace(`?meta`, ``));
+        const resolved = await this.resolve(
+          id.replace(`?meta`, ``),
+          importer,
+          options
+        );
         if (!resolved) {
           return;
         }

--- a/src/rollup/plugins/handlers-meta.ts
+++ b/src/rollup/plugins/handlers-meta.ts
@@ -18,7 +18,7 @@ const esbuildLoaders = {
 export function handlersMeta(nitro: Nitro) {
   return {
     name: "nitro:handlers-meta",
-    async resolveId(id, importer, options) {
+    async resolveId(id, importer, resolveOpts) {
       if (id.startsWith("\0")) {
         return;
       }
@@ -26,7 +26,7 @@ export function handlersMeta(nitro: Nitro) {
         const resolved = await this.resolve(
           id.replace(`?meta`, ``),
           importer,
-          options
+          resolveOpts
         );
         if (!resolved) {
           return;

--- a/src/rollup/plugins/raw.ts
+++ b/src/rollup/plugins/raw.ts
@@ -20,7 +20,7 @@ export function raw(opts: RawOptions = {}): Plugin {
 
   return {
     name: "raw",
-    async resolveId(id, importer, options) {
+    async resolveId(id, importer, resolveOpts) {
       if (id === HELPER_ID) {
         return id;
       }
@@ -34,7 +34,7 @@ export function raw(opts: RawOptions = {}): Plugin {
         id = id.slice(4);
       }
 
-      const resolvedId = (await this.resolve(id, importer, options))?.id;
+      const resolvedId = (await this.resolve(id, importer, resolveOpts))?.id;
 
       if (!resolvedId || resolvedId.startsWith("\0")) {
         return resolvedId;

--- a/src/rollup/plugins/raw.ts
+++ b/src/rollup/plugins/raw.ts
@@ -20,7 +20,7 @@ export function raw(opts: RawOptions = {}): Plugin {
 
   return {
     name: "raw",
-    async resolveId(id, importer) {
+    async resolveId(id, importer, options) {
       if (id === HELPER_ID) {
         return id;
       }
@@ -34,8 +34,7 @@ export function raw(opts: RawOptions = {}): Plugin {
         id = id.slice(4);
       }
 
-      const resolvedId = (await this.resolve(id, importer, { skipSelf: true }))
-        ?.id;
+      const resolvedId = (await this.resolve(id, importer, options))?.id;
 
       if (!resolvedId || resolvedId.startsWith("\0")) {
         return resolvedId;


### PR DESCRIPTION
Resolves #2841

Rollup expects resolve options from `resolveId` to be passed through.

`skipSelf: true` override removed for static since it is now default behavior in rollup.