### PR TITLE
feat(cache): cache event handler stream response

### DIFF
--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -91,6 +91,7 @@ export default defineNitroConfig({
     "/rules/_/cached/noncached": { cache: false, swr: false, isr: false },
     "/rules/_/cached/**": { swr: true },
     "/api/proxy/**": { proxy: "/api/echo" },
+    "/stream-cached": { swr: true },
   },
   prerender: {
     crawlLinks: true,

--- a/test/fixture/routes/stream-cached.ts
+++ b/test/fixture/routes/stream-cached.ts
@@ -1,0 +1,13 @@
+export default eventHandler(() => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode("nitro"));
+      controller.enqueue(encoder.encode("is"));
+      controller.enqueue(encoder.encode("awesome,"));
+      controller.enqueue(encoder.encode(Date.now().toString()));
+      controller.close();
+    },
+  });
+  return stream;
+});

--- a/test/presets/netlify-legacy.test.ts
+++ b/test/presets/netlify-legacy.test.ts
@@ -71,6 +71,7 @@ describe("nitro:preset:netlify-legacy", async () => {
         /rules/isr-ttl/*	/.netlify/builders/server 200
         /rules/isr/*	/.netlify/builders/server 200
         /rules/dynamic	/.netlify/functions/server 200
+        /stream-cached	/.netlify/builders/server 200
         /build/* /build/:splat 200
         /* /.netlify/functions/server 200"
       `);

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -143,6 +143,10 @@ describe("nitro:preset:vercel", async () => {
                 "src": "(?<url>/rules/swr-ttl/.*)",
               },
               {
+                "dest": "/stream-cached?url=$url",
+                "src": "/stream-cached",
+              },
+              {
                 "dest": "/__nitro",
                 "src": "/(.*)",
               },

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -729,6 +729,34 @@ export function testNitro(
         }
       }
     );
+
+    it.skipIf(
+      ctx.isIsolated ||
+        (isWindows && ctx.preset === "nitro-dev") ||
+        ctx.isLambda
+    )("should cache stream result", async () => {
+      const { data } = await callHandler({
+        url: "/stream-cached",
+      });
+
+      const [str, timestamp] = data.split(",") as string[];
+
+      expect(str).toBe(
+        ctx.isLambda ? btoa("nitroisawesome") : "nitroisawesome"
+      );
+
+      const calls = await Promise.all([
+        callHandler({ url: "/stream-cached" }),
+        callHandler({ url: "/stream-cached" }),
+        callHandler({ url: "/stream-cached" }),
+      ]);
+
+      for (const call of calls) {
+        expect(call.data).toBe(
+          ctx.isLambda ? btoa(`${str},${timestamp}`) : `${str},${timestamp}`
+        );
+      }
+    });
   });
 
   describe("scanned files", () => {


### PR DESCRIPTION
### 🔗 Linked issue

- #2932 

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

#### Problem

When a stream is used in a cachedEventHandler the cached body is the serialized stream and not the result of this stream.
Resulting in an undesired behavior as the response sent when taken from the cache is the serialized stream.

#### Solution

This pull request add the ability to use `defineCachedEventHandler` with stream responses.
When the `eventHandler` returns a stream, the response of this stream is cached rather than the stream itself.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
