### PR TITLE
feat: add `aws-lambda-alb` support

### DIFF
--- a/docs/2.deploy/20.providers/aws.md
+++ b/docs/2.deploy/20.providers/aws.md
@@ -7,7 +7,7 @@
 :read-more{title="AWS Lambda" to="https://aws.amazon.com/lambda/"}
 
 Nitro provides a built-in preset to generate output format compatible with [AWS Lambda](https://aws.amazon.com/lambda/).
-The output entrypoint in `.output/server/index.mjs` is compatible with [AWS Lambda format](https://docs.aws.amazon.com/lex/latest/dg/lambda-input-response-format.html).
+The output entrypoint in `.output/server/index.mjs` is an [AWS Lambda function handler](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html).
 
 It can be used programmatically or as part of a deployment.
 
@@ -17,6 +17,17 @@ import { handler } from './.output/server'
 // Use programmatically
 const { statusCode, headers, body } = handler({ rawPath: '/' })
 ```
+
+## Supported event types
+
+The following [@types/aws-lambda](https://www.npmjs.com/package/@types/aws-lambda) event types are supported:
+
+- `ALBEvent`: ALB (Application Load Balancer) [Lambda target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html).
+- `APIGatewayProxyEvent`: API Gateway REST [Lambda proxy integration](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html) or API Gateway HTTP [Lambda integration with 1.0 payload format](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html).
+- `APIGatewayProxyEventV2`: API Gateway HTTP [Lambda integration with 2.0 payload format](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html).
+- `LambdaFunctionURLEvent`: Lambda [function URL](https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html).
+
+_Note:_ API Gateway REST [Lambda custom integrations](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-custom-integrations.html) are not supported.
 
 ## Inlining chunks
 

--- a/src/runtime/internal/index.ts
+++ b/src/runtime/internal/index.ts
@@ -11,6 +11,7 @@ export {
 
 export {
   normalizeLambdaIncomingHeaders,
+  normalizeLambdaIncomingQuery,
   normalizeLambdaOutgoingHeaders,
   normalizeLambdaOutgoingBody,
 } from "./utils.lambda";

--- a/src/runtime/internal/utils.lambda/incoming.ts
+++ b/src/runtime/internal/utils.lambda/incoming.ts
@@ -1,0 +1,112 @@
+import type {
+  ALBEvent,
+  ALBEventMultiValueQueryStringParameters,
+  ALBEventQueryStringParameters,
+  APIGatewayProxyEvent,
+  APIGatewayProxyEventHeaders,
+  APIGatewayProxyEventMultiValueHeaders,
+  APIGatewayProxyEventV2,
+} from "aws-lambda";
+import { decode } from "ufo";
+
+export function normalizeLambdaIncomingHeaders(
+  headers?:
+    | ALBEventQueryStringParameters
+    | ALBEventMultiValueQueryStringParameters
+    | APIGatewayProxyEventHeaders
+    | APIGatewayProxyEventMultiValueHeaders
+): Record<string, string | string[] | undefined>;
+export function normalizeLambdaIncomingHeaders(
+  event: ALBEvent | APIGatewayProxyEvent | APIGatewayProxyEventV2
+): Record<string, string | string[] | undefined>;
+export function normalizeLambdaIncomingHeaders(
+  eventOrHeaders?:
+    | ALBEvent
+    | APIGatewayProxyEvent
+    | APIGatewayProxyEventV2
+    | APIGatewayProxyEventHeaders
+    | APIGatewayProxyEventMultiValueHeaders
+): Record<string, string | string[] | undefined> {
+  if (isEvent(eventOrHeaders)) {
+    // ALB event has either `headers` or `multiValueHeaders`
+    if (isAlbEvent(eventOrHeaders)) {
+      return normalizeLambdaIncomingHeaders(
+        eventOrHeaders.headers ?? eventOrHeaders.multiValueHeaders
+      );
+    }
+
+    // Other events always have `headers`
+    return normalizeLambdaIncomingHeaders(eventOrHeaders.headers);
+  }
+
+  // if we're here, `eventOrHeaders` is `APIGatewayProxyEventHeaders`
+  return Object.fromEntries(
+    Object.entries(eventOrHeaders || {}).map(([key, value]) => [
+      key.toLowerCase(),
+      value,
+    ])
+  );
+}
+
+export function normalizeLambdaIncomingQuery(
+  event: ALBEvent | APIGatewayProxyEvent | APIGatewayProxyEventV2
+): Record<string, string | string[] | undefined> {
+  const rawQueryObj: Record<string, string | string[] | undefined> = {
+    ...event.queryStringParameters,
+    ...(event as ALBEvent | APIGatewayProxyEvent)
+      .multiValueQueryStringParameters,
+  };
+
+  // `APIGatewayProxyEvent | APIGatewayProxyEventV2` have URL-decoded query parameters
+  if (!isAlbEvent(event)) {
+    return rawQueryObj;
+  }
+
+  /*
+   * `ALBEvent` has either `queryStringParameters` or `multiValueQueryStringParameters`.
+   * Query params in raw form, they must be decoded to avoid double URL encoding
+   */
+  return Object.fromEntries(
+    Object.entries(
+      event.queryStringParameters ?? event.multiValueQueryStringParameters ?? {}
+    ).map(([key, value]) => {
+      let decodedValue: string | string[] | undefined;
+      if (typeof value === "string") {
+        decodedValue = decode(value);
+      } else if (Array.isArray(value)) {
+        decodedValue = value.map((v) => decode(v));
+      } else {
+        decodedValue = value;
+      }
+
+      return [decode(key), decodedValue];
+    })
+  );
+}
+
+// -- Internal --
+
+function isAlbEvent(
+  event: ALBEvent | APIGatewayProxyEvent | APIGatewayProxyEventV2
+): event is ALBEvent {
+  return !!event?.requestContext && "elb" in event.requestContext;
+}
+
+function isEvent(
+  obj?:
+    | ALBEvent
+    | ALBEventQueryStringParameters
+    | ALBEventMultiValueQueryStringParameters
+    | APIGatewayProxyEvent
+    | APIGatewayProxyEventV2
+    | APIGatewayProxyEventHeaders
+    | APIGatewayProxyEventMultiValueHeaders
+): obj is ALBEvent | APIGatewayProxyEvent | APIGatewayProxyEventV2 {
+  // All events have a `requestContext` object field
+  return (
+    !!obj &&
+    !!obj.requestContext &&
+    typeof obj.requestContext === "object" &&
+    !Array.isArray(obj.requestContext)
+  );
+}

--- a/src/runtime/internal/utils.lambda/index.ts
+++ b/src/runtime/internal/utils.lambda/index.ts
@@ -1,0 +1,2 @@
+export * from "./incoming";
+export * from "./outgoing";

--- a/src/runtime/internal/utils.lambda/outgoing.ts
+++ b/src/runtime/internal/utils.lambda/outgoing.ts
@@ -1,17 +1,5 @@
 import type { Readable } from "node:stream";
-import type { APIGatewayProxyEventHeaders } from "aws-lambda";
-import { toBuffer } from "./utils";
-
-export function normalizeLambdaIncomingHeaders(
-  headers?: APIGatewayProxyEventHeaders
-): Record<string, string | string[] | undefined> {
-  return Object.fromEntries(
-    Object.entries(headers || {}).map(([key, value]) => [
-      key.toLowerCase(),
-      value,
-    ])
-  );
-}
+import { toBuffer } from "../utils";
 
 export function normalizeLambdaOutgoingHeaders(
   headers: Record<string, number | string | string[] | undefined>,
@@ -60,3 +48,4 @@ const TEXT_TYPE_RE = /^text\/|\/(javascript|json|xml)|utf-?8/;
 function isTextType(contentType = "") {
   return TEXT_TYPE_RE.test(contentType);
 }
+

--- a/src/runtime/internal/utils.lambda/outgoing.ts
+++ b/src/runtime/internal/utils.lambda/outgoing.ts
@@ -48,4 +48,3 @@ const TEXT_TYPE_RE = /^text\/|\/(javascript|json|xml)|utf-?8/;
 function isTextType(contentType = "") {
   return TEXT_TYPE_RE.test(contentType);
 }
-

--- a/test/presets/aws-lambda.test.ts
+++ b/test/presets/aws-lambda.test.ts
@@ -1,65 +1,418 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from "aws-lambda";
 import destr from "destr";
 import { resolve } from "pathe";
-import { describe } from "vitest";
-import { setupTest, testNitro } from "../tests";
+import { describe, expect, it } from "vitest";
+import {
+  setupTest,
+  testNitro,
+  type Context,
+  type TestHandlerResult,
+} from "../tests";
+import type { DeepPartial } from "../../src/types/_utils";
+
+/**
+ * Enumerates the types of HTTP Lambdas:
+ *
+ * - `alb-single`: Application Load Balancer without multi-value query/headers enabled.
+ * - `alb-multi`: Application Load Balancer with multi-value query/headers enabled.
+ * - `rest`: API Gateway REST API.
+ * - `http-v2`: API Gateway HTTP API with v2.0 paylaod.
+ *
+ * Note: API Gateway HTTP API with v1.0 payload is omitted as it's the same as `rest` for practical purposes.
+ */
+type HttpLambdaType = "alb-single" | "alb-multi" | "rest" | "http-v2";
+
+/**
+ * Creates query string parameters with the format of an HTTP Lambda type.
+ * @param params The URL query string parameters.
+ * @param type The HTTP Lambda type.
+ */
+function createQueryStringParameters(
+  params: URLSearchParams,
+  type: HttpLambdaType
+) {
+  const queryStringParameters: Record<string, string | undefined> | undefined =
+    type === "alb-multi" ? undefined : {};
+  const multiValueQueryStringParameters:
+    | Record<string, string[] | undefined>
+    | undefined = type === "alb-single" ? undefined : {};
+
+  const isAlb = type === "alb-single" || type === "alb-multi";
+  for (const [rawKey, rawValue] of params) {
+    // ALB does not decode query string params
+    const key = isAlb ? encodeURIComponent(rawKey) : rawKey;
+    const value = isAlb ? encodeURIComponent(rawValue) : rawValue;
+
+    if (type === "alb-single" || type === "rest") {
+      // last value wins
+      queryStringParameters![key] = value;
+    }
+
+    if (type === "alb-multi" || type === "rest") {
+      // array with all values
+      if (multiValueQueryStringParameters![key]) {
+        multiValueQueryStringParameters![key].push(value);
+      } else {
+        multiValueQueryStringParameters![key] = [value];
+      }
+    }
+
+    if (type === "http-v2") {
+      // comma-separated values
+      if (queryStringParameters![key]) {
+        queryStringParameters![key] += `,${value}`;
+      } else {
+        queryStringParameters![key] = value;
+      }
+    }
+  }
+
+  return { queryStringParameters, multiValueQueryStringParameters };
+}
+
+/**
+ * Creates headers with the format of an HTTP Lambda type.
+ * @param rawHeaders The raw HTTP headers.
+ * @param type The HTTP Lambda type.
+ */
+function createHeaders(
+  rawHeaders:
+    | Record<string, string | (string | undefined)[] | undefined>
+    | undefined,
+  type: HttpLambdaType
+) {
+  const headers: Record<string, string | undefined> | undefined =
+    type === "alb-multi" ? undefined : {};
+  const multiValueHeaders: Record<string, string[] | undefined> | undefined =
+    type === "alb-single" ? undefined : {};
+
+  for (const [key, value] of Object.entries(rawHeaders ?? {})) {
+    if (type === "alb-single" || type === "rest") {
+      if (value === undefined) {
+        if (type === "rest") {
+          // ALB omits headers without values
+          headers![key] = "";
+        }
+      } else {
+        // last value wins
+        headers![key] = typeof value === "string" ? value : value.at(-1);
+      }
+    }
+
+    if (type === "alb-multi" || type === "rest") {
+      if (value === undefined) {
+        if (type === "rest") {
+          // ALB omits headers without values
+          multiValueHeaders![key] = [""];
+        }
+      } else {
+        // array with all values, ALB omits headers without values
+        multiValueHeaders![key] =
+          typeof value === "string"
+            ? [value]
+            : value
+                .filter((x) => x !== undefined || type === "rest")
+                .map((x) => x ?? "");
+      }
+    }
+
+    if (type === "http-v2") {
+      // comma-separated values
+      headers![key] =
+        (typeof value === "string" ? value : value?.join(",")) ?? "";
+    }
+  }
+
+  return { headers, multiValueHeaders };
+}
 
 describe("nitro:preset:aws-lambda", async () => {
+  const additionalTests =
+    (options: { type: HttpLambdaType }) =>
+    (
+      ctx: Context,
+      callHandler: (options: any) => Promise<TestHandlerResult>
+    ): void => {
+      const { type } = options;
+
+      describe("URL-encoded query params", () => {
+        it("keeps query params intact", async () => {
+          const actual = await callHandler({
+            url: "/api/echo?Foo%2Fbar=Val%2Fue",
+          });
+          expect(actual).toMatchObject({
+            data: {
+              url: "/api/echo?Foo%2Fbar=Val%2Fue",
+            },
+          });
+        });
+      });
+
+      describe("multi-value", () => {
+        describe("headers", () => {
+          it.skipIf(type !== "alb-single" && type !== "rest")(
+            "keeps last value",
+            async () => {
+              const actual = await callHandler({
+                url: "/api/echo",
+                headers: { Foo: ["Bar", "Baz"] },
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo",
+                  headers: { foo: "Baz" },
+                },
+              });
+            }
+          );
+
+          it.skipIf(type !== "http-v2")(
+            "keeps comma-separated values (no spaces)",
+            async () => {
+              const actual = await callHandler({
+                url: "/api/echo",
+                headers: { Foo: ["Bar", "Baz"] },
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo",
+                  headers: { foo: "Bar,Baz" },
+                },
+              });
+            }
+          );
+
+          it.skipIf(
+            type === "alb-single" || type === "http-v2" || type === "rest"
+          )("keeps comma-separated values", async () => {
+            const actual = await callHandler({
+              url: "/api/echo",
+              headers: { Foo: ["Bar", "Baz"] },
+            });
+            expect(actual).toMatchObject({
+              data: {
+                url: "/api/echo",
+                headers: { foo: "Bar, Baz" },
+              },
+            });
+          });
+        });
+
+        describe("query string parameters", () => {
+          it.skipIf(type !== "alb-single")("keeps last value", async () => {
+            const actual = await callHandler({
+              url: "/api/echo?Foo=Bar&Foo=Baz",
+            });
+            expect(actual).toMatchObject({
+              data: {
+                url: "/api/echo?Foo=Baz",
+              },
+            });
+          });
+
+          it.skipIf(type !== "http-v2")(
+            "keeps comma-separated values",
+            async () => {
+              const actual = await callHandler({
+                url: "/api/echo?Foo=Bar&Foo=Baz",
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo?Foo=Bar,Baz",
+                },
+              });
+            }
+          );
+
+          it.skipIf(type === "alb-single" || type === "http-v2")(
+            "keeps comma-separated values",
+            async () => {
+              const actual = await callHandler({
+                url: "/api/echo?Foo=Bar&Foo=Baz",
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo?Foo=Bar&Foo=Baz",
+                },
+              });
+            }
+          );
+        });
+      });
+
+      describe("missing values", () => {
+        describe("headers", () => {
+          describe("single-value", () => {
+            it("omits header", async () => {
+              const actual = await callHandler({
+                url: "/api/echo",
+                headers: { foo: undefined },
+              });
+              expect(actual).not.toHaveProperty("data.headers.foo");
+            });
+          });
+
+          describe("multi-value", () => {
+            it.skipIf(type !== "http-v2")("keeps empty value", async () => {
+              const actual = await callHandler({
+                url: "/api/echo",
+                headers: { foo: ["1", undefined, "2", "3"] },
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo",
+                  headers: {
+                    foo: "1,,2,3",
+                  },
+                },
+              });
+            });
+
+            it.skipIf(
+              type === "alb-single" || type === "http-v2" || type === "rest"
+            )("omits header", async () => {
+              const actual = await callHandler({
+                url: "/api/echo",
+                headers: { foo: ["1", undefined, "2", "3"] },
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo",
+                  headers: {
+                    foo: "1, 2, 3",
+                  },
+                },
+              });
+            });
+          });
+        });
+
+        describe("query string parameters", () => {
+          describe("single-value", () => {
+            it("keeps parameter", async () => {
+              const actual = await callHandler({
+                url: "/api/echo?foo",
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: expect.stringMatching(/^\/api\/echo\?foo=?$/),
+                },
+              });
+            });
+          });
+
+          describe("multi-value", () => {
+            it.skipIf(type !== "http-v2")("keeps empty parameter", async () => {
+              const actual = await callHandler({
+                url: "/api/echo?foo=1&foo&foo=2&foo=3",
+              });
+              expect(actual).toMatchObject({
+                data: {
+                  url: "/api/echo?foo=1,,2,3",
+                },
+              });
+            });
+
+            it.skipIf(type === "alb-single" || type === "http-v2")(
+              "keeps empty parameter",
+              async () => {
+                const actual = await callHandler({
+                  url: "/api/echo?foo=1&foo&foo=2&foo=3",
+                });
+                expect(actual).toMatchObject({
+                  data: {
+                    url: "/api/echo?foo=1&foo=&foo=2&foo=3",
+                  },
+                });
+              }
+            );
+          });
+        });
+      });
+    };
+
   const ctx = await setupTest("aws-lambda");
+
   // Lambda v1 paylod
-  testNitro({ ...ctx, lambdaV1: true }, async () => {
-    const { handler } = await import(resolve(ctx.outDir, "server/index.mjs"));
-    return async ({ url: rawRelativeUrl, headers, method, body }) => {
-      // creating new URL object to parse query easier
-      const url = new URL(`https://example.com${rawRelativeUrl}`);
-      const queryStringParameters = Object.fromEntries(
-        url.searchParams.entries()
-      );
-      const event: Partial<APIGatewayProxyEvent> = {
-        resource: "/my/path",
-        path: url.pathname,
-        headers: headers || {},
-        httpMethod: method || "GET",
-        queryStringParameters,
-        body: body || "",
+  const rest = "rest";
+  testNitro(
+    ctx,
+    async () => {
+      const { handler } = await import(resolve(ctx.outDir, "server/index.mjs"));
+      return async ({
+        url: rawRelativeUrl,
+        headers: rawHeaders,
+        method,
+        body,
+      }) => {
+        // creating new URL object to parse query easier
+        const url = new URL(`https://example.com${rawRelativeUrl}`);
+        const { queryStringParameters, multiValueQueryStringParameters } =
+          createQueryStringParameters(url.searchParams, rest);
+        const { headers, multiValueHeaders } = createHeaders(rawHeaders, rest);
+        const event: DeepPartial<APIGatewayProxyEvent> = {
+          httpMethod: method || "GET",
+          path: url.pathname,
+          resource: "/my/path",
+          queryStringParameters,
+          multiValueQueryStringParameters,
+          headers,
+          multiValueHeaders,
+          body: body || "",
+          requestContext: {},
+        };
+        const res = await handler(event);
+        return makeResponse(res);
       };
-      const res = await handler(event);
-      return makeResponse(res);
-    };
-  });
+    },
+    additionalTests({ type: rest })
+  );
+
   // Lambda v2 paylod
