### PR TITLE
refactor: use `node-mock-http` instead of `unenv` v1 for local fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "mime": "^4.0.6",
     "mlly": "^1.7.4",
     "node-fetch-native": "^1.6.6",
-    "node-mock-http": "^0.1.0",
+    "node-mock-http": "^0.1.2",
     "ofetch": "^1.4.1",
     "ohash": "^1.1.4",
     "openapi-typescript": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "mime": "^4.0.6",
     "mlly": "^1.7.4",
     "node-fetch-native": "^1.6.6",
+    "node-mock-http": "^0.1.0",
     "ofetch": "^1.4.1",
     "ohash": "^1.1.4",
     "openapi-typescript": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "mime": "^4.0.6",
     "mlly": "^1.7.4",
     "node-fetch-native": "^1.6.6",
-    "node-mock-http": "^0.1.2",
+    "node-mock-http": "^1.0.0",
     "ofetch": "^1.4.1",
     "ohash": "^1.1.4",
     "openapi-typescript": "^7.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       node-fetch-native:
         specifier: ^1.6.6
         version: 1.6.6
+      node-mock-http:
+        specifier: ^0.1.0
+        version: 0.1.0
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
@@ -4422,6 +4425,9 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-mock-http@0.1.0:
+    resolution: {integrity: sha512-uguVoOrUjmS8VvB4CBi82WUaZrBsTvjbXk4bm8JtH/stPqNHBJoUcaGuAOWEBftflJcQkRcvkJ85pQNePrtbyA==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -10903,6 +10909,8 @@ snapshots:
   node-forge@1.3.1: {}
 
   node-gyp-build@4.8.4: {}
+
+  node-mock-http@0.1.0: {}
 
   node-releases@2.0.19: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6
       node-mock-http:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^1.0.0
+        version: 1.0.0
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
@@ -4426,8 +4426,8 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-mock-http@0.1.2:
-    resolution: {integrity: sha512-G7KCCUZ/aYzwwyDwPH5mESs18ijVJaktSNg1MVcYFAOHw3PTHh1O8S7c4ioWRXVdz7NniKAY5nM6359pAPYfwQ==}
+  node-mock-http@1.0.0:
+    resolution: {integrity: sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -10910,7 +10910,7 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-mock-http@0.1.2: {}
+  node-mock-http@1.0.0: {}
 
   node-releases@2.0.19: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6
       node-mock-http:
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.2
+        version: 0.1.2
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
@@ -4426,8 +4426,8 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-mock-http@0.1.0:
-    resolution: {integrity: sha512-uguVoOrUjmS8VvB4CBi82WUaZrBsTvjbXk4bm8JtH/stPqNHBJoUcaGuAOWEBftflJcQkRcvkJ85pQNePrtbyA==}
+  node-mock-http@0.1.2:
+    resolution: {integrity: sha512-G7KCCUZ/aYzwwyDwPH5mESs18ijVJaktSNg1MVcYFAOHw3PTHh1O8S7c4ioWRXVdz7NniKAY5nM6359pAPYfwQ==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -10910,7 +10910,7 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-mock-http@0.1.0: {}
+  node-mock-http@0.1.2: {}
 
   node-releases@2.0.19: {}
 

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -17,12 +17,12 @@ import type {
   NitroRuntimeHooks,
 } from "nitropack/types";
 import type { NitroAsyncContext } from "nitropack/types";
-import type { $Fetch, NitroFetchRequest } from "nitropack/types";
 import { Headers, createFetch } from "ofetch";
 import {
-  createCall,
-  createFetch as createLocalFetch,
-} from "unenv/runtime/fetch/index";
+  fetchNodeRequestHandler,
+  callNodeRequestHandler,
+  type AbstractRequest,
+} from "node-mock-http";
 import errorHandler from "#nitro-internal-virtual/error-handler";
 import { plugins } from "#nitro-internal-virtual/plugins";
 import { handlers } from "#nitro-internal-virtual/server-handlers";
@@ -85,14 +85,20 @@ function createNitroApp(): NitroApp {
     preemptive: true,
   });
 
-  // Create local fetch callers
-  const localCall = createCall(toNodeListener(h3App) as any);
-  // prettier-ignore
-  const _localFetch = createLocalFetch(localCall, (u, i) => globalThis.fetch(u, i));
-  const localFetch: typeof fetch = (input, init) =>
-    _localFetch(input as RequestInfo, init as any).then((response) =>
-      normalizeFetchResponse(response)
-    );
+  // Create local fetch caller
+  const nodeHandler = toNodeListener(h3App);
+  const localCall = (aRequest: AbstractRequest) =>
+    callNodeRequestHandler(nodeHandler, aRequest);
+  const localFetch: typeof fetch = (input, init) => {
+    if (!input.toString().startsWith("/")) {
+      return globalThis.fetch(input, init);
+    }
+    return fetchNodeRequestHandler(
+      nodeHandler,
+      input as string /* TODO */,
+      init
+    ).then((response) => normalizeFetchResponse(response));
+  };
   const $fetch = createFetch({
     fetch: localFetch,
     Headers,

--- a/src/types/runtime/nitro.ts
+++ b/src/types/runtime/nitro.ts
@@ -1,17 +1,17 @@
 import type { App as H3App, H3Event, Router } from "h3";
 import type { Hookable } from "hookable";
 import type { NitroRuntimeHooks as NitroTypesRuntimeHooks } from "nitropack";
-import type {
-  createCall,
-  createFetch as createLocalFetch,
-} from "unenv/runtime/fetch/index";
+import type { AbstractRequest, AbstractResponse } from "node-mock-http";
 
 export interface NitroApp {
   h3App: H3App;
   router: Router;
   hooks: Hookable<NitroRuntimeHooks>;
-  localCall: ReturnType<typeof createCall>;
-  localFetch: ReturnType<typeof createLocalFetch>;
+  localCall: (aRequest: AbstractRequest) => Promise<AbstractResponse>;
+  localFetch: (
+    req: string | URL | Request,
+    init?: RequestInit
+  ) => Promise<Response>;
   captureError: CaptureError;
 }
 

--- a/src/types/runtime/nitro.ts
+++ b/src/types/runtime/nitro.ts
@@ -10,7 +10,7 @@ export interface NitroApp {
   localCall: (aRequest: AbstractRequest) => Promise<AbstractResponse>;
   localFetch: (
     req: string | URL | Request,
-    init?: RequestInit
+    init?: RequestInit & AbstractRequest
   ) => Promise<Response>;
   captureError: CaptureError;
 }

--- a/test/fixture/routes/fetch.ts
+++ b/test/fixture/routes/fetch.ts
@@ -1,6 +1,7 @@
 export default eventHandler(async (event) => {
   const nitroApp = useNitroApp();
   return {
+    $fetch: await fetch("/api/hey").then((r) => r.text()),
     "event.fetch": await event.fetch("/api/hey").then((r) => r.text()),
     "event.$fetch": await event.$fetch("/api/hey"),
     "nitroApp.localFetch": await nitroApp

--- a/test/fixture/routes/fetch.ts
+++ b/test/fixture/routes/fetch.ts
@@ -1,0 +1,13 @@
+export default eventHandler(async (event) => {
+  const nitroApp = useNitroApp();
+  return {
+    "event.fetch": await event.fetch("/api/hey").then((r) => r.text()),
+    "event.$fetch": await event.$fetch("/api/hey"),
+    "nitroApp.localFetch": await nitroApp
+      .localFetch("/api/hey")
+      .then((r) => r.text()),
+    "nitroApp.localCall": await nitroApp
+      .localCall({ url: "/api/hey" })
+      .then((r) => r.body),
+  };
+});


### PR DESCRIPTION
This PR migrates direct fetch implementation from unenv v1 to [node-mock-http](https://github.com/unjs/node-mock-http).

This unblocks nitro v2 to migrate to unenv v2 which has breaking changes for HTTP (https://github.com/unjs/unenv/issues/364).

One other benefit of `node-mock-http` is that it leverages Node.js `node:buffer` and `node:events` (downside is temporary polyfill duplicate in environments without native Buffer/Events support -- cloudflare does support now) 

Complementry h3 (v1) PR: https://github.com/unjs/h3/pull/970