### PR TITLE
fix: correct path check to ensure it is absolute

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -64,7 +64,7 @@ export async function writeTypes(nitro: Nitro) {
         continue;
       }
       let path = resolveAlias(i.from, nitro.options.alias);
-      if (!isAbsolute(path)) {
+      if (isAbsolute(path)) {
         const resolvedPath = await resolvePath(i.from, {
           url: nitro.options.nodeModulesDirs,
         }).catch(() => null);


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

nitro-import.d.ts was giving libraries to the wrong paths when importing.

Old
<details><summary>Details</summary>
<p>

```
declare global {
  const __buildAssetsURL: typeof import('../../node_modules/.pnpm/nuxt@3.15.3_@parcel+watcher@2.5.1_@types+node@22.10.10_db0@0.2.1_drizzle-orm@0.38.4_@types+pg_siyhbzoo3b52tyxpwydjjnbywq/node_modules/nuxt/dist/core/runtime/nitro/paths')['buildAssetsURL']
  const __publicAssetsURL: typeof import('../../node_modules/.pnpm/nuxt@3.15.3_@parcel+watcher@2.5.1_@types+node@22.10.10_db0@0.2.1_drizzle-orm@0.38.4_@types+pg_siyhbzoo3b52tyxpwydjjnbywq/node_modules/nuxt/dist/core/runtime/nitro/paths')['publicAssetsURL']
  const appendCorsHeaders: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['appendCorsHeaders']
  const appendCorsPreflightHeaders: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['appendCorsPreflightHeaders']
  const appendHeader: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['appendHeader']
  const appendHeaders: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['appendHeaders']
  const appendResponseHeader: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['appendResponseHeader']
  const appendResponseHeaders: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['appendResponseHeaders']
  const assertMethod: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['assertMethod']
  const auth: typeof import('../../server/providers/auth')['auth']
  const cachedEventHandler: typeof import('../../node_modules/.pnpm/nitropack@2.10.4_patch_hash=sus37sqsdkybfx3yfzhkygugve_drizzle-orm@0.38.4_@types+pg@8.11.11_k_q4bfbddcxxv4dw5ybmyn56ysze/node_modules/nitropack/dist/runtime/internal/cache')['cachedEventHandler']
  const cachedFunction: typeof import('../../node_modules/.pnpm/nitropack@2.10.4_patch_hash=sus37sqsdkybfx3yfzhkygugve_drizzle-orm@0.38.4_@types+pg@8.11.11_k_q4bfbddcxxv4dw5ybmyn56ysze/node_modules/nitropack/dist/runtime/internal/cache')['cachedFunction']
  const callNodeListener: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['callNodeListener']
  const checkCircularReference: typeof import('../../server/utils/util')['checkCircularReference']
  const clearResponseHeaders: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['clearResponseHeaders']
  const clearSession: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['clearSession']
  const createApp: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['createApp']
  const createAppEventHandler: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['createAppEventHandler']
  const createError: typeof import('../../node_modules/.pnpm/h3@1.14.0/node_modules/h3')['createError']
  ``` 


</p>
</details> 


New 
<details><summary>Details</summary>
<p>

```
declare global {
  const __buildAssetsURL: typeof import('../../node_modules/.pnpm/nuxt@3.15.3_@parcel+watcher@2.5.1_@types+node@22.10.10_db0@0.2.1_drizzle-orm@0.38.4_@types+pg_siyhbzoo3b52tyxpwydjjnbywq/node_modules/nuxt/dist/core/runtime/nitro/paths')['buildAssetsURL']
  const __publicAssetsURL: typeof import('../../node_modules/.pnpm/nuxt@3.15.3_@parcel+watcher@2.5.1_@types+node@22.10.10_db0@0.2.1_drizzle-orm@0.38.4_@types+pg_siyhbzoo3b52tyxpwydjjnbywq/node_modules/nuxt/dist/core/runtime/nitro/paths')['publicAssetsURL']
  const appendCorsHeaders: typeof import('h3')['appendCorsHeaders']
  const appendCorsPreflightHeaders: typeof import('h3')['appendCorsPreflightHeaders']
  const appendHeader: typeof import('h3')['appendHeader']
  const appendHeaders: typeof import('h3')['appendHeaders']
  const appendResponseHeader: typeof import('h3')['appendResponseHeader']
  const appendResponseHeaders: typeof import('h3')['appendResponseHeaders']
  const assertMethod: typeof import('h3')['assertMethod']
  const auth: typeof import('../../server/providers/auth')['auth']
  const cachedEventHandler: typeof import('nitropack/runtime/internal/cache')['cachedEventHandler']
  const cachedFunction: typeof import('nitropack/runtime/internal/cache')['cachedFunction']
  const callNodeListener: typeof import('h3')['callNodeListener']
  const checkCircularReference: typeof import('../../server/utils/util')['checkCircularReference']
  const clearResponseHeaders: typeof import('h3')['clearResponseHeaders']
  const clearSession: typeof import('h3')['clearSession']
  const createApp: typeof import('h3')['createApp']
  const createAppEventHandler: typeof import('h3')['createAppEventHandler']
  const createError: typeof import('h3')['createError']
  const createEvent: typeof import('h3')['createEvent']
  const createEventStream: typeof import('h3')['createEventStream']
  const createRouter: typeof import('h3')['createRouter']
  const defaultContentType: typeof import('h3')['defaultContentType']
  const defineAppConfig: typeof import('../../node_modules/.pnpm/nuxt@3.15.3_@parcel+watcher@2.5.1_@types+node@22.10.10_db0@0.2.1_drizzle-orm@0.38.4_@types+pg_siyhbzoo3b52tyxpwydjjnbywq/node_modules/nuxt/dist/core/runtime/nitro/config')['defineAppConfig']
  const defineCachedEventHandler: typeof import('nitropack/runtime/internal/cache')['defineCachedEventHandler']
  const defineCachedFunction: typeof import('nitropack/runtime/internal/cache')['defineCachedFunction']
  const defineEventHandler: typeof import('h3')['defineEventHandler']
  const defineLazyEventHandler: typeof import('h3')['defineLazyEventHandler']
  const defineNitroErrorHandler: typeof import('nitropack/runtime/internal/error')['defineNitroErrorHandler']
  const defineNitroPlugin: typeof import('nitropack/runtime/internal/plugin')['defineNitroPlugin']
  const defineNodeListener: typeof import('h3')['defineNodeListener']
  const defineNodeMiddleware: typeof import('h3')['defineNodeMiddleware']
  const defineRenderHandler: typeof import('nitropack/runtime/internal/renderer')['defineRenderHandler']
  const defineRequestMiddleware: typeof import('h3')['defineRequestMiddleware']
  const defineResponseMiddleware: typeof import('h3')['defineResponseMiddleware']
  const defineRouteMeta: typeof import('nitropack/runtime/internal/meta')['defineRouteMeta']
  const defineTask: typeof import('nitropack/runtime/internal/task')['defineTask']
  const defineWebSocket: typeof import('h3')['defineWebSocket']
  const defineWebSocketHandler: typeof import('h3')['defineWebSocketHandler']
  const deleteCookie: typeof import('h3')['deleteCookie']
  const dynamicEventHandler: typeof import('h3')['dynamicEventHandler']
  const emailFrom: typeof import('../../server/utils/email')['emailFrom']
  const eventHandler: typeof import('h3')['eventHandler']
  const fetchWithEvent: typeof import('h3')['fetchWithEvent']
  const fromNodeMiddleware: typeof import('h3')['fromNodeMiddleware']
  const fromPlainHandler: typeof import('h3')['fromPlainHandler']
  const fromWebHandler: typeof import('h3')['fromWebHandler']
  const getCookie: typeof import('h3')['getCookie']
  const getHeader: typeof import('h3')['getHeader']
  const getHeaders: typeof import('h3')['getHeaders']
  const getMethod: typeof import('h3')['getMethod']
  const getProxyRequestHeaders: typeof import('h3')['getProxyRequestHeaders']
  const getQuery: typeof import('h3')['getQuery']
  const getRequestFingerprint: typeof import('h3')['getRequestFingerprint']
  const getRequestHeader: typeof import('h3')['getRequestHeader']
  const getRequestHeaders: typeof import('h3')['getRequestHeaders']
  const getRequestHost: typeof import('h3')['getRequestHost']
  const getRequestIP: typeof import('h3')['getRequestIP']
  const getRequestPath: typeof import('h3')['getRequestPath']
  const getRequestProtocol: typeof import('h3')['getRequestProtocol']
  const getRequestURL: typeof import('h3')['getRequestURL']
  const getRequestWebStream: typeof import('h3')['getRequestWebStream']
  const getResponseHeader: typeof import('h3')['getResponseHeader']
  const getResponseHeaders: typeof import('h3')['getResponseHeaders']
  const getResponseStatus: typeof import('h3')['getResponseStatus']
  const getResponseStatusText: typeof import('h3')['getResponseStatusText']
  const getRouteRules: typeof import('nitropack/runtime/internal/route-rules')['getRouteRules']
  const getRouterParam: typeof import('h3')['getRouterParam']
  const getRouterParams: typeof import('h3')['getRouterParams']
  const getSession: typeof import('h3')['getSession']
  const getValidatedQuery: typeof import('h3')['getValidatedQuery']
  const getValidatedRouterParams: typeof import('h3')['getValidatedRouterParams']
  const handleCacheHeaders: typeof import('h3')['handleCacheHeaders']
  const handleCors: typeof import('h3')['handleCors']
  const isCorsOriginAllowed: typeof import('h3')['isCorsOriginAllowed']
  const isError: typeof import('h3')['isError']
  const isEvent: typeof import('h3')['isEvent']
  const isEventHandler: typeof import('h3')['isEventHandler']
  const isMethod: typeof import('h3')['isMethod']
  const isPreflightRequest: typeof import('h3')['isPreflightRequest']
  const isStream: typeof import('h3')['isStream']
  const isWebResponse: typeof import('h3')['isWebResponse']
  const lazyEventHandler: typeof import('h3')['lazyEventHandler']
  const nitroPlugin: typeof import('nitropack/runtime/internal/plugin')['nitroPlugin']
  const parseCookies: typeof import('h3')['parseCookies']
  const promisifyNodeListener: typeof import('h3')['promisifyNodeListener']
  const proxyRequest: typeof import('h3')['proxyRequest']
  const readBody: typeof import('h3')['readBody']
  const readFormData: typeof import('h3')['readFormData']
  const readMultipartFormData: typeof import('h3')['readMultipartFormData']
  const readRawBody: typeof import('h3')['readRawBody']
  const readValidatedBody: typeof import('h3')['readValidatedBody']
  const removeResponseHeader: typeof import('h3')['removeResponseHeader']
  const runTask: typeof import('nitropack/runtime/internal/task')['runTask']
  const sanitizeStatusCode: typeof import('h3')['sanitizeStatusCode']
  const sanitizeStatusMessage: typeof import('h3')['sanitizeStatusMessage']
  const sealSession: typeof import('h3')['sealSession']
  const send: typeof import('h3')['send']
  const sendEmail: typeof import('../../server/utils/email')['sendEmail']
  const sendError: typeof import('h3')['sendError']
  const sendIterable: typeof import('h3')['sendIterable']
  const sendNoContent: typeof import('h3')['sendNoContent']
  const sendProxy: typeof import('h3')['sendProxy']
  const sendRedirect: typeof import('h3')['sendRedirect']
  const sendStream: typeof import('h3')['sendStream']
  const sendWebResponse: typeof import('h3')['sendWebResponse']
  const serveStatic: typeof import('h3')['serveStatic']
  const setCookie: typeof import('h3')['setCookie']
  const setHeader: typeof import('h3')['setHeader']
  const setHeaders: typeof import('h3')['setHeaders']
  const setResponseHeader: typeof import('h3')['setResponseHeader']
  const setResponseHeaders: typeof import('h3')['setResponseHeaders']
  const setResponseStatus: typeof import('h3')['setResponseStatus']
  const silgi: typeof import('silgi')['silgi']
  const splitCookiesString: typeof import('h3')['splitCookiesString']
  const tables: typeof import('../../server/providers/db')['tables']
  const toEventHandler: typeof import('h3')['toEventHandler']
  const toNodeListener: typeof import('h3')['toNodeListener']
  const toPlainHandler: typeof import('h3')['toPlainHandler']
  const toWebHandler: typeof import('h3')['toWebHandler']
  const toWebRequest: typeof import('h3')['toWebRequest']
  const unsealSession: typeof import('h3')['unsealSession']
  const updateSession: typeof import('h3')['updateSession']
  const useAppConfig: typeof import('nitropack/runtime/internal/config')['useAppConfig']
  const useBase: typeof import('h3')['useBase']
  const useDb: typeof import('../../server/providers/db')['useDb']
  const useEvent: typeof import('nitropack/runtime/internal/context')['useEvent']
  const useNitroApp: typeof import('nitropack/runtime/internal/app')['useNitroApp']
  const useResend: typeof import('../../server/providers/resend')['useResend']
  const useRuntimeConfig: typeof import('nitropack/runtime/internal/config')['useRuntimeConfig']
  const useS3Client: typeof import('../../server/providers/s3')['useS3Client']
  const useSession: typeof import('h3')['useSession']
  const useStorage: typeof import('nitropack/runtime/internal/storage')['useStorage']
  const validateBookName: typeof import('../../server/utils/util')['validateBookName']
  const validateDirectoryName: typeof import('../../server/utils/util')['validateDirectoryName']
  const writeEarlyHints: typeof import('h3')['writeEarlyHints']
  const z: typeof import('zod')['z']
}
// for type re-export
declare global {
  // @ts-ignore
  export type { z as Zod } from 'zod'
  import('zod')

```

</p>
</details> 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
