### PR TITLE
fix(dynamic-require): update to match new webpack chunk format

### DIFF
--- a/src/rollup/plugins/dynamic-require.ts
+++ b/src/rollup/plugins/dynamic-require.ts
@@ -92,7 +92,14 @@ async function getWebpackChunkMeta(src: string) {
   const chunk = await import(pathToFileURL(src).href).then(
     (r) => r.default || r || {}
   );
-  const { id, ids, modules } = chunk;
+  const {
+    __webpack_id__,
+    __webpack_ids__,
+    __webpack_modules__,
+    id = __webpack_id__,
+    ids = __webpack_ids__,
+    modules = __webpack_modules__,
+  } = chunk;
   if (!id && !ids) {
     return null; // Not a webpack chunk
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

discovered in https://github.com/nuxt/nuxt/pull/30279
related in https://github.com/nuxt/nuxt/pull/30278

It seems webpack chunk format changes in the latest minor update. This is a backwards-compatible change, which resolves the issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
