### PR TITLE
fix(config): normalize route rules with leading slash

### DIFF
--- a/src/core/config/resolvers/route-rules.ts
+++ b/src/core/config/resolvers/route-rules.ts
@@ -19,8 +19,8 @@ export function normalizeRouteRules(
   const normalizedRules: Record<string, NitroRouteRules> = {};
   for (let path in config.routeRules) {
     const routeConfig = config.routeRules[path] as NitroRouteConfig;
-    if (!path.startsWith('/')) {
-      path = `/${path}`
+    if (!path.startsWith("/")) {
+      path = `/${path}`;
     }
     const routeRules: NitroRouteRules = {
       ...routeConfig,

--- a/src/core/config/resolvers/route-rules.ts
+++ b/src/core/config/resolvers/route-rules.ts
@@ -5,6 +5,7 @@ import type {
   NitroRouteConfig,
   NitroRouteRules,
 } from "nitropack/types";
+import { withLeadingSlash } from "ufo";
 
 export async function resolveRouteRulesOptions(options: NitroOptions) {
   // Backward compatibility for options.routes
@@ -19,9 +20,7 @@ export function normalizeRouteRules(
   const normalizedRules: Record<string, NitroRouteRules> = {};
   for (let path in config.routeRules) {
     const routeConfig = config.routeRules[path] as NitroRouteConfig;
-    if (!path.startsWith("/")) {
-      path = `/${path}`;
-    }
+    path = withLeadingSlash(path);
     const routeRules: NitroRouteRules = {
       ...routeConfig,
       redirect: undefined,

--- a/src/core/config/resolvers/route-rules.ts
+++ b/src/core/config/resolvers/route-rules.ts
@@ -17,8 +17,11 @@ export function normalizeRouteRules(
   config: NitroConfig
 ): Record<string, NitroRouteRules> {
   const normalizedRules: Record<string, NitroRouteRules> = {};
-  for (const path in config.routeRules) {
+  for (let path in config.routeRules) {
     const routeConfig = config.routeRules[path] as NitroRouteConfig;
+    if (!path.startsWith('/')) {
+      path = `/${path}`
+    }
     const routeRules: NitroRouteRules = {
       ...routeConfig,
       redirect: undefined,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -95,6 +95,7 @@ export default defineNitroConfig({
     "/rules/_/cached/noncached": { cache: false, swr: false, isr: false },
     "/rules/_/cached/**": { swr: true },
     "/api/proxy/**": { proxy: "/api/echo" },
+    "**": { headers: { "x-test": "test" } },
   },
   prerender: {
     crawlLinks: true,

--- a/test/presets/netlify-legacy.test.ts
+++ b/test/presets/netlify-legacy.test.ts
@@ -82,19 +82,21 @@ describe("nitro:preset:netlify-legacy", async () => {
         );
 
         expect(headers).toMatchInlineSnapshot(`
-        "/rules/headers
-          cache-control: s-maxage=60
-        /rules/cors
-          access-control-allow-origin: *
-          access-control-allow-methods: GET
-          access-control-allow-headers: *
-          access-control-max-age: 0
-        /rules/nested/*
-          x-test: test
-        /build/*
-          cache-control: public, max-age=3600, immutable
-        "
-      `);
+          "/rules/headers
+            cache-control: s-maxage=60
+          /rules/cors
+            access-control-allow-origin: *
+            access-control-allow-methods: GET
+            access-control-allow-headers: *
+            access-control-max-age: 0
+          /rules/nested/*
+            x-test: test
+          /build/*
+            cache-control: public, max-age=3600, immutable
+          /*
+            x-test: test
+          "
+        `);
       });
       it("should write config.json", async () => {
         const config = await fsp

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -62,19 +62,21 @@ describe("nitro:preset:netlify", async () => {
         );
 
         expect(headers).toMatchInlineSnapshot(`
-        "/rules/headers
-          cache-control: s-maxage=60
-        /rules/cors
-          access-control-allow-origin: *
-          access-control-allow-methods: GET
-          access-control-allow-headers: *
-          access-control-max-age: 0
-        /rules/nested/*
-          x-test: test
-        /build/*
-          cache-control: public, max-age=3600, immutable
-        "
-      `);
+          "/rules/headers
+            cache-control: s-maxage=60
+          /rules/cors
+            access-control-allow-origin: *
+            access-control-allow-methods: GET
+            access-control-allow-headers: *
+            access-control-max-age: 0
+          /rules/nested/*
+            x-test: test
+          /build/*
+            cache-control: public, max-age=3600, immutable
+          /*
+            x-test: test
+          "
+        `);
       });
 
       it("writes config.json", async () => {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -97,6 +97,12 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/build/(.*)",
               },
               {
+                "headers": {
+                  "x-test": "test",
+                },
+                "src": "/(.*)",
+              },
+              {
                 "continue": true,
                 "headers": {
                   "cache-control": "public,max-age=31536000,immutable",


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #2463 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vercel deployment is failing because with this configuration :point_down:  the `.vercel/output/config.json` is wrong.

```
//https://nitro.unjs.io/config
export default defineNitroConfig({
  compatibilityDate: "2025-01-07",
  srcDir: "server",
  routeRules: { "**": { headers: { "x-foo": "bar" } } },
  preset: 'vercel'
});
```

Forcing the initial `/` will solve the issue.

#### BEFORE ❌

FILE: `.vercel/output/config.json`
```
{
  "version": 3,
  "overrides": {},
  "routes": [
    {
      "headers": {
        "x-foo": "bar"
      },
      "src": "**"
    },
    {
      "handle": "filesystem"
    },
    {
      "src": "/(.*)",
      "dest": "/__nitro"
    }
  ]
}
```

#### AFTER ✅

FILE: `.vercel/output/config.json`
```
{
  "version": 3,
  "overrides": {},
  "routes": [
    {
      "headers": {
        "x-foo": "bar"
      },
      "src": "/(.*)"
    },
    {
      "handle": "filesystem"
    },
    {
      "src": "/(.*)",
      "dest": "/__nitro"
    }
  ]
}
```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
