### PR TITLE
fix(dev): store dev worker socket in buildDir

### DIFF
--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -4,10 +4,8 @@ import { runTask } from "nitropack/runtime";
 import { trapUnhandledNodeErrors } from "nitropack/runtime/internal";
 import { startScheduleRunner } from "nitropack/runtime/internal";
 import { scheduledTasks, tasks } from "#nitro-internal-virtual/tasks";
-
-import { mkdirSync } from "node:fs";
 import { Server } from "node:http";
-import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { parentPort, threadId } from "node:worker_threads";
 import wsAdapter from "crossws/adapters/node";
@@ -42,9 +40,7 @@ function getAddress() {
   if (isWindows) {
     return join(String.raw`\\.\pipe\nitro`, socketName);
   }
-  const socketDir = join(tmpdir(), "nitro");
-  mkdirSync(socketDir, { recursive: true });
-  return join(socketDir, socketName);
+  return fileURLToPath(new URL(socketName, import.meta.url));
 }
 
 const listenAddress = getAddress();


### PR DESCRIPTION
resolves #1881

When running nitro in Linux environment, `tmpdir()` points to a shared `/tmp` directory often, if one user runs a nitro app, it makes `/tmp/nitro` with `w` permission only for that specific user. If another user tries to run a nitro app, it cannot.

This PR changes dev-server to use local `.nitro/dev/.sock` socket alongside with dev server entry point to avoid this kind of issues.