### PR TITLE
fix(netlify): avoid second bundling

### DIFF
--- a/src/presets/netlify/utils.ts
+++ b/src/presets/netlify/utils.ts
@@ -116,6 +116,8 @@ export const config = {
   name: "server handler",
   generator: "${getGeneratorString(nitro)}",
   path: "/*",
+  nodeBundler: "none",
+  includedFiles: ["**"],
   excludedPath: ${JSON.stringify(getStaticPaths(nitro.options.publicAssets, nitro.options.baseURL))},
   preferStatic: true,
 };

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -105,6 +105,8 @@ describe("nitro:preset:netlify", async () => {
             name: "server handler",
             generator: "nitro@2.x",
             path: "/*",
+            nodeBundler: "none",
+            includedFiles: ["**"],
             excludedPath: ["/.netlify/*","/build/*"],
             preferStatic: true,
           };"


### PR DESCRIPTION
Context: Found while investigating https://github.com/nuxt/nuxt/issues/30789#issuecomment-2622552133

Netlify functions (both user and framework internals) are bundled by default via a last esbuild step. ([netlify docs](https://docs.netlify.com/frameworks-api/#bundling-2)) this is an unnecessary step for Nitro as nitro already makes an optimized bundle output.

In the legacy netify v1 preset, we were using `nodeModuleFormat: "esm"` to preserve ESM compatibility however it is broken currently with v2 format (https://github.com/nitrojs/nitro/pull/2406) in 2.10.0

With this PR, ESM compat of output remains as-is 