### PR TITLE
feat: upgrade to db0 0.3 with native `node:sqlite` support

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm stub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install
       - run: pnpm stub
@@ -37,7 +37,7 @@ jobs:
       - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - uses: oven-sh/setup-bun@v2
         if: ${{ matrix.os != 'windows-latest' }}

--- a/docs/1.guide/5.database.md
+++ b/docs/1.guide/5.database.md
@@ -44,10 +44,6 @@ export default defineNuxtConfig({
 ```
 ::
 
-Also install `better-sqlite3` dependency:
-
-:pm-install{name="-D better-sqlite3"}
-
 ## Usage
 
 <!-- automd:file code src="../../examples/database/routes/index.ts" -->

--- a/examples/database/package.json
+++ b/examples/database/package.json
@@ -6,7 +6,6 @@
     "build": "nitro build"
   },
   "devDependencies": {
-    "better-sqlite3": "^8.4.0",
     "nitropack": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cookie-es": "^1.2.2",
     "croner": "^9.0.0",
     "crossws": "^0.3.4",
-    "db0": "^0.2.4",
+    "db0": "^0.3.1",
     "defu": "^6.1.4",
     "destr": "^2.0.3",
     "dot-prop": "^9.0.0",
@@ -189,7 +189,6 @@
     "@types/xml2js": "^0.4.14",
     "@vitest/coverage-v8": "^3.0.7",
     "automd": "^0.4.0",
-    "better-sqlite3": "^11.8.1",
     "changelogen": "^0.6.0",
     "edge-runtime": "^4.0.1",
     "eslint": "^9.21.0",
@@ -236,7 +235,6 @@
     ],
     "onlyBuiltDependencies": [
       "@parcel/watcher",
-      "better-sqlite3",
       "esbuild",
       "workerd"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4
       db0:
-        specifier: ^0.2.4
-        version: 0.2.4(better-sqlite3@11.8.1)
+        specifier: ^0.3.1
+        version: 0.3.1(better-sqlite3@11.8.1)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -220,7 +220,7 @@ importers:
         version: 0.2.4
       unstorage:
         specifier: ^1.15.0
-        version: 1.15.0(@azure/identity@4.7.0)(db0@0.2.4(better-sqlite3@11.8.1))(ioredis@5.5.0)
+        version: 1.15.0(@azure/identity@4.7.0)(db0@0.3.1(better-sqlite3@11.8.1))(ioredis@5.5.0)
       untyped:
         specifier: ^2.0.0
         version: 2.0.0
@@ -285,9 +285,6 @@ importers:
       automd:
         specifier: ^0.4.0
         version: 0.4.0(magicast@0.3.5)
-      better-sqlite3:
-        specifier: ^11.8.1
-        version: 11.8.1
       changelogen:
         specifier: ^0.6.0
         version: 0.6.0(magicast@0.3.5)
@@ -366,9 +363,6 @@ importers:
 
   examples/database:
     devDependencies:
-      better-sqlite3:
-        specifier: ^8.4.0
-        version: 8.7.0
       nitropack:
         specifier: link:../..
         version: link:../..
@@ -2204,9 +2198,6 @@ packages:
   better-sqlite3@11.8.1:
     resolution: {integrity: sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==}
 
-  better-sqlite3@8.7.0:
-    resolution: {integrity: sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==}
-
   bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
 
@@ -2621,8 +2612,8 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
-  db0@0.2.4:
-    resolution: {integrity: sha512-hIzftLH1nMsF95zSLjDLYLbE9huOXnLYUTAQ5yKF5amp0FpeD+B15XJa8BvGYSOeSCH4gl2WahB/y1FcUByQSg==}
+  db0@0.3.1:
+    resolution: {integrity: sha512-3RogPLE2LLq6t4YiFCREyl572aBjkfMvfwPyN51df00TbPbryL3XqBYuJ/j6mgPssPK8AKfYdLxizaO5UG10sA==}
     peerDependencies:
       '@electric-sql/pglite': '*'
       '@libsql/client': '*'
@@ -8026,11 +8017,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
-
-  better-sqlite3@8.7.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
+    optional: true
 
   bignumber.js@9.1.2:
     optional: true
@@ -8497,7 +8484,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.9
 
-  db0@0.2.4(better-sqlite3@11.8.1):
+  db0@0.3.1(better-sqlite3@11.8.1):
     optionalDependencies:
       better-sqlite3: 11.8.1
 
@@ -11930,7 +11917,7 @@ snapshots:
       acorn: 8.14.0
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.15.0(@azure/identity@4.7.0)(db0@0.2.4(better-sqlite3@11.8.1))(ioredis@5.5.0):
+  unstorage@1.15.0(@azure/identity@4.7.0)(db0@0.3.1(better-sqlite3@11.8.1))(ioredis@5.5.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -11942,7 +11929,7 @@ snapshots:
       ufo: 1.5.4
     optionalDependencies:
       '@azure/identity': 4.7.0
-      db0: 0.2.4(better-sqlite3@11.8.1)
+      db0: 0.3.1(better-sqlite3@11.8.1)
       ioredis: 5.5.0
 
   untun@0.1.3:


### PR DESCRIPTION
Upgrade db0 to 0.3 with native `node:sqlite` supported in Node.js >= 22.5 (experimental) and Deno >= [2.2](https://deno.com/blog/v2.2) (used as default - `better-sqlite3` driver can be used for node 20 support)