### PR TITLE
fix(rollup): resolve unenv paths with expected version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "resolutions": {
     "nitropack": "link:.",
     "undici": "^6.20.1",
-    "unenv": "npm:unenv-nightly@2.0.0-20250207-011423-492459d"
+    "unenv": "npm:unenv-nightly@2.0.0-20250207-023056-21dea9b"
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   },
   "resolutions": {
     "nitropack": "link:.",
-    "undici": "^6.20.1"
+    "undici": "^6.20.1",
+    "unenv": "npm:unenv-nightly@2.0.0-20250206-225311-890c145"
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.3.4",
@@ -163,7 +164,7 @@
     "ultrahtml": "^1.5.3",
     "uncrypto": "^0.1.3",
     "unctx": "^2.4.1",
-    "unenv": "2.0.0-rc.2",
+    "unenv": "2.0.0-rc.3",
     "unimport": "^4.0.0",
     "unstorage": "^1.14.4",
     "untyped": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "resolutions": {
     "nitropack": "link:.",
     "undici": "^6.20.1",
-    "unenv": "npm:unenv-nightly@2.0.0-20250206-225311-890c145"
+    "unenv": "npm:unenv-nightly@2.0.0-20250207-011423-492459d"
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
   },
   "resolutions": {
     "nitropack": "link:.",
-    "undici": "^6.20.1",
-    "unenv": "npm:unenv-nightly@2.0.0-20250207-023056-21dea9b"
+    "undici": "^6.20.1"
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   nitropack: link:.
   undici: ^6.20.1
-  unenv: npm:unenv-nightly@2.0.0-20250206-225311-890c145
+  unenv: npm:unenv-nightly@2.0.0-20250207-011423-492459d
 
 importers:
 
@@ -212,8 +212,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20250206-225311-890c145
-        version: unenv-nightly@2.0.0-20250206-225311-890c145
+        specifier: npm:unenv-nightly@2.0.0-20250207-011423-492459d
+        version: unenv-nightly@2.0.0-20250207-011423-492459d
       unimport:
         specifier: ^4.0.0
         version: 4.0.0(rollup@4.32.1)
@@ -5678,8 +5678,8 @@ packages:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
 
-  unenv-nightly@2.0.0-20250206-225311-890c145:
-    resolution: {integrity: sha512-Wv9KcCcb9mqq3nR4QvHk2Nt33Vx9CGpX/tqKb1ZsNXx9kYYaD4W+MgAFA4vLo01tO2sl4FV77vWKygl+H3GreQ==}
+  unenv-nightly@2.0.0-20250207-011423-492459d:
+    resolution: {integrity: sha512-DwU7/bh428nG5EwQghgiIMdm/9yZzzbVhS8hP/5v7rBRrjifFXJ+hefwcfmJ9kMjL9wdI/KJNTfXLQensVeBVQ==}
 
   unhead@1.11.18:
     resolution: {integrity: sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==}
@@ -12292,7 +12292,7 @@ snapshots:
 
   undici@6.21.1: {}
 
-  unenv-nightly@2.0.0-20250206-225311-890c145:
+  unenv-nightly@2.0.0-20250207-011423-492459d:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   nitropack: link:.
   undici: ^6.20.1
-  unenv: npm:unenv-nightly@2.0.0-20250207-011423-492459d
+  unenv: npm:unenv-nightly@2.0.0-20250207-023056-21dea9b
 
 importers:
 
@@ -212,8 +212,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20250207-011423-492459d
-        version: unenv-nightly@2.0.0-20250207-011423-492459d
+        specifier: npm:unenv-nightly@2.0.0-20250207-023056-21dea9b
+        version: unenv-nightly@2.0.0-20250207-023056-21dea9b
       unimport:
         specifier: ^4.0.0
         version: 4.0.0(rollup@4.32.1)
@@ -5678,8 +5678,8 @@ packages:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
 
-  unenv-nightly@2.0.0-20250207-011423-492459d:
-    resolution: {integrity: sha512-DwU7/bh428nG5EwQghgiIMdm/9yZzzbVhS8hP/5v7rBRrjifFXJ+hefwcfmJ9kMjL9wdI/KJNTfXLQensVeBVQ==}
+  unenv-nightly@2.0.0-20250207-023056-21dea9b:
+    resolution: {integrity: sha512-kr/O6ZFIsNy7o7Iy3OSF0SU1mdBnYg7In/Q3bUvPfHrMFCqQw7ch044C89IihYne+SpUZ/BNHTV2dnsy9GqSDA==}
 
   unhead@1.11.18:
     resolution: {integrity: sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==}
@@ -12292,7 +12292,7 @@ snapshots:
 
   undici@6.21.1: {}
 
-  unenv-nightly@2.0.0-20250207-011423-492459d:
+  unenv-nightly@2.0.0-20250207-023056-21dea9b:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   nitropack: link:.
   undici: ^6.20.1
+  unenv: npm:unenv-nightly@2.0.0-20250206-225311-890c145
 
 importers:
 
@@ -211,8 +212,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       unenv:
-        specifier: 2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: npm:unenv-nightly@2.0.0-20250206-225311-890c145
+        version: unenv-nightly@2.0.0-20250206-225311-890c145
       unimport:
         specifier: ^4.0.0
         version: 4.0.0(rollup@4.32.1)
@@ -5677,8 +5678,8 @@ packages:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
 
-  unenv@2.0.0-rc.2:
-    resolution: {integrity: sha512-bO8CNyJRtXrZ+KlS+hOAHRKh49HiaTSJiI8whdHOTffzsBY8Vfe5rMxQZpoljmJ26ifEZdEyOnx3s5Lc5f824A==}
+  unenv-nightly@2.0.0-20250206-225311-890c145:
+    resolution: {integrity: sha512-Wv9KcCcb9mqq3nR4QvHk2Nt33Vx9CGpX/tqKb1ZsNXx9kYYaD4W+MgAFA4vLo01tO2sl4FV77vWKygl+H3GreQ==}
 
   unhead@1.11.18:
     resolution: {integrity: sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==}
@@ -12291,7 +12292,7 @@ snapshots:
 
   undici@6.21.1: {}
 
-  unenv@2.0.0-rc.2:
+  unenv-nightly@2.0.0-20250206-225311-890c145:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   nitropack: link:.
   undici: ^6.20.1
-  unenv: npm:unenv-nightly@2.0.0-20250207-023056-21dea9b
 
 importers:
 
@@ -212,8 +211,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20250207-023056-21dea9b
-        version: unenv-nightly@2.0.0-20250207-023056-21dea9b
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
       unimport:
         specifier: ^4.0.0
         version: 4.0.0(rollup@4.32.1)
@@ -5678,8 +5677,8 @@ packages:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
 
-  unenv-nightly@2.0.0-20250207-023056-21dea9b:
-    resolution: {integrity: sha512-kr/O6ZFIsNy7o7Iy3OSF0SU1mdBnYg7In/Q3bUvPfHrMFCqQw7ch044C89IihYne+SpUZ/BNHTV2dnsy9GqSDA==}
+  unenv@2.0.0-rc.3:
+    resolution: {integrity: sha512-RSv8Mt/BXcmdUyJsA2yvQv50F/Rznl0EvopFbFp4ZxDlzfvgJ7IFe0yzcUNPdKzqFibqxdmqqWX4lbrlJcRTSA==}
 
   unhead@1.11.18:
     resolution: {integrity: sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==}
@@ -12292,7 +12291,7 @@ snapshots:
 
   undici@6.21.1: {}
 
-  unenv-nightly@2.0.0-20250207-023056-21dea9b:
+  unenv@2.0.0-rc.3:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4

--- a/src/presets/cloudflare/unenv/preset.ts
+++ b/src/presets/cloudflare/unenv/preset.ts
@@ -68,6 +68,10 @@ export const unenvCfPreset: Preset = {
     "node-mock-http/_polyfill/buffer": "node:buffer",
   },
   inject: {
+    // process: "TODO",
+    // console: "TODO",
+    Buffer: ["node:buffer", "Buffer"],
+    "global.Buffer": ["node:buffer", "Buffer"],
     "globalThis.Buffer": ["node:buffer", "Buffer"],
   },
 };

--- a/src/presets/cloudflare/unenv/preset.ts
+++ b/src/presets/cloudflare/unenv/preset.ts
@@ -45,15 +45,22 @@ const resolvePresetRuntime = (m: string) => join(presetRuntimeDir, `${m}.mjs`);
 export const unenvCfPreset: Preset = {
   external: nodeCompatModules.map((m) => `node:${m}`),
   alias: {
-    // <id> => node:<id>
-    ...Object.fromEntries(nodeCompatModules.map((m) => [m, `node:${m}`])),
-    ...Object.fromEntries(hybridNodeCompatModules.map((m) => [m, `node:${m}`])),
-    // node:<id> => runtime/<id>.mjs (hybrid)
+    // (native)
     ...Object.fromEntries(
-      hybridNodeCompatModules.map((m) => [
-        `node:${m}`,
-        resolvePresetRuntime(m === "sys" ? "util" : m),
+      nodeCompatModules.flatMap((m) => [
+        [m, `node:${m}`],
+        [`node:${m}`, `node:${m}`],
       ])
+    ),
+    // (hybrid)
+    ...Object.fromEntries(
+      hybridNodeCompatModules.flatMap((m) => {
+        const resolved = resolvePresetRuntime(m);
+        return [
+          [`node:${m}`, resolved],
+          [m, resolved],
+        ];
+      })
     ),
     sys: resolvePresetRuntime("util"),
     "node:sys": resolvePresetRuntime("util"),

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -20,7 +20,7 @@ import { dirname, join, normalize, resolve } from "pathe";
 import type { Plugin } from "rollup";
 import { visualizer } from "rollup-plugin-visualizer";
 import { isTest, isWindows } from "std-env";
-import * as unenv from "unenv";
+import { defineEnv } from "unenv";
 import type { Preset } from "unenv";
 import unimportPlugin from "unimport/unplugin";
 import { rollup as unwasm } from "unwasm/plugin";
@@ -54,27 +54,29 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     ".jsx",
   ];
 
-  const nodePreset = nitro.options.node === false ? unenv.nodeless : unenv.node;
-
-  const builtinPreset: Preset = {
-    alias: {
-      // General
-      ...(nitro.options.dev
-        ? {}
-        : {
-            debug: "unenv/npm/debug",
-          }),
-      ...(nitro.options.node === false
-        ? {}
-        : {
-            "node-mock-http/_polyfill/events": "node:events",
-            "node-mock-http/_polyfill/buffer": "node:buffer",
-          }),
-      ...nitro.options.alias,
+  const { env } = defineEnv({
+    nodeCompat: nitro.options.node === false,
+    resolve: true,
+    overrides: {
+      alias: {
+        // General
+        ...(nitro.options.dev
+          ? {}
+          : {
+              debug: "unenv/npm/debug",
+            }),
+        ...(nitro.options.node === false
+          ? {}
+          : {
+              "node-mock-http/_polyfill/events": "node:events",
+              "node-mock-http/_polyfill/buffer": "node:buffer",
+            }),
+        ...nitro.options.alias,
+      },
     },
-  };
+  });
 
-  const env = unenv.env(nodePreset, builtinPreset, nitro.options.unenv);
+  console.log(env);
 
   const buildServerDir = join(nitro.options.buildDir, "dist/server");
 

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -54,10 +54,28 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     ".jsx",
   ];
 
+  const isNodeless = nitro.options.node === false;
+
   const { env } = defineEnv({
-    nodeCompat: nitro.options.node === false,
+    nodeCompat: isNodeless,
     resolve: true,
-    presets: [nitro.options.unenv],
+    presets: [
+      isNodeless
+        ? {
+            // Backward compatibility (remove in v2)
+            // https://github.com/unjs/unenv/pull/427
+            inject: {
+              performance: "unenv/polyfill/performance",
+            },
+            polyfill: [
+              "unenv/polyfill/globalthis-global",
+              "unenv/polyfill/process",
+              "unenv/polyfill/performance",
+            ],
+          }
+        : {},
+      nitro.options.unenv,
+    ],
     overrides: {
       alias: {
         // General
@@ -66,7 +84,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
           : {
               debug: "unenv/npm/debug",
             }),
-        ...(nitro.options.node === false
+        ...(isNodeless
           ? {}
           : {
               "node-mock-http/_polyfill/events": "node:events",

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -57,6 +57,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
   const { env } = defineEnv({
     nodeCompat: nitro.options.node === false,
     resolve: true,
+    presets: [nitro.options.unenv],
     overrides: {
       alias: {
         // General
@@ -75,8 +76,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       },
     },
   });
-
-  console.log(env);
 
   const buildServerDir = join(nitro.options.buildDir, "dist/server");
 


### PR DESCRIPTION
Use new `defineEnv` util from unenv to resolve polyfill paths from nitro-specified dependency to avoid conflicting with globals.