### PR TITLE
Introducing Nitro Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://flat.badgen.net/npm/v/nitropack)](https://npmjs.com/package/nitropack)
 [![npm downloads](https://flat.badgen.net/npm/dm/nitropack)](https://npmjs.com/package/nitropack)
-[![Gurubase](https://flat.badgen.net/badge/Gurubase-Ask%20Nitro%20Guru-006BFF)](https://gurubase.io/g/nitro)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Nitro%20Guru-006BFF)](https://gurubase.io/g/nitro)
 
 <!-- /automd -->
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![npm version](https://flat.badgen.net/npm/v/nitropack)](https://npmjs.com/package/nitropack)
 [![npm downloads](https://flat.badgen.net/npm/dm/nitropack)](https://npmjs.com/package/nitropack)
+[![Gurubase](https://flat.badgen.net/badge/Gurubase-Ask%20Nitro%20Guru-006BFF)](https://gurubase.io/g/nitro)
 
 <!-- /automd -->
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Nitro Guru](https://gurubase.io/g/nitro) to Gurubase. Nitro Guru uses the data from this repo and data from the [docs](https://nitro.build) to answer questions by leveraging the LLM.

In this PR, I showcased the "Nitro Guru", which highlights that Nitro now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Nitro Guru in Gurubase, just let me know that's totally fine.
