### PR TITLE
feat(cloudflare): `cloudflare:fetch` and `cloudflare:durable:fetch` hooks

### DIFF
--- a/playground/wrangler.toml
+++ b/playground/wrangler.toml
@@ -10,4 +10,4 @@ class_name = "$DurableObject"
 
 [[migrations]]
 tag = "v1"
-new_classes = ["$DurableObject"]
+new_sqlite_classes = ["$DurableObject"]

--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -1,4 +1,6 @@
 import type {
+  Request,
+  Response,
   ExecutionContext,
   ForwardableEmailMessage,
   MessageBatch,
@@ -61,8 +63,22 @@ export interface CloudflareOptions {
 
 type DurableObjectState = ConstructorParameters<typeof DurableObject>[0];
 
+export interface NitroCloudflareFetchEvent {
+  readonly request: Request;
+  readonly env: unknown;
+  readonly context: unknown;
+  readonly url: URL;
+
+  /**
+   * @experimental only available in the `cloudflare:durable` preset and might be removed in the future
+   */
+  durableFech?: () => Promise<Response>;
+}
+
 declare module "nitropack/types" {
   export interface NitroRuntimeHooks {
+    "cloudflare:fetch": (event: NitroCloudflareFetchEvent) => void;
+
     // https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/
     "cloudflare:scheduled": (_: {
       controller: ScheduledController;
@@ -97,6 +113,16 @@ declare module "nitropack/types" {
       context: ExecutionContext;
     }) => void;
 
+    // --- Durable Objects ---
+
+    /** @experimental */
+    "cloudflare:durable:fetch": (
+      event: NitroCloudflareFetchEvent & {
+        readonly durable: DurableObject;
+      }
+    ) => void;
+
+    /** @experimental */
     "cloudflare:durable:init": (
       durable: DurableObject,
       _: {
@@ -105,6 +131,7 @@ declare module "nitropack/types" {
       }
     ) => void;
 
+    /** @experimental */
     "cloudflare:durable:alarm": (durable: DurableObject) => void;
   }
 }


### PR DESCRIPTION
This PR enables two new hooks:

- `cloudflare:fetch(event)`
- `cloudflare:durable:fetch(event)`

These hooks (while adding to complexity and runtime overhead) allow custom extensions to normal nitro lifecycle.

The main use case of this is for durable objects to allow **redirect** some requests from main worker to the single instance durable worker.

```ts
export default defineNitroPlugin((nitroApp: NitroApp) => {
  nitroApp.hooks.hook("cloudflare:fetch", async (event) => {
    // Force redirects all fetch requests to the durable object
    return event.durableFech();
  });

  nitroApp.hooks.hook("cloudflare:durable:fetch", async (event) => {
    console.log("Handling response in durable object:", event.url);
  });
});
```

With the above plugin, `event` in event handlers has ` event.context.cloudflare.context` with the value of DurableObjectState type

---

(this is mainly a draft idea; An alternative is to simply expose a method of direct `fetch` to durable)