### PR TITLE
feat(cloudflare-durable): allow redirect fetch to durable object

### DIFF
--- a/playground/wrangler.toml
+++ b/playground/wrangler.toml
@@ -10,4 +10,4 @@ class_name = "$DurableObject"
 
 [[migrations]]
 tag = "v1"
-new_classes = ["$DurableObject"]
+new_sqlite_classes = ["$DurableObject"]

--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -4,24 +4,46 @@ import { DurableObject } from "cloudflare:workers";
 import wsAdapter from "crossws/adapters/cloudflare-durable";
 import { useNitroApp } from "nitropack/runtime";
 import { isPublicAssetURL } from "#nitro-internal-virtual/public-assets";
-import { createHandler } from "./_module-handler";
+import { createHandler, fetchHandler } from "./_module-handler";
 
-const nitroApp = useNitroApp();
-
-const ws = import.meta._websocket
-  ? wsAdapter(nitroApp.h3App.websocket)
-  : undefined;
+const DURABLE_BINDING = "$DurableObject";
+const DURABLE_INSTANCE = "server";
 
 interface Env {
   ASSETS?: { fetch: typeof CF.fetch };
+  [DURABLE_BINDING]?: CF.DurableObjectNamespace;
 }
 
+const nitroApp = useNitroApp();
+
+const getDurableStub = (env: Env) => {
+  const binding = env[DURABLE_BINDING];
+  if (!binding) {
+    throw new Error(
+      `Durable Object binding "${DURABLE_BINDING}" not available.`
+    );
+  }
+  const id = binding.idFromName(DURABLE_INSTANCE);
+  return binding.get(id);
+};
+
+const ws = import.meta._websocket
+  ? wsAdapter({
+      ...nitroApp.h3App.websocket,
+      instanceName: DURABLE_INSTANCE,
+      bindingName: DURABLE_BINDING,
+    })
+  : undefined;
+
 export default createHandler<Env>({
-  fetch(request, env, context, url) {
+  fetch(request, env, context, url, ctxExt) {
     // Static assets fallback (optional binding)
     if (env.ASSETS && isPublicAssetURL(url.pathname)) {
       return env.ASSETS.fetch(request);
     }
+
+    // Expose stub fetch to the context
+    ctxExt.durableFetch = (req = request) => getDurableStub(env).fetch(req);
 
     // Websocket upgrade
     // https://crossws.unjs.io/adapters/cloudflare#durable-objects
@@ -49,10 +71,15 @@ export class $DurableObject extends DurableObject {
   }
 
   override fetch(request: Request) {
-    if (import.meta._websocket) {
+    if (
+      import.meta._websocket &&
+      request.headers.get("upgrade") === "websocket"
+    ) {
       return ws!.handleDurableUpgrade(this, request);
     }
-    return new Response("404", { status: 404 });
+    // Main handler
+    const url = new URL(request.url);
+    return fetchHandler(request, this.env, this.ctx, url, nitroApp);
   }
 
   override alarm(): void | Promise<void> {

--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -79,7 +79,9 @@ export class $DurableObject extends DurableObject {
     }
     // Main handler
     const url = new URL(request.url);
-    return fetchHandler(request, this.env, this.ctx, url, nitroApp);
+    return fetchHandler(request, this.env, this.ctx, url, nitroApp, {
+      durable: this,
+    });
   }
 
   override alarm(): void | Promise<void> {


### PR DESCRIPTION
This PR updates the experimental cloudflare_durable preset (#2801) with new context util `durableFetch()` allowing redirecting fetches to durable instance for handling.

This is useful for running code in a durable instance handler, such as access to the storage or connected WebSocket peers.

```ts
export default eventHandler(async (event) => {
  const { durable, durableFetch } = event.context.cloudflare;

  if (durableFetch) {
    return durableFetch(); // Redirect to durable object
  }

  // This runs inside durable object
  console.log("Durable object:", durable);
  console.log("context:", event.context.cloudflare.context); // DurableObjectState

  return "check console logs";
});

```

Notes:
- `new_classes` in `wrangler` config should be changed to `new_sqlite_classes` to allow storage access
- Durable instance name changed from `crossws` (websocket-only) to `server` (generic)
- This API is part of the experimental preset and might change
- In nitro v2 / h3 v1, response handling (result of `durableFetch`) is limited. this PR aims for stable support in nitro v3 / h3 v2 with native `Response` handler

(alternative to #3047)