### PR TITLE
docs(alwaysdata): fix casting

### DIFF
--- a/docs/2.deploy/20.providers/alwaysdata.md
+++ b/docs/2.deploy/20.providers/alwaysdata.md
@@ -1,4 +1,4 @@
-# Alwaysdata
+# alwaysdata
 
 > Deploy Nitro apps to alwaysdata.
 


### PR DESCRIPTION
`alwaysdata` starts with lowercase `a`. It is there naming convention I think 

https://www.alwaysdata.com/en/ 
https://www.linkedin.com/company/alwaysdata/