### PR TITLE
fix(netlify): only include env polyfill in `netlify-edge`

### DIFF
--- a/src/presets/netlify/legacy/runtime/netlify-builder.ts
+++ b/src/presets/netlify/legacy/runtime/netlify-builder.ts
@@ -1,5 +1,4 @@
 import "#nitro-internal-pollyfills";
-import "./_deno-env-polyfill";
 
 import { builder } from "@netlify/functions";
 import { lambda } from "./netlify-lambda";

--- a/src/presets/netlify/legacy/runtime/netlify-lambda.ts
+++ b/src/presets/netlify/legacy/runtime/netlify-lambda.ts
@@ -1,5 +1,4 @@
 import "#nitro-internal-pollyfills";
-import "./_deno-env-polyfill";
 import { useNitroApp } from "nitropack/runtime";
 import {
   normalizeCookieHeader,

--- a/src/presets/netlify/legacy/runtime/netlify.ts
+++ b/src/presets/netlify/legacy/runtime/netlify.ts
@@ -1,5 +1,4 @@
 import "#nitro-internal-pollyfills";
-import "./_deno-env-polyfill";
 import type { Handler } from "@netlify/functions";
 import { getRouteRulesForPath } from "nitropack/runtime/internal";
 import { withQuery } from "ufo";

--- a/src/presets/netlify/runtime/netlify-edge.ts
+++ b/src/presets/netlify/runtime/netlify-edge.ts
@@ -1,4 +1,5 @@
 import "#nitro-internal-pollyfills";
+import "./_deno-env-polyfill";
 import { useNitroApp } from "nitropack/runtime";
 import { isPublicAssetURL } from "#nitro-internal-virtual/public-assets";
 import type { Context } from "@netlify/edge-functions";

--- a/src/presets/netlify/runtime/netlify.ts
+++ b/src/presets/netlify/runtime/netlify.ts
@@ -1,5 +1,4 @@
 import "#nitro-internal-pollyfills";
-import "./_deno-env-polyfill";
 import { useNitroApp } from "nitropack/runtime";
 import {
   getRouteRulesForPath,


### PR DESCRIPTION
### 🔗 Linked issue

Discussed on Discord. Possibly also related to https://discord.com/channels/473401852243869706/1303374973465006102/1303374973465006102.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

https://github.com/nitrojs/nitro/commit/93d002b72f772fd15153edf01d26298796d7f924 introduced a regression by importing the Deno env polyfill in _all_ Netlify presets rather than just the Netlify Edge preset(s). This fixes that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
