### PR TITLE
fix: scan route files with other chars in param name

### DIFF
--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -98,7 +98,7 @@ export async function scanServerRoutes(
       .replace(/\(([^(/\\]+)\)[/\\]/g, "")
       .replace(/\[\.{3}]/g, "**")
       .replace(/\[\.{3}(\w+)]/g, "**:$1")
-      .replace(/\[(\w+)]/g, ":$1");
+      .replace(/\[([^/\]]+)]/g, ":$1");
     route = withLeadingSlash(withoutTrailingSlash(withBase(route, prefix)));
 
     const suffixMatch = route.match(suffixRegex);

--- a/test/fixture/api/param/[test-id].ts
+++ b/test/fixture/api/param/[test-id].ts
@@ -1,4 +1,4 @@
 export default eventHandler((event) => {
   setHeader(event, "Content-Type", "text/plain; charset=utf-16");
-  return event.context.params!.id;
+  return event.context.params!["test-id"];
 });


### PR DESCRIPTION
resolves #2868

radix3 matcher allows wider matches per segment (as long as starts or in newer version contains `:`).

This PR relaxes `/[param]/` to `/:param/` normalization regex.