### PR TITLE
perf: use exsolve for module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "esbuild": "^0.25.0",
     "escape-string-regexp": "^5.0.0",
     "etag": "^1.8.1",
-    "exsolve": "^0.3.0",
+    "exsolve": "^0.3.1",
     "fs-extra": "^11.3.0",
     "globby": "^14.1.0",
     "gzip-size": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "esbuild": "^0.25.0",
     "escape-string-regexp": "^5.0.0",
     "etag": "^1.8.1",
+    "exsolve": "^0.2.0",
     "fs-extra": "^11.3.0",
     "globby": "^14.1.0",
     "gzip-size": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "esbuild": "^0.25.0",
     "escape-string-regexp": "^5.0.0",
     "etag": "^1.8.1",
-    "exsolve": "^0.2.0",
+    "exsolve": "^0.3.0",
     "fs-extra": "^11.3.0",
     "globby": "^14.1.0",
     "gzip-size": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1
       exsolve:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.3.0
+        version: 0.3.0
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -3084,8 +3084,8 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
-  exsolve@0.2.0:
-    resolution: {integrity: sha512-JNWfZ+ktuA3QTF3cOjY6HKhik+/A0FvKp7Lbv3UZXYc55ETGN0+k8DvaLAI6aOppzYaWsJsj0IR5o1zHQmHnVA==}
+  exsolve@0.3.0:
+    resolution: {integrity: sha512-BLpecKkLPgfkK3REtDylppPRsVo7wT8ecB8x/aJ7R87lKVS+VxxmCgmPZh/57uoIqk87k3eH3oLqckMcYP+hgQ==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -9228,7 +9228,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  exsolve@0.2.0: {}
+  exsolve@0.3.0: {}
 
   extend@3.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       etag:
         specifier: ^1.8.1
         version: 1.8.1
+      exsolve:
+        specifier: ^0.1.4
+        version: 0.1.4
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -3080,6 +3083,9 @@ packages:
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  exsolve@0.1.4:
+    resolution: {integrity: sha512-08muLXvKl1dre+XmG95njeLG/b09FwSmHX9JaQ5KRhG0QvoJ+9TqeMz+cjlUoBF6WtpS2fdxVSlWb/d7U1SRYg==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -9221,6 +9227,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  exsolve@0.1.4: {}
 
   extend@3.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1
       exsolve:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.1
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -3084,8 +3084,8 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
-  exsolve@0.3.0:
-    resolution: {integrity: sha512-BLpecKkLPgfkK3REtDylppPRsVo7wT8ecB8x/aJ7R87lKVS+VxxmCgmPZh/57uoIqk87k3eH3oLqckMcYP+hgQ==}
+  exsolve@0.3.1:
+    resolution: {integrity: sha512-xa17gUR9Lx94Dt36Sp6JFHQbFTtauLsWrrRQLr4IfBokEZHstKosxah9hLc1oCdF5ZknhD8ckmktSzybr7J9XA==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -9228,7 +9228,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  exsolve@0.3.0: {}
+  exsolve@0.3.1: {}
 
   extend@3.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1
       exsolve:
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.2.0
+        version: 0.2.0
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -3084,8 +3084,8 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
-  exsolve@0.1.4:
-    resolution: {integrity: sha512-08muLXvKl1dre+XmG95njeLG/b09FwSmHX9JaQ5KRhG0QvoJ+9TqeMz+cjlUoBF6WtpS2fdxVSlWb/d7U1SRYg==}
+  exsolve@0.2.0:
+    resolution: {integrity: sha512-JNWfZ+ktuA3QTF3cOjY6HKhik+/A0FvKp7Lbv3UZXYc55ETGN0+k8DvaLAI6aOppzYaWsJsj0IR5o1zHQmHnVA==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -9228,7 +9228,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  exsolve@0.1.4: {}
+  exsolve@0.2.0: {}
 
   extend@3.0.2: {}
 

--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -1,11 +1,8 @@
 import { existsSync, promises as fsp } from "node:fs";
 import { defu } from "defu";
 import { genTypeImport } from "knitwork";
-import {
-  lookupNodeModuleSubpath,
-  parseNodeModulePath,
-  resolvePath,
-} from "mlly";
+import { lookupNodeModuleSubpath, parseNodeModulePath } from "mlly";
+import { resolveModulePath } from "exsolve";
 import { isDirectory, resolveNitroPath, writeFile } from "nitropack/kit";
 import { runtimeDir } from "nitropack/runtime/meta";
 import type { Nitro, NitroTypes } from "nitropack/types";
@@ -66,9 +63,12 @@ export async function writeTypes(nitro: Nitro) {
       }
       let path = resolveAlias(i.from, nitro.options.alias);
       if (!isAbsolute(path)) {
-        const resolvedPath = await resolvePath(i.from, {
-          url: nitro.options.nodeModulesDirs,
-        }).catch(() => null);
+        const resolvedPath = resolveModulePath(i.from, {
+          try: true,
+          from: nitro.options.nodeModulesDirs,
+          suffixes: ["/index"],
+          extensions: [".mjs", ".cjs", ".js", ".mts", ".cts", ".ts"],
+        });
         if (resolvedPath) {
           const { dir, name } = parseNodeModulePath(resolvedPath);
           if (!dir || !name) {

--- a/src/core/config/resolvers/paths.ts
+++ b/src/core/config/resolvers/paths.ts
@@ -56,7 +56,8 @@ export async function resolvePathOptions(options: NitroOptions) {
   options.nodeModulesDirs.push(resolve(pkgDir, "..")); // pnpm
   options.nodeModulesDirs = [
     ...new Set(
-      options.nodeModulesDirs.map((dir) => resolve(options.rootDir, dir))
+      // Adding trailing slash to optimize resolve performance (path is explicitly a dir)
+      options.nodeModulesDirs.map((dir) => resolve(options.rootDir, dir) + "/")
     ),
   ];
 

--- a/src/presets/node/preset.ts
+++ b/src/presets/node/preset.ts
@@ -1,6 +1,6 @@
 import { defineNitroPreset } from "nitropack/kit";
 import { normalize } from "pathe";
-import { resolvePathSync } from "mlly";
+import { resolveModulePath } from "exsolve";
 
 const node = defineNitroPreset(
   {
@@ -36,8 +36,9 @@ const nodeCluster = defineNitroPreset(
       "rollup:before"(_nitro, rollupConfig) {
         const manualChunks = rollupConfig.output?.manualChunks;
         if (manualChunks && typeof manualChunks === "function") {
-          const serverEntry = resolvePathSync("./runtime/node-server", {
-            url: import.meta.url,
+          const serverEntry = resolveModulePath("./runtime/node-server", {
+            from: import.meta.url,
+            extensions: [".mjs", ".ts"],
           });
           rollupConfig.output.manualChunks = (id, meta) => {
             if (id.includes("node-server") && normalize(id) === serverEntry) {

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -7,7 +7,8 @@ import inject from "@rollup/plugin-inject";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import { defu } from "defu";
-import { resolvePath, sanitizeFilePath } from "mlly";
+import { sanitizeFilePath } from "mlly";
+import { resolveModulePath } from "exsolve";
 import { runtimeDependencies, runtimeDir } from "nitropack/runtime/meta";
 import type {
   Nitro,
@@ -423,8 +424,11 @@ export const plugins = [
         }
         const resolved = await this.resolve(id, from, resolveOpts);
         if (!resolved) {
-          const _resolved = await resolvePath(id, {
-            url: nitro.options.nodeModulesDirs,
+          const _resolved = resolveModulePath(id, {
+            try: true,
+            from: nitro.options.nodeModulesDirs,
+            suffixes: ["/index"],
+            extensions: [".mjs", ".cjs", ".js", ".mts", ".cts", ".ts", ".json"],
             conditions: [
               "default",
               nitro.options.dev ? "development" : "production",
@@ -432,7 +436,7 @@ export const plugins = [
               "import",
               "require",
             ],
-          }).catch(() => null);
+          });
           if (_resolved) {
             return { id: _resolved, external: false };
           }

--- a/src/rollup/plugins/externals-legacy.ts
+++ b/src/rollup/plugins/externals-legacy.ts
@@ -1,7 +1,8 @@
 import { existsSync, promises as fsp } from "node:fs";
 import { type NodeFileTraceOptions, nodeFileTrace } from "@vercel/nft";
 import { consola } from "consola";
-import { isValidNodeImport, normalizeid, resolvePath } from "mlly";
+import { isValidNodeImport, normalizeid } from "mlly";
+import { resolveModulePath } from "exsolve";
 import { isDirectory } from "nitropack/kit";
 import { dirname, isAbsolute, join, normalize, resolve } from "pathe";
 import type { Plugin } from "rollup";
@@ -36,9 +37,11 @@ export function externals(opts: NodeExternalsOptions): Plugin {
     if (resolved) {
       return resolved;
     }
-    resolved = await resolvePath(id, {
+    resolved = resolveModulePath(id, {
       conditions: opts.exportConditions,
-      url: opts.moduleDirectories,
+      from: opts.moduleDirectories,
+      suffixes: ["/index"],
+      extensions: [".mjs", ".cjs", ".js", ".mts", ".cts", ".ts", ".json"],
     });
     _resolveCache.set(id, resolved);
     return resolved;
@@ -94,7 +97,7 @@ export function externals(opts: NodeExternalsOptions): Plugin {
         id,
       };
 
-      // Try resolving with mlly as fallback
+      // Try resolving with Node.js algorithm as fallback
       if (
         !isAbsolute(resolved.id) ||
         !existsSync(resolved.id) ||

--- a/src/rollup/plugins/externals-legacy.ts
+++ b/src/rollup/plugins/externals-legacy.ts
@@ -1,8 +1,7 @@
 import { existsSync, promises as fsp } from "node:fs";
 import { type NodeFileTraceOptions, nodeFileTrace } from "@vercel/nft";
 import { consola } from "consola";
-import { isValidNodeImport, normalizeid } from "mlly";
-import { resolveModulePath } from "exsolve";
+import { isValidNodeImport, normalizeid, resolvePath } from "mlly";
 import { isDirectory } from "nitropack/kit";
 import { dirname, isAbsolute, join, normalize, resolve } from "pathe";
 import type { Plugin } from "rollup";
@@ -37,11 +36,9 @@ export function externals(opts: NodeExternalsOptions): Plugin {
     if (resolved) {
       return resolved;
     }
-    resolved = resolveModulePath(id, {
+    resolved = await resolvePath(id, {
       conditions: opts.exportConditions,
-      from: opts.moduleDirectories,
-      suffixes: ["/index"],
-      extensions: [".mjs", ".cjs", ".js", ".mts", ".cts", ".ts", ".json"],
+      url: opts.moduleDirectories,
     });
     _resolveCache.set(id, resolved);
     return resolved;
@@ -97,7 +94,7 @@ export function externals(opts: NodeExternalsOptions): Plugin {
         id,
       };
 
-      // Try resolving with Node.js algorithm as fallback
+      // Try resolving with mlly as fallback
       if (
         !isAbsolute(resolved.id) ||
         !existsSync(resolved.id) ||

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -1,5 +1,6 @@
 import { existsSync, promises as fsp } from "node:fs";
 import { platform } from "node:os";
+import { fileURLToPath } from "node:url";
 import { nodeFileTrace } from "@vercel/nft";
 import {
   isValidNodeImport,
@@ -7,7 +8,7 @@ import {
   normalizeid,
   parseNodeModulePath,
 } from "mlly";
-import { resolveModulePath } from "exsolve";
+import { resolveModuleURL } from "exsolve";
 import { isDirectory } from "nitropack/kit";
 import type { NodeExternalsOptions } from "nitropack/types";
 import { dirname, isAbsolute, join, normalize, relative, resolve } from "pathe";
@@ -23,12 +24,14 @@ export function externals(opts: NodeExternalsOptions): Plugin {
     if (id.startsWith("\0")) {
       return id;
     }
-    return resolveModulePath(id, {
+    const res = resolveModuleURL(id, {
+      try: true,
       conditions: opts.exportConditions,
       from: opts.moduleDirectories,
       suffixes: ["/index"],
       extensions: [".mjs", ".cjs", ".js", ".mts", ".cts", ".ts", ".json"],
     });
+    return res?.startsWith("file://") ? fileURLToPath(res) : res;
   };
 
   // Normalize options

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -6,8 +6,8 @@ import {
   lookupNodeModuleSubpath,
   normalizeid,
   parseNodeModulePath,
-  resolvePath,
 } from "mlly";
+import { resolveModulePath } from "exsolve";
 import { isDirectory } from "nitropack/kit";
 import type { NodeExternalsOptions } from "nitropack/types";
 import { dirname, isAbsolute, join, normalize, relative, resolve } from "pathe";
@@ -28,9 +28,11 @@ export function externals(opts: NodeExternalsOptions): Plugin {
     if (resolved) {
       return resolved;
     }
-    resolved = await resolvePath(id, {
+    resolved = resolveModulePath(id, {
       conditions: opts.exportConditions,
-      url: opts.moduleDirectories,
+      from: opts.moduleDirectories,
+      suffixes: ["/index"],
+      extensions: [".mjs", ".cjs", ".js", ".mts", ".cts", ".ts", ".json"],
     });
     _resolveCache.set(id, resolved);
     return resolved;
@@ -97,7 +99,7 @@ export function externals(opts: NodeExternalsOptions): Plugin {
         return null;
       }
 
-      // Try resolving with mlly as fallback
+      // Try resolving with Node.js algorithm as fallback
       if (
         !isAbsolute(resolved.id) ||
         !existsSync(resolved.id) ||


### PR DESCRIPTION
This PR uses resolve utils from [exsolve](https://github.com/unjs/exsolve) which have improved performances.

Additional extensions and suffixes have to be kept to avoid breaking behavior change but still perf should be better.

`modulesDir` option is also normalized with trailing slashes to allow search path fast-path (could be better with `file://` URL but nothing significant for now)