### PR TITLE
Don't use options object for listening on unix socket

### DIFF
--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -29,7 +29,7 @@ const host = process.env.NITRO_HOST || process.env.HOST;
 const path = process.env.NITRO_UNIX_SOCKET;
 
 // @ts-ignore
-const listener = server.listen(path ? { path } : { port, host }, (err) => {
+const listener = server.listen(path ? path : { port, host }, (err) => {
   if (err) {
     console.error(err);
     // eslint-disable-next-line unicorn/no-process-exit


### PR DESCRIPTION
This change is so nitro works on a passenger server with autoinstall turned on

https://www.phusionpassenger.com/library/indepth/nodejs/reverse_port_binding.html

The gist is that if we have multiple server.listen on passenger, we need to disable autoinstall and instead call `server.listen('passenger', ...)`

It is very important that the parameter is a string, it cannot be passed as an object like `{path: 'passenger'}` or `{port: 'passenger'}`, otherwise passenger doesn't pick up on it and instead the server will be registered on a unix socket `passenger` in the cwd
