### PR TITLE
fix(error): strict security headers

### DIFF
--- a/src/runtime/internal/error.ts
+++ b/src/runtime/internal/error.ts
@@ -1,5 +1,10 @@
 // import ansiHTML from 'ansi-html'
-import { send, setResponseHeader, setResponseStatus } from "h3";
+import {
+  send,
+  setResponseHeader,
+  setResponseHeaders,
+  setResponseStatus,
+} from "h3";
 import type { NitroErrorHandler } from "nitropack/types";
 import { isJsonRequest, normalizeError } from "./utils";
 
@@ -55,6 +60,18 @@ export default defineNitroErrorHandler(
     if (statusCode === 404) {
       setResponseHeader(event, "Cache-Control", "no-cache");
     }
+
+    // Security headers
+    setResponseHeaders(event, {
+      // Disable the execution of any js
+      "Content-Security-Policy": "script-src 'none'; frame-ancestors 'none';",
+      // Prevent browser from guessing the MIME types of resources.
+      "X-Content-Type-Options": "nosniff",
+      // Prevent error page from being embedded in an iframe
+      "X-Frame-Options": "DENY",
+      // Prevent browsers from sending the Referer header
+      "Referrer-Policy": "no-referrer",
+    });
 
     setResponseStatus(event, statusCode, statusMessage);
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -378,13 +378,21 @@ export function testNitro(
   });
 
   it("handles errors", async () => {
-    const { status } = await callHandler({
+    const { status, headers } = await callHandler({
       url: "/api/error",
       headers: {
         Accept: "application/json",
       },
     });
     expect(status).toBe(503);
+    expect(headers).toMatchObject({
+      connection: "keep-alive",
+      "content-type": "application/json",
+      "content-security-policy": "script-src 'none'; frame-ancestors 'none';",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+      "x-frame-options": "DENY",
+    });
   });
 
   it.skipIf(isWindows && ctx.preset === "nitro-dev")(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -386,7 +386,6 @@ export function testNitro(
     });
     expect(status).toBe(503);
     expect(headers).toMatchObject({
-      connection: "keep-alive",
       "content-type": "application/json",
       "content-security-policy": "script-src 'none'; frame-ancestors 'none';",
       "referrer-policy": "no-referrer",


### PR DESCRIPTION
#2591 prevented possible security issues when user input could be included in the stack trace. 

This PR increases the security of the error page by using secure headers making sure no js code can be executed (specially for production), it cannot have mixed mimes, being iframed or report referer to external resources in case anything goes invalidated in "error message".