### PR TITLE
fix(types): deduplicate aliases

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -280,23 +280,25 @@ declare module "nitropack/types" {
     });
 
     for (const alias in tsConfig.compilerOptions!.paths) {
-      const paths = tsConfig.compilerOptions!.paths[alias];
-      tsConfig.compilerOptions!.paths[alias] = await Promise.all(
-        paths.map(async (path: string) => {
-          if (!isAbsolute(path)) {
-            return path;
-          }
-          const stats = await fsp
-            .stat(path)
-            .catch(() => null /* file does not exist */);
-          return relativeWithDot(
-            tsconfigDir,
-            stats?.isFile()
-              ? path.replace(/(?<=\w)\.\w+$/g, "") /* remove extension */
-              : path
-          );
-        })
+      const paths = new Set<string>(
+        await Promise.all(
+          tsConfig.compilerOptions!.paths[alias].map(async (path: string) => {
+            if (!isAbsolute(path)) {
+              return path;
+            }
+            const stats = await fsp
+              .stat(path)
+              .catch(() => null /* file does not exist */);
+            return relativeWithDot(
+              tsconfigDir,
+              stats?.isFile()
+                ? path.replace(/(?<=\w)\.\w+$/g, "") /* remove extension */
+                : path
+            );
+          })
+        )
       );
+      tsConfig.compilerOptions!.paths[alias] = [...paths];
     }
 
     tsConfig.include = [

--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -280,25 +280,23 @@ declare module "nitropack/types" {
     });
 
     for (const alias in tsConfig.compilerOptions!.paths) {
-      const paths = new Set<string>(
-        await Promise.all(
-          tsConfig.compilerOptions!.paths[alias].map(async (path: string) => {
-            if (!isAbsolute(path)) {
-              return path;
-            }
-            const stats = await fsp
-              .stat(path)
-              .catch(() => null /* file does not exist */);
-            return relativeWithDot(
-              tsconfigDir,
-              stats?.isFile()
-                ? path.replace(/(?<=\w)\.\w+$/g, "") /* remove extension */
-                : path
-            );
-          })
-        )
+      const paths = await Promise.all(
+        tsConfig.compilerOptions!.paths[alias].map(async (path: string) => {
+          if (!isAbsolute(path)) {
+            return path;
+          }
+          const stats = await fsp
+            .stat(path)
+            .catch(() => null /* file does not exist */);
+          return relativeWithDot(
+            tsconfigDir,
+            stats?.isFile()
+              ? path.replace(/(?<=\w)\.\w+$/g, "") /* remove extension */
+              : path
+          );
+        })
       );
-      tsConfig.compilerOptions!.paths[alias] = [...paths];
+      tsConfig.compilerOptions!.paths[alias] = [...new Set(paths)];
     }
 
     tsConfig.include = [


### PR DESCRIPTION

### 🔗 Linked issue

context: https://github.com/nuxt/nuxt/issues/27161

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt is setting paths to match its aliases. We can likely remove this code as it's now implemented in Nitro. But Nitro probably can safely deduplicate the paths too.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
