### PR TITLE
fix(node-cluster): create dedicated chunk for worker

### DIFF
--- a/src/presets/node/preset.ts
+++ b/src/presets/node/preset.ts
@@ -1,4 +1,6 @@
 import { defineNitroPreset } from "nitropack/kit";
+import { normalize } from "pathe";
+import { resolvePathSync } from "mlly";
 
 const node = defineNitroPreset(
   {
@@ -30,6 +32,22 @@ const nodeCluster = defineNitroPreset(
   {
     extends: "node-server",
     entry: "./runtime/node-cluster",
+    hooks: {
+      "rollup:before"(_nitro, rollupConfig) {
+        const manualChunks = rollupConfig.output?.manualChunks;
+        if (manualChunks && typeof manualChunks === "function") {
+          const clusterEntry = resolvePathSync("./runtime/node-server", {
+            url: import.meta.url,
+          });
+          rollupConfig.output.manualChunks = (id, meta) => {
+            if (id.includes("node-server") && normalize(id) === clusterEntry) {
+              return "nitro/node-worker";
+            }
+            return manualChunks(id, meta);
+          };
+        }
+      },
+    },
   },
   {
     name: "node-cluster" as const,

--- a/src/presets/node/preset.ts
+++ b/src/presets/node/preset.ts
@@ -36,11 +36,11 @@ const nodeCluster = defineNitroPreset(
       "rollup:before"(_nitro, rollupConfig) {
         const manualChunks = rollupConfig.output?.manualChunks;
         if (manualChunks && typeof manualChunks === "function") {
-          const clusterEntry = resolvePathSync("./runtime/node-server", {
+          const serverEntry = resolvePathSync("./runtime/node-server", {
             url: import.meta.url,
           });
           rollupConfig.output.manualChunks = (id, meta) => {
-            if (id.includes("node-server") && normalize(id) === clusterEntry) {
+            if (id.includes("node-server") && normalize(id) === serverEntry) {
               return "nitro/node-worker";
             }
             return manualChunks(id, meta);


### PR DESCRIPTION
resolves #2892

as a side effect of fixes in #2547 (nitro 2.10) we were forcing all nitro-relevant stuff into one big chunk. 

This PR makes sure for node-cluster we create a dedicated external chunk for server-entrypoint.

