### PR TITLE
fix: use relative paths for imports types

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -87,12 +87,18 @@ export async function writeTypes(nitro: Nitro) {
       resolvedImportPathMap.set(i.from, path);
     }
 
+    const tsConfigPath = resolve(
+      nitro.options.buildDir,
+      nitro.options.typescript.tsconfigPath
+    );
+    const tsconfigDir = dirname(tsConfigPath);
+
     autoImportedTypes = [
       nitro.options.imports && nitro.options.imports.autoImport !== false
         ? (
             await nitro.unimport.generateTypeDeclarations({
               exportHelper: false,
-              resolvePath: (i) => resolvedImportPathMap.get(i.from) ?? i.from,
+              resolvePath: (i) => resolvedImportPathMap.get(i.from) ?? relativeWithDot(tsconfigDir, i.from),
             })
           ).trim()
         : "",

--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -98,7 +98,9 @@ export async function writeTypes(nitro: Nitro) {
         ? (
             await nitro.unimport.generateTypeDeclarations({
               exportHelper: false,
-              resolvePath: (i) => resolvedImportPathMap.get(i.from) ?? relativeWithDot(tsconfigDir, i.from),
+              resolvePath: (i) =>
+                resolvedImportPathMap.get(i.from) ??
+                relativeWithDot(tsconfigDir, i.from),
             })
           ).trim()
         : "",


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

if the path is long it will put it directly, whereas ts-config should fix it from where it was created.

```ts
  if (nitro.options.imports) {
    nitro.options.imports.dirs ??= []
    nitro.options.imports.dirs.push(
     join('/Users/productdevbook/Documents/GitHub/dev/test/examples/nitro/server/test/', '**/*')
    )

    // nitro.unimport = createUnimport(nitro.options.imports)
    await nitro.unimport?.init()
  }
```

```
 const useSilgi: typeof import('/Users/productdevbook/Documents/GitHub/dev/test/examples/nitro/server/test/hello.ts')['useHello']
 ``` 
 
 
 # Now 
 
 ```
   const useSilgi: typeof import('../../server/test/hello.ts')['useHello']
   ``` 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
