### PR TITLE
fix(storage): make sure serialized options are not modified

### DIFF
--- a/src/core/utils/storage.ts
+++ b/src/core/utils/storage.ts
@@ -1,13 +1,15 @@
 import type { Nitro } from "nitropack/types";
+import { klona } from "klona";
 import { createStorage as _createStorage, builtinDrivers } from "unstorage";
 
 export async function createStorage(nitro: Nitro) {
   const storage = _createStorage();
 
-  const mounts = {
+  // https://github.com/unjs/unstorage/issues/566
+  const mounts = klona({
     ...nitro.options.storage,
     ...nitro.options.devStorage,
-  };
+  });
 
   for (const [path, opts] of Object.entries(mounts)) {
     if (opts.driver) {


### PR DESCRIPTION
resolves #2174

Nitro mounts unstorage drivers with same config object that is going to be bundled for prod during build to expose `nitro.storage`.

Due to https://github.com/unjs/unstorage/issues/566, unstorage drivers apply their runtime normalization (such as resolving paths to absolute path) that causes side-effect to be carried to bundled options.