### PR TITLE
feat(deno-deploy, netlify-edge): enable node compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "esbuild": "^0.25.0",
     "escape-string-regexp": "^5.0.0",
     "etag": "^1.8.1",
-    "exsolve": "^1.0.0",
+    "exsolve": "^1.0.1",
     "fs-extra": "^11.3.0",
     "globby": "^14.1.0",
     "gzip-size": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1
       exsolve:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -3006,8 +3006,8 @@ packages:
   exsolve@0.4.4:
     resolution: {integrity: sha512-74RiT9i1G0eyFyE9n5f6mdX8+AicZFnhJ0CHB9VrkIl3Sy8vmW49ODbpwevdLswST7fhp3jvfPzD4DArTfjnsA==}
 
-  exsolve@1.0.0:
-    resolution: {integrity: sha512-iBv7HbA5im///8J1VuoyM+VPVxqGJrDK2q4LjCDs4F2wl0yh1X858LGUrw71EqaWXGcNOwin0XI7FklHKhp8dg==}
+  exsolve@1.0.1:
+    resolution: {integrity: sha512-Smf0iQtkQVJLaph8r/qS8C8SWfQkaq9Q/dFcD44MLbJj6DNhlWefVuaS21SjfqOsBbjVlKtbCj6L9ekXK6EZUg==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -8129,7 +8129,7 @@ snapshots:
       confbox: 0.1.8
       defu: 6.1.4
       dotenv: 16.4.7
-      exsolve: 1.0.0
+      exsolve: 1.0.1
       giget: 2.0.0
       jiti: 2.4.2
       ohash: 2.0.5
@@ -8974,7 +8974,7 @@ snapshots:
 
   exsolve@0.4.4: {}
 
-  exsolve@1.0.0: {}
+  exsolve@1.0.1: {}
 
   extend@3.0.2: {}
 
@@ -11825,7 +11825,7 @@ snapshots:
   unenv@2.0.0-rc.8:
     dependencies:
       defu: 6.1.4
-      exsolve: 1.0.0
+      exsolve: 1.0.1
       ohash: 2.0.5
       pathe: 2.0.3
       ufo: 1.5.4

--- a/src/presets/deno/preset.ts
+++ b/src/presets/deno/preset.ts
@@ -1,6 +1,7 @@
 import { defineNitroPreset } from "nitropack/kit";
 import { writeFile } from "nitropack/kit";
 import { resolve } from "pathe";
+import { builtnNodeModules } from "./unenv/node-compat";
 
 import { denoServerLegacy } from "./preset-legacy";
 
@@ -15,6 +16,19 @@ const denoDeploy = defineNitroPreset(
       preview: "",
       deploy:
         "cd ./ && deployctl deploy --project=<project_name> server/index.ts",
+    },
+    unenv: {
+      external: builtnNodeModules.map((m) => `node:${m}`),
+      alias: {
+        ...Object.fromEntries(
+          builtnNodeModules.flatMap((m) => [
+            [m, `node:${m}`],
+            [`node:${m}`, `node:${m}`],
+          ])
+        ),
+        "node-mock-http/_polyfill/events": "node:events",
+        "node-mock-http/_polyfill/buffer": "node:buffer",
+      },
     },
     rollupConfig: {
       preserveEntrySignatures: false,

--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -1,8 +1,8 @@
 import { promises as fsp } from "node:fs";
 import { defineNitroPreset } from "nitropack/kit";
 import type { Nitro } from "nitropack/types";
-import { joinURL } from "ufo";
 import { dirname, join } from "pathe";
+import { builtnNodeModules } from "./unenv/node-compat";
 import netlifyLegacyPresets from "./legacy/preset";
 import {
   generateNetlifyFunction,
@@ -74,6 +74,19 @@ const netlifyEdge = defineNitroPreset(
       output: {
         entryFileNames: "server.js",
         format: "esm",
+      },
+    },
+    unenv: {
+      external: builtnNodeModules.map((m) => `node:${m}`),
+      alias: {
+        ...Object.fromEntries(
+          builtnNodeModules.flatMap((m) => [
+            [m, `node:${m}`],
+            [`node:${m}`, `node:${m}`],
+          ])
+        ),
+        "node-mock-http/_polyfill/events": "node:events",
+        "node-mock-http/_polyfill/buffer": "node:buffer",
       },
     },
     hooks: {


### PR DESCRIPTION
Enable Node.js compat for `deno-deploy` and `netlify-edge` presets (based on data from #3128)

There are minor [missing exports](https://github.com/nitrojs/nitro/blob/45c95786538c497508fcfe77b97f5259475e80e1/src/presets/deno/unenv/node-compat.ts) which hopefully deno will add in the future. Also this PR does not injects any globals.

Result is enabling Node.js natives such as AsyncLocalStorage + ~60kB bundle reduction

/cc @serhalp 