### PR TITLE
fix(config): add back default storage mounts

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -11,8 +11,8 @@ import type {
 
 import { NitroDefaults } from "./defaults";
 
-import { resolveAssetsOptions } from "./resolvers/assets";
 // Resolvers
+import { resolveAssetsOptions } from "./resolvers/assets";
 import {
   fallbackCompatibilityDate,
   resolveCompatibilityOptions,
@@ -25,6 +25,7 @@ import { resolveOpenAPIOptions } from "./resolvers/open-api";
 import { resolvePathOptions } from "./resolvers/paths";
 import { resolveRouteRulesOptions } from "./resolvers/route-rules";
 import { resolveRuntimeConfigOptions } from "./resolvers/runtime-config";
+import { resolveStorageOptions } from "./resolvers/storage";
 import { resolveURLOptions } from "./resolvers/url";
 
 const configResolvers = [
@@ -39,6 +40,7 @@ const configResolvers = [
   resolveOpenAPIOptions,
   resolveURLOptions,
   resolveAssetsOptions,
+  resolveStorageOptions,
 ] as const;
 
 export async function loadOptions(

--- a/test/fixture/api/storage/src.dev.ts
+++ b/test/fixture/api/storage/src.dev.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+  const storage = useStorage();
+  return {
+    keys: await storage.getKeys("src"),
+  };
+});

--- a/test/presets/nitro-dev.test.ts
+++ b/test/presets/nitro-dev.test.ts
@@ -23,6 +23,12 @@ describe.skipIf(isCI)("nitro:preset:nitro-dev", async () => {
         expect(status).toBe(200);
       });
 
+      it("dev storage", async () => {
+        const { data } = await callHandler({ url: "/api/storage/src" });
+        expect(data.keys.length).toBeGreaterThan(0);
+        expect(data.keys).includes("src:nitro.config.ts");
+      });
+
       describe("openAPI", () => {
         let spec: OpenAPI3;
         it("/_openapi.json", async () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -183,7 +183,10 @@ type TestHandler = (options: any) => Promise<TestHandlerResult | Response>;
 export function testNitro(
   ctx: Context,
   getHandler: () => TestHandler | Promise<TestHandler>,
-  additionalTests?: (ctx: Context, callHandler: TestHandler) => void
+  additionalTests?: (
+    ctx: Context,
+    callHandler: (options: any) => Promise<TestHandlerResult>
+  ) => void
 ) {
   let _handler: TestHandler;
 


### PR DESCRIPTION
(reported by `@mrk` through @atinux on discord)

With nitro 2.10 refactors, we were missing default storage mounts by mistake. 