-  testNitro(ctx, async () => {
-    const { handler } = await import(resolve(ctx.outDir, "server/index.mjs"));
-    return async ({ url: rawRelativeUrl, headers, method, body }) => {
-      // creating new URL object to parse query easier
-      const url = new URL(`https://example.com${rawRelativeUrl}`);
-      const queryStringParameters = Object.fromEntries(
-        url.searchParams.entries()
-      );
-      const event: Partial<APIGatewayProxyEventV2> = {
-        rawPath: url.pathname,
-        headers: headers || {},
-        requestContext: {
-          ...Object.fromEntries([
-            ["accountId"],
-            ["apiId"],
-            ["domainName"],
-            ["domainPrefix"],
-          ]),
-          http: {
-            path: url.pathname,
-            protocol: "http",
-            ...Object.fromEntries([["userAgent"], ["sourceIp"]]),
-            method: method || "GET",
+  const httpV2 = "http-v2";
+  testNitro(
+    ctx,
+    async () => {
+      const { handler } = await import(resolve(ctx.outDir, "server/index.mjs"));
+      return async ({
+        url: rawRelativeUrl,
+        headers: rawHeaders,
+        method,
+        body,
+      }) => {
+        // creating new URL object to parse query easier
+        const url = new URL(`https://example.com${rawRelativeUrl}`);
+        const { queryStringParameters } = createQueryStringParameters(
+          url.searchParams,
+          httpV2
+        );
+        const { headers } = createHeaders(rawHeaders, httpV2);
+        const event: Partial<APIGatewayProxyEventV2> = {
+          rawPath: url.pathname,
+          queryStringParameters,
+          headers,
+          body: body || "",
+          requestContext: {
+            ...Object.fromEntries([
+              ["accountId"],
+              ["apiId"],
+              ["domainName"],
+              ["domainPrefix"],
+            ]),
+            http: {
+              path: url.pathname,
+              protocol: "http",
+              ...Object.fromEntries([["userAgent"], ["sourceIp"]]),
+              method: method || "GET",
+            },
           },
-        },
-        queryStringParameters,
-        body: body || "",
+        };
+        const res = await handler(event);
+        return makeResponse(res);
       };
-      const res = await handler(event);
-      return makeResponse(res);
-    };
-  });
+    },
+    additionalTests({ type: httpV2 })
+  );
 });
 
 const makeResponse = (response: any) => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -34,7 +34,6 @@ export interface Context {
   isIsolated: boolean;
   supportsEnv: boolean;
   env: Record<string, string>;
-  lambdaV1?: boolean;
   // [key: string]: unknown;
 }
 
