### PR TITLE
fix(netlify, netlify-edge): prefix build output paths with `baseURL`

### DIFF
--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -1,6 +1,7 @@
 import { promises as fsp } from "node:fs";
 import { defineNitroPreset } from "nitropack/kit";
 import type { Nitro } from "nitropack/types";
+import { joinURL } from "ufo";
 import { dirname, join } from "pathe";
 import netlifyLegacyPresets from "./legacy/preset";
 import {
@@ -85,8 +86,11 @@ const netlifyEdge = defineNitroPreset(
           version: 1,
           functions: [
             {
-              path: "/*",
-              excludedPath: getStaticPaths(nitro.options.publicAssets),
+              path: `${joinURL(nitro.options.baseURL, "*")}`,
+              excludedPath: getStaticPaths(
+                nitro.options.publicAssets,
+                nitro.options.baseURL
+              ),
               name: "edge server handler",
               function: "server",
               generator: getGeneratorString(nitro),

--- a/src/presets/netlify/utils.ts
+++ b/src/presets/netlify/utils.ts
@@ -93,16 +93,16 @@ export async function writeHeaders(nitro: Nitro) {
   await fsp.writeFile(headersPath, contents);
 }
 
-export function getStaticPaths(publicAssets: PublicAssetDir[]): string[] {
+export function getStaticPaths(
+  publicAssets: PublicAssetDir[],
+  baseURL: string
+): string[] {
   return [
-    "/.netlify",
+    "/.netlify/*", // TODO: should this be also be prefixed with baseURL?
     ...publicAssets
-      .filter(
-        (path) =>
-          path.fallthrough !== true && path.baseURL && path.baseURL !== "/"
-      )
-      .map(({ baseURL }) => baseURL),
-  ].map((url) => joinURL("/", url!, "*"));
+      .filter((a) => a.fallthrough !== true && a.baseURL && a.baseURL !== "/")
+      .map((a) => joinURL(baseURL, a.baseURL!, "*")),
+  ];
 }
 
 // This is written to the functions directory. It just re-exports the compiled handler,
@@ -115,8 +115,8 @@ export { default } from "./main.mjs";
 export const config = {
   name: "server handler",
   generator: "${getGeneratorString(nitro)}",
-  path: "/*",
-  excludedPath: ${JSON.stringify(getStaticPaths(nitro.options.publicAssets))},
+  path: "${joinURL(nitro.options.baseURL, "*")}",
+  excludedPath: ${JSON.stringify(getStaticPaths(nitro.options.publicAssets, nitro.options.baseURL))},
   preferStatic: true,
 };
     `.trim();

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -167,7 +167,7 @@ describe("nitro:preset:netlify", async () => {
 
   describe("getStaticPaths", () => {
     it("always returns `/.netlify/*`", () => {
-      expect(getStaticPaths([])).toEqual(["/.netlify/*"]);
+      expect(getStaticPaths([], "/base")).toEqual(["/.netlify/*"]);
     });
 
     it("returns a pattern with a leading slash for each non-fallthrough non-root public asset path", () => {

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -206,10 +206,10 @@ describe("nitro:preset:netlify", async () => {
           maxAge: 0,
         },
       ];
-      expect(getStaticPaths(publicAssets)).toEqual([
+      expect(getStaticPaths(publicAssets, "/base")).toEqual([
         "/.netlify/*",
-        "/with-default-fallthrough/*",
-        "/nested/no-fallthrough/*",
+        "/base/with-default-fallthrough/*",
+        "/base/nested/no-fallthrough/*",
       ]);
     });
   });


### PR DESCRIPTION
followup on #1484 / #2966

(discovered via nitro-deploys as netlify-edge with baseURL is still broken)

This PR adds global `baseURL` prefix to `excludedPath` and `functions[].path` 