### PR TITLE
feat: add `env` suffix for plugins/middlewares/tasks

### DIFF
--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -6,8 +6,8 @@ import { withBase, withLeadingSlash, withoutTrailingSlash } from "ufo";
 export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
 type FileInfo = { path: string; fullPath: string };
 
-const suffixRegex =
-  /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?(\.(?<env>dev|prod|prerender))?$/;
+const methodSuffixRegex = /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?/;
+const envSuffixRegex = /(\.(?<env>dev|prod|prerender))?$/;
 
 // prettier-ignore
 type MatchedMethodSuffix = "connect" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "trace";
@@ -79,9 +79,11 @@ export async function scanHandlers(nitro: Nitro) {
 export async function scanMiddleware(nitro: Nitro) {
   const files = await scanFiles(nitro, "middleware");
   return files.map((file) => {
+    const { env } = extractSuffix(file.path)
     return {
       middleware: true,
       handler: file.fullPath,
+      env,
     };
   });
 }
@@ -101,16 +103,8 @@ export async function scanServerRoutes(
       .replace(/\[([^/\]]+)]/g, ":$1");
     route = withLeadingSlash(withoutTrailingSlash(withBase(route, prefix)));
 
-    const suffixMatch = route.match(suffixRegex);
-    let method: MatchedMethodSuffix | undefined;
-    let env: MatchedEnvSuffix | undefined;
-    if (suffixMatch?.index && suffixMatch?.index >= 0) {
-      route = route.slice(0, suffixMatch.index);
-      method = suffixMatch.groups?.method as MatchedMethodSuffix | undefined;
-      env = suffixMatch.groups?.env as MatchedEnvSuffix | undefined;
-    }
-
-    route = route.replace(/\/index$/, "") || "/";
+    const { path, method, env } = extractSuffix(route, true)
+    route = path.replace(/\/index$/, "") || "/";
 
     return {
       handler: file.fullPath,
@@ -131,11 +125,12 @@ export async function scanPlugins(nitro: Nitro) {
 export async function scanTasks(nitro: Nitro) {
   const files = await scanFiles(nitro, "tasks");
   return files.map((f) => {
-    const name = f.path
+    const { path, env } = extractSuffix(f.path)
+    const name = path
       .replace(/\/index$/, "")
       .replace(/\.[A-Za-z]+$/, "")
       .replace(/\//g, ":");
-    return { name, handler: f.fullPath };
+    return { name, handler: f.fullPath, env };
   });
 }
 
@@ -170,4 +165,32 @@ async function scanDir(
       };
     })
     .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function extractSuffix(
+  path: string,
+): { path: string; env?: MatchedEnvSuffix }
+function extractSuffix(
+  path: string,
+  includeMethod: true
+): { path: string; method?: MatchedMethodSuffix; env?: MatchedEnvSuffix }
+function extractSuffix(
+  path: string,
+  includeMethod: boolean = false
+) {
+  const regex = includeMethod
+    ? new RegExp(methodSuffixRegex.source + envSuffixRegex.source)
+    : envSuffixRegex;
+
+  const suffixMatch = path.match(regex);
+  let method: MatchedMethodSuffix | undefined;
+  let env: MatchedEnvSuffix | undefined;
+
+  if (suffixMatch?.index && suffixMatch?.index >= 0) {
+    path = path.slice(0, suffixMatch.index);
+    method = suffixMatch.groups?.method as MatchedMethodSuffix | undefined;
+    env = suffixMatch.groups?.env as MatchedEnvSuffix | undefined;
+  }
+
+  return { path, method, env };
 }

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -6,7 +6,8 @@ import { withBase, withLeadingSlash, withoutTrailingSlash } from "ufo";
 export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
 type FileInfo = { path: string; fullPath: string };
 
-const methodSuffixRegex = /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?/;
+const methodSuffixRegex =
+  /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?/;
 const envSuffixRegex = /(\.(?<env>dev|prod|prerender))?$/;
 
 // prettier-ignore
@@ -79,7 +80,7 @@ export async function scanHandlers(nitro: Nitro) {
 export async function scanMiddleware(nitro: Nitro) {
   const files = await scanFiles(nitro, "middleware");
   return files.map((file) => {
-    const { env } = extractSuffix(file.path)
+    const { env } = extractSuffix(file.path);
     return {
       middleware: true,
       handler: file.fullPath,
@@ -103,7 +104,7 @@ export async function scanServerRoutes(
       .replace(/\[([^/\]]+)]/g, ":$1");
     route = withLeadingSlash(withoutTrailingSlash(withBase(route, prefix)));
 
-    const { path, method, env } = extractSuffix(route, true)
+    const { path, method, env } = extractSuffix(route, true);
     route = path.replace(/\/index$/, "") || "/";
 
     return {
@@ -125,7 +126,7 @@ export async function scanPlugins(nitro: Nitro) {
 export async function scanTasks(nitro: Nitro) {
   const files = await scanFiles(nitro, "tasks");
   return files.map((f) => {
-    const { path, env } = extractSuffix(f.path)
+    const { path, env } = extractSuffix(f.path);
     const name = path
       .replace(/\/index$/, "")
       .replace(/\.[A-Za-z]+$/, "")
@@ -167,17 +168,12 @@ async function scanDir(
     .sort((a, b) => a.path.localeCompare(b.path));
 }
 
-function extractSuffix(
-  path: string,
-): { path: string; env?: MatchedEnvSuffix }
+function extractSuffix(path: string): { path: string; env?: MatchedEnvSuffix };
 function extractSuffix(
   path: string,
   includeMethod: true
-): { path: string; method?: MatchedMethodSuffix; env?: MatchedEnvSuffix }
-function extractSuffix(
-  path: string,
-  includeMethod: boolean = false
-) {
+): { path: string; method?: MatchedMethodSuffix; env?: MatchedEnvSuffix };
+function extractSuffix(path: string, includeMethod: boolean = false) {
   const regex = includeMethod
     ? new RegExp(methodSuffixRegex.source + envSuffixRegex.source)
     : envSuffixRegex;

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -3,15 +3,19 @@ import type { Nitro } from "nitropack/types";
 import { join, relative } from "pathe";
 import { withBase, withLeadingSlash, withoutTrailingSlash } from "ufo";
 
-export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
-type FileInfo = { path: string; fullPath: string };
-
-const suffixRegex =
-  /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?(\.(?<env>dev|prod|prerender))?$/;
-
 // prettier-ignore
 type MatchedMethodSuffix = "connect" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "trace";
 type MatchedEnvSuffix = "dev" | "prod" | "prerender";
+type FileInfo = {
+  path: string;
+  fullPath: string;
+  method?: MatchedMethodSuffix;
+  env?: MatchedEnvSuffix;
+};
+
+export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
+const suffixRegex =
+  /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?(\.(?<env>dev|prod|prerender))?$/;
 
 export async function scanAndSyncOptions(nitro: Nitro) {
   // Scan plugins
@@ -82,6 +86,7 @@ export async function scanMiddleware(nitro: Nitro) {
     return {
       middleware: true,
       handler: file.fullPath,
+      env: file.env,
     };
   });
 }
@@ -100,16 +105,6 @@ export async function scanServerRoutes(
       .replace(/\[\.{3}(\w+)]/g, "**:$1")
       .replace(/\[([^/\]]+)]/g, ":$1");
     route = withLeadingSlash(withoutTrailingSlash(withBase(route, prefix)));
-
-    const suffixMatch = route.match(suffixRegex);
-    let method: MatchedMethodSuffix | undefined;
-    let env: MatchedEnvSuffix | undefined;
-    if (suffixMatch?.index && suffixMatch?.index >= 0) {
-      route = route.slice(0, suffixMatch.index);
-      method = suffixMatch.groups?.method as MatchedMethodSuffix | undefined;
-      env = suffixMatch.groups?.env as MatchedEnvSuffix | undefined;
-    }
-
     route = route.replace(/\/index$/, "") || "/";
 
     return {
@@ -117,8 +112,8 @@ export async function scanServerRoutes(
       lazy: true,
       middleware: false,
       route,
-      method,
-      env,
+      method: file.method,
+      env: file.env,
     };
   });
 }
@@ -135,7 +130,7 @@ export async function scanTasks(nitro: Nitro) {
       .replace(/\/index$/, "")
       .replace(/\.[A-Za-z]+$/, "")
       .replace(/\//g, ":");
-    return { name, handler: f.fullPath };
+    return { name, handler: f.fullPath, env: f.env };
   });
 }
 
@@ -164,9 +159,21 @@ async function scanDir(
   });
   return fileNames
     .map((fullPath) => {
+      const path = relative(join(dir, name), fullPath);
+      const suffixMatch = path.match(suffixRegex);
+      let method: MatchedMethodSuffix | undefined;
+      let env: MatchedEnvSuffix | undefined;
+
+      if (suffixMatch?.index && suffixMatch?.index >= 0) {
+        method = suffixMatch.groups?.method as MatchedMethodSuffix | undefined;
+        env = suffixMatch.groups?.env as MatchedEnvSuffix | undefined;
+      }
+
       return {
         fullPath,
-        path: relative(join(dir, name), fullPath),
+        path,
+        method,
+        env,
       };
     })
     .sort((a, b) => a.path.localeCompare(b.path));


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Resolves #2866

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As discussed in the linked issue this will make the `env` suffix (`.dev.ts`, `.prod.ts` and `.prerender.ts`) also available to plugins, middlewares and tasks.

#### TODO
- [x] move the regex matching to `scanDir`
- [ ] update the related `scan*` functions to return an object with `env`
  - [ ] `scanAndSyncOptions`
  - [x] `scanHandlers` (untouched)
  - [x] `scanMiddleware`
  - [x] `scanServerRoutes`
  - [ ] `scanPlugins`
  - [x] `scanTasks`
  - [ ] `scanModules`
- [ ] make the builder filter them

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