@@ -173,7 +172,7 @@ export async function startServer(ctx: Context, handle: RequestListener) {
   console.log(">", ctx.server!.url);
 }
 
-type TestHandlerResult = {
+export type TestHandlerResult = {
   data: any;
   status: number;
   headers: Record<string, string | string[]>;
@@ -692,7 +691,7 @@ export function testNitro(
       const { data } = await callHandler({ url: "/context?foo" });
       expect(data).toMatchObject({
         context: {
-          path: "/context?foo",
+          path: expect.stringMatching(/^\/context\?foo=?$/),
         },
       });
     });

--- a/test/unit/lambda.utils/incoming.test.ts
+++ b/test/unit/lambda.utils/incoming.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeLambdaIncomingHeaders,
+  normalizeLambdaIncomingQuery,
+} from "../../../src/runtime/internal/utils.lambda/incoming";
+import type {
+  ALBEvent,
+  APIGatewayProxyEvent,
+  APIGatewayProxyEventV2,
+} from "aws-lambda";
+import type { DeepPartial } from "../../../src/types/_utils";
+
+describe("normalizeLambdaIncomingHeaders", () => {
+  describe("single-value headers", () => {
+    it("lowecases header names", () => {
+      const actual = normalizeLambdaIncomingHeaders({
+        Foo: "Bar",
+      });
+
+      expect(actual).toStrictEqual({ foo: "Bar" });
+    });
+  });
+
+  describe("multi-value headers", () => {
+    it("lowecases header names", () => {
+      const actual = normalizeLambdaIncomingHeaders({
+        Foo: ["Bar"],
+      });
+
+      expect(actual).toStrictEqual({ foo: ["Bar"] });
+    });
+  });
+
+  describe("ALB event", () => {
+    describe("with single-value headers", () => {
+      it("lowercases header names", () => {
+        const event: Partial<ALBEvent> = {
+          requestContext: { elb: { targetGroupArn: "some-target" } },
+          headers: { Foo: "Bar" },
+        };
+        const actual = normalizeLambdaIncomingHeaders(event as ALBEvent);
+
+        expect(actual).toStrictEqual({ foo: "Bar" });
+      });
+    });
+
+    describe("with multi-value headers", () => {
+      it("lowercases header names", () => {
+        const event: Partial<ALBEvent> = {
+          requestContext: { elb: { targetGroupArn: "some-target" } },
+          multiValueHeaders: { Foo: ["Bar"] },
+        };
+        const actual = normalizeLambdaIncomingHeaders(event as ALBEvent);
+
+        expect(actual).toStrictEqual({ foo: ["Bar"] });
+      });
+    });
+  });
+
+  describe("API gateway proxy event", () => {
+    it("lowercases headers names", () => {
+      const event: DeepPartial<APIGatewayProxyEvent> = {
+        requestContext: { httpMethod: "get" },
+        headers: { Foo: "Bar" },
+      };
+      const actual = normalizeLambdaIncomingHeaders(
+        event as APIGatewayProxyEvent
+      );
+
+      expect(actual).toStrictEqual({ foo: "Bar" });
+    });
+  });
+
+  describe("API gateway proxy V2 event", () => {
+    it("lowercases headers names", () => {
+      const event: DeepPartial<APIGatewayProxyEventV2> = {
+        requestContext: { http: { method: "get" } },
+        headers: { Foo: "Bar" },
+      };
+      const actual = normalizeLambdaIncomingHeaders(
+        event as APIGatewayProxyEventV2
+      );
+
+      expect(actual).toStrictEqual({ foo: "Bar" });
+    });
+  });
+});
+
+describe("normalizeLambdaIncomingQuery", () => {
+  describe("ALB event", () => {
+    describe("with single-value headers", () => {
+      it("URL decodes the query params", () => {
+        const event: Partial<ALBEvent> = {
+          requestContext: { elb: { targetGroupArn: "some-target" } },
+          /*
+           * ALB does not automatically URL decodes query params.
+           * If they come this way it means they were encoded once by the client.
+           * They should be decoded.
+           */
+          queryStringParameters: { "Foo%2FFoo": "Bar%2FBar" },
+        };
+        const actual = normalizeLambdaIncomingQuery(event as ALBEvent);
+
+        expect(actual).toStrictEqual({ "Foo/Foo": "Bar/Bar" });
+      });
+    });
+
+    describe("with multi-value headers", () => {
+      it("URL decodes the query params", () => {
+        const event: Partial<ALBEvent> = {
+          requestContext: { elb: { targetGroupArn: "some-target" } },
+          /*
+           * ALB does not automatically URL decodes query params.
+           * If they come this way it means they were encoded once by the client.
+           * They should be decoded.
+           */
+          multiValueQueryStringParameters: { "Foo%2FFoo": ["Bar%2FBar"] },
+        };
+        const actual = normalizeLambdaIncomingQuery(event as ALBEvent);
+
+        expect(actual).toStrictEqual({ "Foo/Foo": ["Bar/Bar"] });
+      });
+    });
+  });
+
+  describe("API gateway proxy event", () => {
+    it("merges single and multi-value query params and returns them as is", () => {
+      const event: DeepPartial<APIGatewayProxyEvent> = {
+        requestContext: { httpMethod: "get" },
+        /*
+         * API Gateway automatically URL decodes query params.
+         * If they come this way it means they were double encoded by the client.
+         * They should be left "as is".
+         */
+        queryStringParameters: { "Foo%2FFoo": "Bar%2FBar" },
+        multiValueQueryStringParameters: { "Foo%2FFoo": ["Bar%2FBar"] },
+      };
+      const actual = normalizeLambdaIncomingQuery(
+        event as APIGatewayProxyEvent
+      );
+
+      expect(actual).toStrictEqual({ "Foo%2FFoo": ["Bar%2FBar"] });
+    });
+  });
+
+  describe("API gateway proxy V2 event", () => {
+    it("returns query params as is", () => {
+      const event: DeepPartial<APIGatewayProxyEventV2> = {
+        requestContext: { http: { method: "get" } },
+        /*
+         * API Gateway automatically URL decodes query params.
+         * If they come this way it means they were double encoded by the client.
+         * They should be left "as is".
+         */
+        queryStringParameters: { "Foo%2FFoo": "Bar%2FBar" },
+      };
+      const actual = normalizeLambdaIncomingQuery(
+        event as APIGatewayProxyEventV2
+      );
+
+      expect(actual).toStrictEqual({ "Foo%2FFoo": "Bar%2FBar" });
+    });
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

#2072

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

WHAT?

Add support for ALB lambda function targets.

WHY?

`ALBEvent` is similar to `APIGatewayProxyEvent`. However, it has key differences such as:

- Query string parameters are not URL-decoded automatically.
- The events either have `headers`/`queryStringParameters` or `multiValueHeaders`/`multiValueQueryStringParameters`, but
  not both.
- Headers without values are removed from the event's input.

Without this change, using `nitro` with Lambda + ALB yields unexpected behaviors like double URL encoding.

RESOLVES?

#2072

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.