### PR TITLE
feat(openapi): allow `$global.components` in `defineRouteMeta`

### DIFF
--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,12 +1,14 @@
 import type { EventHandler, H3Error, H3Event, RouterMethod } from "h3";
 import type { PresetName } from "nitropack/presets";
-import type { OperationObject } from "openapi-typescript";
+import type { OperationObject, SchemaObject } from "openapi-typescript";
 
 type MaybeArray<T> = T | T[];
 
 /** @exprerimental */
 export interface NitroRouteMeta {
-  openAPI?: OperationObject;
+  openAPI?: OperationObject & {
+    components?: Record<string, SchemaObject>;
+  };
 }
 
 export interface NitroEventHandler {

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,13 +1,13 @@
 import type { EventHandler, H3Error, H3Event, RouterMethod } from "h3";
 import type { PresetName } from "nitropack/presets";
-import type { OperationObject, SchemaObject } from "openapi-typescript";
+import type { OperationObject, OpenAPI3 } from "openapi-typescript";
 
 type MaybeArray<T> = T | T[];
 
 /** @exprerimental */
 export interface NitroRouteMeta {
   openAPI?: OperationObject & {
-    components?: Record<string, SchemaObject>;
+    $global: Pick<OpenAPI3, "components">;
   };
 }
 

--- a/test/fixture/api/meta/test.ts
+++ b/test/fixture/api/meta/test.ts
@@ -5,10 +5,28 @@ defineRouteMeta({
     parameters: [{ in: "query", name: "test", required: true }],
     responses: {
       200: {
-        description: "OK",
+        description: "OK ",
+        content: {
+          "application/json": { schema: { $ref: "#/components/schemas/Test" } },
+        },
+      },
+    },
+    components: {
+      Test: {
+        type: "object",
+        properties: {
+          status: {
+            type: "string",
+            enum: ["OK", "ERROR"],
+          },
+        },
       },
     },
   },
 });
 
-export default defineEventHandler(() => "OK");
+export default defineEventHandler(() => {
+  return {
+    status: "OK",
+  };
+});

--- a/test/fixture/api/meta/test.ts
+++ b/test/fixture/api/meta/test.ts
@@ -11,13 +11,17 @@ defineRouteMeta({
         },
       },
     },
-    components: {
-      Test: {
-        type: "object",
-        properties: {
-          status: {
-            type: "string",
-            enum: ["OK", "ERROR"],
+    $global: {
+      components: {
+        schemas: {
+          Test: {
+            type: "object",
+            properties: {
+              status: {
+                type: "string",
+                enum: ["OK", "ERROR"],
+              },
+            },
           },
         },
       },

--- a/test/fixture/api/meta/test.ts
+++ b/test/fixture/api/meta/test.ts
@@ -5,7 +5,7 @@ defineRouteMeta({
     parameters: [{ in: "query", name: "test", required: true }],
     responses: {
       200: {
-        description: "OK ",
+        description: "result",
         content: {
           "application/json": { schema: { $ref: "#/components/schemas/Test" } },
         },

--- a/test/presets/nitro-dev.test.ts
+++ b/test/presets/nitro-dev.test.ts
@@ -51,7 +51,14 @@ describe("nitro:preset:nitro-dev", async () => {
                 ],
                 "responses": {
                   "200": {
-                    "description": "OK",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Test",
+                        },
+                      },
+                    },
+                    "description": "result",
                   },
                 },
                 "tags": [


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Fixes https://github.com/nitrojs/nitro/issues/2920

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add `components` support for OpenAPI module. 

#### Usage:
```typescript
defineRouteMeta({
  openAPI: {
    tags: ["test"],
    description: "Test route description",
    parameters: [{ in: "query", name: "test", required: true }],
    responses: {
      200: {
        description: "default",
        content: {
          "application/json": { schema: { $ref: "#/components/schemas/Test" } },
        },
      },
    },
    $global: {
      components: {
        schemas: {
          Test: {
            type: "object",
            properties: {
              status: {
                type: "string",
                enum: ["OK", "ERROR"],
              },
            },
          },
        },
      },
    },
  },
});
```
#### Result:

```json
{
  "openapi": "3.1.0",
  "paths": {
    "/api/meta/test": {
      "get": {
        "tags": [
          "test"
        ],
        "parameters": [
          {
            "in": "query",
            "name": "test",
            "required": true
          }
        ],
        "responses": {
          "200": {
            "description": "default",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Test"
                }
              }
            }
          }
        },
        "description": "Test route description"
      }
    }
  },
  "components": {
    "schemas": {
      "Test": {
        "type": "object",
        "properties": {
          "status": {
            "type": "string",
            "enum": [
              "OK",
              "ERROR"
            ]
          }
        }
      }
    }
  }
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
