### PR TITLE
feat(vercel-edge): enable node compat

### DIFF
--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -6,6 +6,7 @@ import {
   generateFunctionFiles,
   generateStaticFiles,
 } from "./utils";
+import { hybridNodePlugin, unenvWorkerdPreset } from "../_unenv/preset-workerd";
 
 export type { VercelOptions as PresetOptions } from "./types";
 
@@ -54,14 +55,11 @@ const vercelEdge = defineNitroPreset(
       deploy: "",
       preview: "",
     },
+    unenv: unenvWorkerdPreset,
     rollupConfig: {
+      plugins: [hybridNodePlugin],
       output: {
         format: "module",
-      },
-    },
-    unenv: {
-      inject: {
-        process: undefined,
       },
     },
     wasm: {

--- a/test/presets/vercel-edge.test.ts
+++ b/test/presets/vercel-edge.test.ts
@@ -5,21 +5,42 @@ import { isWindows } from "std-env";
 import { describeIf, setupTest, testNitro } from "../tests";
 
 describeIf(!isWindows, "nitro:preset:vercel-edge", async () => {
-  const ctx = await setupTest("vercel-edge");
+  const ctx = await setupTest("vercel-edge", {
+    config: {
+      minify: false,
+    },
+  });
   testNitro(ctx, async () => {
-    // TODO: Add add-event-listener
     const entry = resolve(ctx.outDir, "functions/__nitro.func/index.mjs");
-    const initialCode = await fsp.readFile(entry, "utf8");
-    const runtime = new EdgeRuntime({
-      extend: (context) =>
-        Object.assign(context, { process: { env: { ...ctx.env } } }),
-    });
-    runtime.evaluate(
-      initialCode.replace(
+
+    const init = (await fsp.readFile(entry, "utf8"))
+      .replace(
         /export ?{ ?handleEvent as default ?}/,
         "globalThis.handleEvent = handleEvent"
       )
-    );
+      // TODO: we can use AST to replace this.
+      // This is only needed for testing via EdgeRuntime since unlike prod (workerd?), it is a simple Node.js isolate
+      .replace(
+        /import\s+(.+)\s+from\s+['"](node:[^'"]+)['"]/g,
+        "const $1 = process.getBuiltinModule('$2')"
+      )
+      .replace(
+        `const nodeAsyncHooks, { AsyncLocalStorage } = process.getBuiltinModule('node:async_hooks');`,
+        `const nodeAsyncHooks = process.getBuiltinModule('node:async_hooks'); const { AsyncLocalStorage } = nodeAsyncHooks;`
+      );
+
+    const runtime = new EdgeRuntime({
+      extend: (context) =>
+        Object.assign(context, {
+          process: {
+            env: { ...ctx.env },
+            getBuiltinModule: process.getBuiltinModule,
+          },
+        }),
+    });
+
+    await runtime.evaluate(`(async function() { ${init} })()`);
+
     return async ({ url, headers, method, body }) => {
       const isGet = ["get", "head"].includes((method || "get").toLowerCase());
       const res = await runtime.evaluate(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -807,9 +807,7 @@ export function testNitro(
   });
 
   it.skipIf(
-    ["cloudflare-worker", "cloudflare-module-legacy", "vercel-edge"].includes(
-      ctx.preset
-    )
+    ["cloudflare-worker", "cloudflare-module-legacy"].includes(ctx.preset)
   )("nodejs compatibility", async () => {
     const { data, status } = await callHandler({ url: "/node-compat" });
     expect(status).toBe(200);


### PR DESCRIPTION
followup on #3128, #3129, #3130

According to [platform tests](https://platform-node-compat.vercel.app/), vercel edge seems identical to cloudflare-workers in terms `node:` imports coverage (which is totally undocumented)

Note: Globals are different. I have to double check `process.env` support (which is something specific to Vercel) if latest unenv v2 preset keeps it compatible with injected `process` hybrid.