### PR TITLE
fix(config): use static preset if `static` flag is set

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -100,11 +100,13 @@ async function _loadUserConfig(
       preset: presetOverride,
     },
     async defaultConfig({ configs }) {
+      const getConf = <K extends keyof NitroConfig>(key: K) =>
+        (configs.main?.[key] ??
+          configs.rc?.[key] ??
+          configs.packageJson?.[key]) as NitroConfig[K];
+
       if (!compatibilityDate) {
-        compatibilityDate =
-          configs.main?.compatibilityDate ||
-          configs.rc?.compatibilityDate ||
-          configs.packageJson?.compatibilityDate;
+        compatibilityDate = getConf("compatibilityDate");
       }
       const framework = configs.overrides?.framework || configs.main?.framework;
       return {
@@ -116,7 +118,7 @@ async function _loadUserConfig(
           presetOverride ||
           (
             await resolvePreset("" /* auto detect */, {
-              static: configOverrides.static,
+              static: getConf("static"),
               compatibilityDate: compatibilityDate || fallbackCompatibilityDate,
             })
           )?._meta?.name,


### PR DESCRIPTION
resolves #1568 

Infer using `static` preset (for default) if `static: true` config is set.