### PR TITLE
fix `no-misused-promises` eslint, when creating plugin with async body

### DIFF
--- a/src/types/runtime/nitro.ts
+++ b/src/types/runtime/nitro.ts
@@ -16,7 +16,7 @@ export interface NitroApp {
 }
 
 export interface NitroAppPlugin {
-  (nitro: NitroApp): void;
+  (nitro: NitroApp): void | Promise<void>;
 }
 
 export interface NitroAsyncContext {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When creating plugin with async body eslint will detect that the body should be function that returns `void`, while its okay to make the body of the plugin async.
_IMO this is the correct return type `void | Promise<void>`._

Here is the eslint message:
```
Promise returned in function argument where a void return was expected. `eslint@typescript-eslint/no-misused-promises`
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
