### PR TITLE
types: fix type for `event.$fetch`

### DIFF
--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -121,10 +121,10 @@ function createNitroApp(): NitroApp {
       // Assign bound fetch to context
       event.fetch = (req, init) =>
         fetchWithEvent(event, req, init, { fetch: localFetch });
-      event.$fetch = ((req, init) =>
+      event.$fetch = (req, init) =>
         fetchWithEvent(event, req, init as RequestInit, {
           fetch: $fetch as any,
-        })) as $Fetch<unknown, NitroFetchRequest>;
+        });
 
       // https://github.com/nitrojs/nitro/issues/1420
       event.waitUntil = (promise) => {

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -369,10 +369,10 @@ export function defineCachedEventHandler<
         fetchWithEvent(event, url, fetchOptions, {
           fetch: useNitroApp().localFetch as any,
         });
-      event.$fetch = ((url, fetchOptions) =>
+      event.$fetch = (url, fetchOptions) =>
         fetchWithEvent(event, url, fetchOptions as RequestInit, {
           fetch: globalThis.$fetch as any,
-        })) as $Fetch<unknown, NitroFetchRequest>;
+        });
       event.context = incomingEvent.context;
       event.context.cache = {
         options: _opts,

--- a/src/types/fetch/fetch.ts
+++ b/src/types/fetch/fetch.ts
@@ -66,24 +66,28 @@ export type ExtractedRouteMethod<
     ? Lowercase<Exclude<O["method"], undefined>>
     : "get";
 
+export type Base$Fetch<
+  DefaultT = unknown,
+  DefaultR extends NitroFetchRequest = NitroFetchRequest,
+> = <
+  T = DefaultT,
+  R extends NitroFetchRequest = DefaultR,
+  O extends NitroFetchOptions<R> = NitroFetchOptions<R>,
+>(
+  request: R,
+  opts?: O
+) => Promise<
+  TypedInternalResponse<
+    R,
+    T,
+    NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<R, O>
+  >
+>;
+
 export interface $Fetch<
   DefaultT = unknown,
   DefaultR extends NitroFetchRequest = NitroFetchRequest,
-> {
-  <
-    T = DefaultT,
-    R extends NitroFetchRequest = DefaultR,
-    O extends NitroFetchOptions<R> = NitroFetchOptions<R>,
-  >(
-    request: R,
-    opts?: O
-  ): Promise<
-    TypedInternalResponse<
-      R,
-      T,
-      NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<R, O>
-    >
-  >;
+> extends Base$Fetch<DefaultT, DefaultR> {
   raw<
     T = DefaultT,
     R extends NitroFetchRequest = DefaultR,

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -3,14 +3,14 @@ import type {
   CaptureError,
   CapturedErrorContext,
 } from "nitropack/types";
-import type { $Fetch, NitroFetchRequest } from "./fetch/fetch";
+import type { Base$Fetch, NitroFetchRequest } from "./fetch/fetch";
 
 export type H3EventFetch = (
   request: NitroFetchRequest,
   init?: RequestInit
 ) => Promise<Response>;
 
-export type H3Event$Fetch = $Fetch<unknown, NitroFetchRequest>;
+export type H3Event$Fetch = Base$Fetch<unknown, NitroFetchRequest>;
 
 declare module "h3" {
   interface H3Event {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/30091

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

currently the types are incorrect (they include `.raw` and `.create`). This refactors the base '$fetch' type into `Base$Fetch` so this can be used to type `event.$fetch` without needing workarounds.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
