### PR TITLE
fix(node-cluster): fix node cluster preset

### DIFF
--- a/src/presets/node/runtime/node-cluster.ts
+++ b/src/presets/node/runtime/node-cluster.ts
@@ -62,11 +62,13 @@ function runMaster() {
 }
 
 function runWorker() {
-  import("./node-server").catch((error) => {
-    console.error(error);
-    // eslint-disable-next-line unicorn/no-process-exit
-    process.exit(1);
-  });
+  import("./node-server")
+    .then(({ serverWorker }) => serverWorker())
+    .catch((error) => {
+      console.error(error);
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    });
 }
 
 // Trap unhandled errors

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -12,60 +12,65 @@ import {
   trapUnhandledNodeErrors,
 } from "nitropack/runtime/internal";
 
-const cert = process.env.NITRO_SSL_CERT;
-const key = process.env.NITRO_SSL_KEY;
+export const serverWorker = async () => {
 
-const nitroApp = useNitroApp();
-
-const server =
-  cert && key
-    ? new HttpsServer({ key, cert }, toNodeListener(nitroApp.h3App))
-    : new HttpServer(toNodeListener(nitroApp.h3App));
-
-const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
-  3000) as number;
-const host = process.env.NITRO_HOST || process.env.HOST;
-
-const path = process.env.NITRO_UNIX_SOCKET;
-
-// @ts-ignore
-const listener = server.listen(path ? { path } : { port, host }, (err) => {
-  if (err) {
-    console.error(err);
-    // eslint-disable-next-line unicorn/no-process-exit
-    process.exit(1);
+  const cert = process.env.NITRO_SSL_CERT;
+  const key = process.env.NITRO_SSL_KEY;
+  
+  const nitroApp = useNitroApp();
+  
+  const server =
+    cert && key
+      ? new HttpsServer({ key, cert }, toNodeListener(nitroApp.h3App))
+      : new HttpServer(toNodeListener(nitroApp.h3App));
+  
+  const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
+    3000) as number;
+  const host = process.env.NITRO_HOST || process.env.HOST;
+  
+  const path = process.env.NITRO_UNIX_SOCKET;
+  
+  // @ts-ignore
+  const listener = server.listen(path ? { path } : { port, host }, (err) => {
+    if (err) {
+      console.error(err);
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    }
+    const protocol = cert && key ? "https" : "http";
+    const addressInfo = listener.address() as AddressInfo;
+    if (typeof addressInfo === "string") {
+      console.log(`Listening on unix socket ${addressInfo}`);
+      return;
+    }
+    const baseURL = (useRuntimeConfig().app.baseURL || "").replace(/\/$/, "");
+    const url = `${protocol}://${
+      addressInfo.family === "IPv6"
+        ? `[${addressInfo.address}]`
+        : addressInfo.address
+    }:${addressInfo.port}${baseURL}`;
+    console.log(`Listening on ${url}`);
+  });
+  
+  // Trap unhandled errors
+  trapUnhandledNodeErrors();
+  
+  // Graceful shutdown
+  setupGracefulShutdown(listener, nitroApp);
+  
+  // Websocket support
+  // https://crossws.unjs.io/adapters/node
+  if (import.meta._websocket) {
+    const { handleUpgrade } = wsAdapter(nitroApp.h3App.websocket);
+    server.on("upgrade", handleUpgrade);
   }
-  const protocol = cert && key ? "https" : "http";
-  const addressInfo = listener.address() as AddressInfo;
-  if (typeof addressInfo === "string") {
-    console.log(`Listening on unix socket ${addressInfo}`);
-    return;
+  
+  // Scheduled tasks
+  if (import.meta._tasks) {
+    startScheduleRunner();
   }
-  const baseURL = (useRuntimeConfig().app.baseURL || "").replace(/\/$/, "");
-  const url = `${protocol}://${
-    addressInfo.family === "IPv6"
-      ? `[${addressInfo.address}]`
-      : addressInfo.address
-  }:${addressInfo.port}${baseURL}`;
-  console.log(`Listening on ${url}`);
-});
-
-// Trap unhandled errors
-trapUnhandledNodeErrors();
-
-// Graceful shutdown
-setupGracefulShutdown(listener, nitroApp);
-
-// Websocket support
-// https://crossws.unjs.io/adapters/node
-if (import.meta._websocket) {
-  const { handleUpgrade } = wsAdapter(nitroApp.h3App.websocket);
-  server.on("upgrade", handleUpgrade);
+  
 }
 
-// Scheduled tasks
-if (import.meta._tasks) {
-  startScheduleRunner();
-}
 
 export default {};

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -13,23 +13,22 @@ import {
 } from "nitropack/runtime/internal";
 
 export const serverWorker = async () => {
-
   const cert = process.env.NITRO_SSL_CERT;
   const key = process.env.NITRO_SSL_KEY;
-  
+
   const nitroApp = useNitroApp();
-  
+
   const server =
     cert && key
       ? new HttpsServer({ key, cert }, toNodeListener(nitroApp.h3App))
       : new HttpServer(toNodeListener(nitroApp.h3App));
-  
+
   const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
     3000) as number;
   const host = process.env.NITRO_HOST || process.env.HOST;
-  
+
   const path = process.env.NITRO_UNIX_SOCKET;
-  
+
   // @ts-ignore
   const listener = server.listen(path ? { path } : { port, host }, (err) => {
     if (err) {
@@ -51,26 +50,24 @@ export const serverWorker = async () => {
     }:${addressInfo.port}${baseURL}`;
     console.log(`Listening on ${url}`);
   });
-  
+
   // Trap unhandled errors
   trapUnhandledNodeErrors();
-  
+
   // Graceful shutdown
   setupGracefulShutdown(listener, nitroApp);
-  
+
   // Websocket support
   // https://crossws.unjs.io/adapters/node
   if (import.meta._websocket) {
     const { handleUpgrade } = wsAdapter(nitroApp.h3App.websocket);
     server.on("upgrade", handleUpgrade);
   }
-  
+
   // Scheduled tasks
   if (import.meta._tasks) {
     startScheduleRunner();
   }
-  
-}
-
+};
 
 export default {};


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue
Fix https://github.com/nitrojs/nitro/issues/2892

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves [#2892](https://github.com/nitrojs/nitro/issues/2892)

This change addresses the issue where, after the `nitro build` (unbuild), the code from `node-server` ends up in the same scope as `node-cluster` (see screen bellow). In the current implementation, the primary cluster executes the server code, and subsequently, when workers attempt to execute the same code, they encounter an error because the port is already in use by the primary. By wrapping the server code into a separate, exported function, we avoid these scope conflicts and port clashes, ensuring that each worker operates independently without interference.

builded `index.mjs`:
![image](https://github.com/user-attachments/assets/c8c83c6b-d3e6-48c1-bd44-d9a04b75a8d3)


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
