### PR TITLE
fix(server-assets): include files without ext by default

### DIFF
--- a/src/rollup/plugins/server-assets.ts
+++ b/src/rollup/plugins/server-assets.ts
@@ -33,7 +33,7 @@ export function serverAssets(nitro: Nitro): Plugin {
         // Scan all assets
         const assets: Record<string, ResolvedAsset> = {};
         for (const asset of nitro.options.serverAssets) {
-          const files = await globby("**/*.*", {
+          const files = await globby(asset.pattern || "**/*", {
             cwd: asset.dir,
             absolute: false,
             ignore: asset.ignore,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -309,6 +309,7 @@ export interface CompressOptions {
 // Server assets
 export interface ServerAssetDir {
   baseName: string;
+  pattern?: string;
   dir: string;
   ignore?: string[];
 }


### PR DESCRIPTION
resolves #2993

Include files without extension to the bundled server assets + adds an option to customize behavior.