### PR TITLE
docs: add deno to installation methods

### DIFF
--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -62,7 +62,7 @@ You can find more examples in the Nitro repository: [nitrojs/nitro/examples](htt
 
 ## Directory structure
 
-The starter template some important files to get you started.
+The starter template includes some important files to get you started.
 
 ### `routes/`
 

--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -23,7 +23,7 @@ Nitro automatically makes your code compatible with any [deployment](/deploy) pr
 ::note
 Make sure you have installed the recommended setup:
 
-- Latest LTS version of [Node.js](https://nodejs.org/en), or [Bun](https://bun.sh/).
+- Latest LTS version of either [Node.js](https://nodejs.org/en), [Bun](https://bun.sh/), or [Deno](https://deno.com/).
 - [Visual Studio Code](https://code.visualstudio.com/)
 ::
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With the addition of Deno commands to the documentation, Deno is likely considered to be supported like any other runtime. As such, it should be mentioned in the recommended setup alongside Node.js and Bun. This pull request also fixes an introductory sentence in the `Getting Started/Directory structure` section that appears to be incomplete.

### 📝 Checklist

- [x] I have updated the documentation accordingly.
