### PR TITLE
refactor(dev): rewrite internal dev server

### DIFF
--- a/src/core/build/dev.ts
+++ b/src/core/build/dev.ts
@@ -74,7 +74,7 @@ function startRollupWatcher(nitro: Nitro, rollupConfig: RollupConfig) {
       }
 
       // Finished building all bundles
-      case "END": {
+      case "BUNDLE_END": {
         nitro.hooks.callHook("compiled", nitro);
 
         if (nitro.options.logging.buildSuccess) {
@@ -91,6 +91,7 @@ function startRollupWatcher(nitro: Nitro, rollupConfig: RollupConfig) {
       // Encountered an error while bundling
       case "ERROR": {
         nitro.logger.error(formatRollupError(event.error));
+        nitro.hooks.callHook("dev:error", event.error);
       }
     }
   });

--- a/src/core/build/dev.ts
+++ b/src/core/build/dev.ts
@@ -61,39 +61,31 @@ function startRollupWatcher(nitro: Nitro, rollupConfig: RollupConfig) {
   let start: number;
 
   watcher.on("event", (event) => {
+    // START > BUNDLE_START > BUNDLE_END > END
+    // START > BUNDLE_START > ERROR > END
     switch (event.code) {
-      // The watcher is (re)starting
       case "START": {
-        return;
-      }
-
-      // Building an individual bundle
-      case "BUNDLE_START": {
         start = Date.now();
-        return;
+        nitro.hooks.callHook("dev:start");
+        break;
       }
-
-      // Finished building all bundles
       case "BUNDLE_END": {
         nitro.hooks.callHook("compiled", nitro);
-
         if (nitro.options.logging.buildSuccess) {
           nitro.logger.success(
             `${nitroServerName(nitro)} built`,
             start ? `in ${Date.now() - start} ms` : ""
           );
         }
-
         nitro.hooks.callHook("dev:reload");
-        return;
+        break;
       }
-
-      // Encountered an error while bundling
       case "ERROR": {
         nitro.logger.error(formatRollupError(event.error));
         nitro.hooks.callHook("dev:error", event.error);
       }
     }
   });
+
   return watcher;
 }

--- a/src/core/dev-server/proxy.ts
+++ b/src/core/dev-server/proxy.ts
@@ -1,0 +1,48 @@
+import type { TLSSocket } from "node:tls";
+import type { ProxyServerOptions, ProxyServer } from "httpxy";
+import type { H3Event } from "h3";
+
+import { createProxyServer } from "httpxy";
+
+export type HTTPProxy = {
+  proxy: ProxyServer;
+  handleEvent: (event: H3Event, opts?: ProxyServerOptions) => Promise<void>;
+};
+
+export function createHTTPProxy(defaults: ProxyServerOptions = {}): HTTPProxy {
+  const proxy = createProxyServer(defaults);
+
+  proxy.on("proxyReq", (proxyReq, req) => {
+    if (!proxyReq.hasHeader("x-forwarded-for")) {
+      const address = req.socket.remoteAddress;
+      if (address) {
+        proxyReq.appendHeader("x-forwarded-for", address);
+      }
+    }
+    if (!proxyReq.hasHeader("x-forwarded-port")) {
+      const localPort = req?.socket?.localPort;
+      if (localPort) {
+        proxyReq.setHeader("x-forwarded-port", req.socket.localPort);
+      }
+    }
+    if (!proxyReq.hasHeader("x-forwarded-Proto")) {
+      const encrypted = (req?.connection as TLSSocket)?.encrypted;
+      proxyReq.setHeader("x-forwarded-proto", encrypted ? "https" : "http");
+    }
+  });
+
+  const handleEvent = async (event: H3Event, opts: ProxyServerOptions = {}) => {
+    try {
+      await proxy.web(event.node.req, event.node.res, opts);
+    } catch (error: any) {
+      if (error?.code !== "ECONNRESET") {
+        throw error;
+      }
+    }
+  };
+
+  return {
+    proxy,
+    handleEvent,
+  };
+}

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -78,6 +78,9 @@ class DevServer {
 
     nitro.hooks.hook("dev:error", (cause: unknown) => {
       this.buildError = cause;
+      for (const worker of this.workers) {
+        worker.close();
+      }
     });
 
     if (nitro.options.devServer.watch.length > 0) {

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -58,7 +58,7 @@ class DevServer {
 
   workerError?: unknown;
 
-  building?: boolean;
+  building?: boolean = true /* assume initial build will start soon */;
   buildError?: unknown;
 
   constructor(nitro: Nitro) {

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -162,7 +162,7 @@ class DevServer {
       if (activeWorker) {
         return activeWorker;
       }
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
   }
 
@@ -288,8 +288,8 @@ class DevServer {
     return new Response(
       JSON.stringify(
         {
-          error:
-            "The dev server is not available. Please reload the page and check the console for errors if the issue persists.",
+          error: "The dev server is unavailable.",
+          hint: "Please reload the page and check the console for errors if the issue persists.",
         },
         null,
         2
@@ -299,6 +299,7 @@ class DevServer {
         headers: {
           "Content-Type": "application/json",
           "Cache-Control": "no-store",
+          Refresh: "3",
         },
       }
     );

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -1,349 +1,239 @@
-import type {
-  Nitro,
-  NitroBuildInfo,
-  NitroDevServer,
-  NitroWorker,
-} from "nitropack/types";
 import type { IncomingMessage, OutgoingMessage } from "node:http";
 import type { Duplex } from "node:stream";
-import type { TLSSocket } from "node:tls";
-import { accessSync, existsSync } from "node:fs";
-import { writeFile, rm } from "node:fs/promises";
-import { resolve, join } from "pathe";
-import { Worker } from "node:worker_threads";
-import { type FSWatcher, watch } from "chokidar";
+import type { GetPortInput } from "get-port-please";
+import type { FSWatcher } from "chokidar";
+import type { App } from "h3";
+import type { Listener, ListenOptions } from "listhen";
+import { NodeDevWorker, type DevWorker, type WorkerAddress } from "./worker";
+import type { Nitro, NitroBuildInfo, NitroDevServer } from "nitropack/types";
 import {
-  type H3Error,
-  type H3Event,
   createApp,
   createError,
   eventHandler,
   fromNodeMiddleware,
   toNodeListener,
 } from "h3";
-import { type ProxyServerOptions, createProxyServer } from "httpxy";
-import { type Listener, listen as listhen } from "listhen";
-import { version as nitroVersion } from "nitropack/meta";
-import { debounce } from "perfect-debounce";
-import { servePlaceholder } from "serve-placeholder";
-import serveStatic from "serve-static";
-import { joinURL } from "ufo";
-import consola from "consola";
-import defaultErrorHandler, {
+import {
+  default as defaultErrorHandler,
   loadStackTrace,
 } from "../../runtime/internal/error/dev";
+import { version as nitroVersion } from "nitropack/meta";
+import consola from "consola";
+import serveStatic from "serve-static";
+import { writeFile } from "node:fs/promises";
+import { resolve } from "pathe";
+import { watch } from "chokidar";
+import { listen as listhen } from "listhen";
+import { servePlaceholder } from "serve-placeholder";
+import { joinURL } from "ufo";
 import { createVFSHandler } from "./vfs";
+import { debounce } from "perfect-debounce";
+import { createHTTPProxy } from "./proxy";
 
 export function createDevServer(nitro: Nitro): NitroDevServer {
-  // Workerdir
-  const workerDir = resolve(
-    nitro.options.output.dir,
-    nitro.options.output.serverDir
-  );
+  const devServer = new DevServer(nitro);
+  return {
+    reload: () => devServer.reload(),
+    listen: (port, opts) => devServer.listen(port, opts),
+    close: () => devServer.close(),
+    upgrade: (req, socket, head) => devServer.handleUpgrade(req, socket, head),
+    get app() {
+      return devServer.app;
+    },
+    get watcher() {
+      return devServer.watcher;
+    },
+  };
+}
 
-  // Error handler
-  const errorHandler = nitro.options.devErrorHandler || defaultErrorHandler;
+class DevServer {
+  nitro: Nitro;
+  workerDir: string;
+  app: App;
+  listeners: Listener[] = [];
+  reloadPromise?: Promise<void>;
+  lastError?: string;
+  watcher?: FSWatcher;
+  workers: DevWorker[] = [];
 
-  let lastError: H3Error | undefined;
-  let reloadPromise: Promise<void> | undefined;
+  constructor(nitro: Nitro) {
+    this.nitro = nitro;
 
-  let currentWorker: NitroWorker | undefined;
+    this.workerDir = resolve(
+      nitro.options.output.dir,
+      nitro.options.output.serverDir
+    );
 
-  const reloadWorker = async () => {
-    // Kill old worker
-    const oldWorker = currentWorker;
-    currentWorker = undefined;
-    await killWorker(oldWorker, nitro);
+    this.app = this.createApp();
 
-    // Create a new worker
-    currentWorker = await initWorker(workerDir);
-    if (!currentWorker) {
-      return;
+    const debouncedReload = debounce(() => this.reload());
+
+    nitro.hooks.hook("close", debouncedReload);
+    nitro.hooks.hook("dev:reload", debouncedReload);
+
+    if (nitro.options.devServer.watch.length > 0) {
+      this.watcher = watch(
+        nitro.options.devServer.watch,
+        nitro.options.watchOptions
+      );
+      this.watcher.on("add", debouncedReload).on("change", debouncedReload);
     }
+  }
 
-    // Write {buildDir}/nitro.json
-    const buildInfoPath = resolve(nitro.options.buildDir, "nitro.json");
+  async listen(port: GetPortInput, opts?: Partial<ListenOptions>) {
+    const listener = await listhen(toNodeListener(this.app), { port, ...opts });
+    this.listeners.push(listener);
+    listener.server.on("upgrade", (req, sock, head) =>
+      this.handleUpgrade(req, sock, head)
+    );
+    return listener;
+  }
+
+  async close() {
+    await Promise.all(
+      [
+        Promise.all(this.listeners.map((l) => l.close())).then(() => {
+          this.listeners = [];
+        }),
+        Promise.all(this.workers.map((w) => w.close())).then(() => {
+          this.workers = [];
+        }),
+        Promise.resolve(this.watcher?.close()).then(() => {
+          this.watcher = undefined;
+        }),
+      ].map((p) =>
+        p.catch((error) => {
+          consola.error(error);
+        })
+      )
+    );
+  }
+
+  reload() {
+    for (const worker of this.workers) {
+      worker.close();
+    }
+    this.workers.unshift(
+      new NodeDevWorker(this.workerDir, {
+        onClose: (worker, reason) => {
+          this.lastError = reason;
+          this.workers = this.workers.filter((w) => w !== worker);
+        },
+        onReady: (worker, addr) => {
+          this.writeBuildInfo(worker, addr);
+        },
+      })
+    );
+  }
+
+  async getWorker() {
+    for (let retry = 0; retry < 10; retry++) {
+      if (this.workers.filter((w) => !w.closed).length === 0) {
+        this.reload();
+      }
+      const activeWorker = this.workers.find((w) => w.ready);
+      if (activeWorker) {
+        return activeWorker;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  writeBuildInfo(_worker: DevWorker, addr?: WorkerAddress) {
+    const buildInfoPath = resolve(this.nitro.options.buildDir, "nitro.json");
     const buildInfo: NitroBuildInfo = {
       date: new Date().toJSON(),
-      preset: nitro.options.preset,
-      framework: nitro.options.framework,
+      preset: this.nitro.options.preset,
+      framework: this.nitro.options.framework,
       versions: {
         nitro: nitroVersion,
       },
       dev: {
         pid: process.pid,
-        workerAddress: currentWorker?.address,
+        workerAddress: addr,
       },
     };
-    await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2));
-  };
-
-  const reloadWorkerDebounced = debounce(() => {
-    reloadPromise = reloadWorker()
-      .then(() => {
-        lastError = undefined;
-      })
-      .catch(async (error) => {
-        await loadStackTrace(error).catch(() => {});
+    writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2)).catch(
+      (error) => {
         consola.error(error);
-        lastError = error;
-      })
-      .finally(() => {
-        reloadPromise = undefined;
-      });
-    return reloadPromise;
-  });
-
-  nitro.hooks.hook("dev:reload", reloadWorkerDebounced);
-
-  // App
-  const app = createApp();
-
-  // Dev-only handlers
-  for (const handler of nitro.options.devHandlers) {
-    app.use(handler.route || "/", handler.handler);
-  }
-
-  // Debugging endpoint to view vfs
-  app.use("/_vfs", createVFSHandler(nitro));
-
-  // Serve asset dirs
-  for (const asset of nitro.options.publicAssets) {
-    const url = joinURL(
-      nitro.options.runtimeConfig.app.baseURL,
-      asset.baseURL || "/"
+      }
     );
-    app.use(url, fromNodeMiddleware(serveStatic(asset.dir)));
-    if (!asset.fallthrough) {
-      app.use(url, fromNodeMiddleware(servePlaceholder()));
-    }
   }
 
-  // User defined dev proxy
-  for (const route of Object.keys(nitro.options.devProxy).sort().reverse()) {
-    let opts = nitro.options.devProxy[route];
-    if (typeof opts === "string") {
-      opts = { target: opts };
+  createApp() {
+    // Init h3 app
+    const app = createApp({
+      onError: async (error, event) => {
+        const errorHandler =
+          this.nitro.options.devErrorHandler || defaultErrorHandler;
+        await loadStackTrace(error).catch(() => {});
+        return errorHandler(error, event);
+      },
+    });
+
+    // Dev-only handlers
+    for (const handler of this.nitro.options.devHandlers) {
+      app.use(handler.route || "/", handler.handler);
     }
-    const proxy = createProxy(opts);
+
+    // Debugging endpoint to view vfs
+    app.use("/_vfs", createVFSHandler(this.nitro));
+
+    // Serve asset dirs
+    for (const asset of this.nitro.options.publicAssets) {
+      const url = joinURL(
+        this.nitro.options.runtimeConfig.app.baseURL,
+        asset.baseURL || "/"
+      );
+      app.use(url, fromNodeMiddleware(serveStatic(asset.dir)));
+      if (!asset.fallthrough) {
+        app.use(url, fromNodeMiddleware(servePlaceholder()));
+      }
+    }
+
+    // User defined dev proxy
+    const routes = Object.keys(this.nitro.options.devProxy).sort().reverse();
+    for (const route of routes) {
+      let opts = this.nitro.options.devProxy[route];
+      if (typeof opts === "string") {
+        opts = { target: opts };
+      }
+      const proxy = createHTTPProxy(opts);
+      app.use(
+        route,
+        eventHandler((event) => proxy.handleEvent(event))
+      );
+    }
+
+    // Main handler
     app.use(
-      route,
       eventHandler(async (event) => {
-        await proxy.handle(event);
+        const worker = await this.getWorker();
+        if (!worker) {
+          throw createError({
+            statusCode: 503,
+            message: "No worker available.",
+          });
+        }
+        return worker.handleEvent(event);
       })
     );
+
+    return app;
   }
 
-  // Main worker proxy
-  const proxy = createProxy();
-  proxy.proxy.on("proxyReq", (proxyReq, req) => {
-    if (!proxyReq.hasHeader("x-forwarded-for")) {
-      const address = req.socket.remoteAddress;
-      if (address) {
-        proxyReq.appendHeader("x-forwarded-for", address);
-      }
-    }
-    if (!proxyReq.hasHeader("x-forwarded-port")) {
-      const localPort = req?.socket?.localPort;
-      if (localPort) {
-        proxyReq.setHeader("x-forwarded-port", req.socket.localPort);
-      }
-    }
-    if (!proxyReq.hasHeader("x-forwarded-Proto")) {
-      const encrypted = (req?.connection as TLSSocket)?.encrypted;
-      proxyReq.setHeader("x-forwarded-proto", encrypted ? "https" : "http");
-    }
-  });
-
-  const getWorkerAddress = () => {
-    const address = currentWorker?.address;
-    if (!address) {
-      return;
-    }
-    if (address.socketPath) {
-      try {
-        accessSync(address.socketPath);
-      } catch (error) {
-        if (!lastError) {
-          lastError = error as typeof lastError;
-        }
-        return;
-      }
-    }
-    return address;
-  };
-
-  // Main handler
-  app.use(
-    eventHandler(async (event) => {
-      await reloadPromise;
-      let address = getWorkerAddress();
-
-      // Wait for worker to be ready or error to occur
-      for (let i = 0; i < 10 && !address && !lastError; i++) {
-        await (reloadPromise ||
-          new Promise((resolve) => setTimeout(resolve, 200)));
-        address = getWorkerAddress();
-      }
-      if (!address || lastError) {
-        return errorHandler(
-          lastError ||
-            createError({
-              statusCode: 503,
-              message: "Worker not ready",
-            }),
-          event
-        );
-      }
-
-      await proxy.handle(event, { target: address as any }).catch((error) => {
-        lastError = error;
-        throw error;
-      });
-    })
-  );
-
-  // WebSocket handler
-  const upgrade = (
+  async handleUpgrade(
     req: IncomingMessage,
     socket: OutgoingMessage<IncomingMessage> | Duplex,
     head: any
-  ) => {
-    return proxy.proxy.ws(
-      req,
-      // @ts-expect-error
-      socket,
-      {
-        target: getWorkerAddress(),
-        xfwd: true,
-      },
-      head
-    );
-  };
-
-  // Listen
-  let listeners: Listener[] = [];
-  const listen: NitroDevServer["listen"] = async (port, opts?) => {
-    const listener = await listhen(toNodeListener(app), { port, ...opts });
-    listener.server.on("upgrade", (req, sock, head) => {
-      upgrade(req, sock, head);
-    });
-    listeners.push(listener);
-    return listener;
-  };
-
-  // Optional watcher
-  let watcher: FSWatcher | undefined;
-  if (nitro.options.devServer.watch.length > 0) {
-    watcher = watch(nitro.options.devServer.watch, nitro.options.watchOptions);
-    watcher
-      .on("add", reloadWorkerDebounced)
-      .on("change", reloadWorkerDebounced);
-  }
-
-  // Close handler
-  const close = async () => {
-    if (watcher) {
-      await watcher.close();
-    }
-    await killWorker(currentWorker, nitro);
-    await Promise.all(listeners.map((l) => l.close()));
-    listeners = [];
-  };
-  nitro.hooks.hook("close", close);
-
-  return {
-    reload: reloadWorkerDebounced,
-    listen,
-    app,
-    close,
-    watcher,
-    upgrade,
-  };
-}
-
-function initWorker(workerDir: string): Promise<NitroWorker> | undefined {
-  const workerEntry = join(workerDir, "index.mjs");
-
-  if (!existsSync(workerEntry)) {
-    return;
-  }
-
-  return new Promise((resolve, reject) => {
-    const worker = new Worker(workerEntry, {
-      env: {
-        ...process.env,
-        NITRO_DEV_WORKER_DIR: workerDir,
-      },
-    });
-    worker.once("exit", (code) => {
-      reject(
-        new Error(
-          code ? "[worker] exited with code: " + code : "[worker] exited"
-        )
-      );
-    });
-    worker.once("error", async (error) => {
-      reject(error);
-    });
-    const addressListener = (event: any) => {
-      if (!event || !event?.address) {
-        return;
-      }
-      worker.off("message", addressListener);
-      resolve({
-        worker,
-        address: event.address,
-      } as NitroWorker);
-    };
-    worker.on("message", addressListener);
-  });
-}
-
-async function killWorker(worker: NitroWorker | undefined, nitro: Nitro) {
-  if (!worker) {
-    return;
-  }
-  if (worker.worker) {
-    worker.worker.postMessage({ event: "shutdown" });
-    const gracefulShutdownTimeout =
-      Number.parseInt(process.env.NITRO_SHUTDOWN_TIMEOUT || "", 10) || 3;
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => {
-        nitro.logger.warn(
-          `[nitro] [dev] Force closing worker after ${gracefulShutdownTimeout} seconds...`
-        );
-        resolve();
-      }, gracefulShutdownTimeout * 1000);
-      worker.worker?.once("message", (message) => {
-        if (message.event === "exit") {
-          clearTimeout(timeout);
-          resolve();
-        }
+  ) {
+    const worker = await this.getWorker();
+    if (!worker) {
+      throw createError({
+        statusCode: 503,
+        message: "No worker available.",
       });
-    });
-    worker.worker.removeAllListeners();
-    await worker.worker.terminate();
-    worker.worker = null;
-  }
-  if (worker.address.socketPath) {
-    await rm(worker.address.socketPath).catch(() => {});
-  }
-}
-
-function createProxy(defaults: ProxyServerOptions = {}) {
-  const proxy = createProxyServer(defaults);
-  const handle = async (event: H3Event, opts: ProxyServerOptions = {}) => {
-    try {
-      await proxy.web(event.node.req, event.node.res, opts);
-    } catch (error: any) {
-      if (error?.code !== "ECONNRESET") {
-        throw error;
-      }
     }
-  };
-  return {
-    proxy,
-    handle,
-  };
+    return worker.handleUpgrade(req, socket, head);
+  }
 }

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -241,7 +241,7 @@ class DevServer {
             JSON.stringify(
               {
                 error:
-                  "Dev server is not available. please reload the page and check CLI console for errors if the issue persists.",
+                  "The dev server is not available. Please reload the page and check the console for errors if the issue persists.",
               },
               null,
               2

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -236,7 +236,13 @@ class DevServer {
     app.use(
       eventHandler(async (event) => {
         const worker = await this.getWorker();
-        if (!worker || 1 === 1) {
+        if (!worker) {
+          const error = this.buildError || this.workerError;
+          if (error) {
+            throw error;
+          }
+
+          // This should not normally happen...
           return new Response(
             JSON.stringify(
               {
@@ -249,9 +255,7 @@ class DevServer {
             {
               status: 503,
               headers: {
-                Refresh: "5",
                 "Content-Type": "application/json",
-                "Retry-After": "3",
                 "Cache-Control": "no-store",
               },
             }

--- a/src/core/dev-server/worker.ts
+++ b/src/core/dev-server/worker.ts
@@ -127,9 +127,9 @@ export class NodeDevWorker implements DevWorker {
   }
 
   async #closeProxy() {
-    await new Promise<void>((resolve) =>
-      this.#proxy?.proxy?.close(() => resolve())
-    );
+    this.#proxy?.proxy?.close(() => {
+      // TODO: it will be never called! Investigate why and then await on it.
+    });
     this.#proxy = undefined;
   }
 

--- a/src/core/dev-server/worker.ts
+++ b/src/core/dev-server/worker.ts
@@ -1,0 +1,151 @@
+import type { IncomingMessage, OutgoingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { createError, type H3Event } from "h3";
+import type { HTTPProxy } from "./proxy";
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "pathe";
+import { Worker } from "node:worker_threads";
+import consola from "consola";
+import { createHTTPProxy } from "./proxy";
+
+export type WorkerAddress = { host: string; port: number; socketPath?: string };
+
+export interface WorkerHooks {
+  onClose?: (worker: DevWorker, reason?: string) => void;
+  onReady?: (worker: DevWorker, address?: WorkerAddress) => void;
+}
+
+export interface DevWorker {
+  readonly ready: boolean;
+  readonly closed: boolean;
+  close(): Promise<void>;
+  handleEvent: (event: H3Event) => Promise<void>;
+  handleUpgrade: (
+    req: IncomingMessage,
+    socket: OutgoingMessage<IncomingMessage> | Duplex,
+    head: any
+  ) => void;
+}
+
+export class NodeDevWorker implements DevWorker {
+  closed: boolean = false;
+  #address?: WorkerAddress;
+  #workerDir: string;
+  #hooks: WorkerHooks;
+  #proxy: HTTPProxy;
+  #worker?: Worker;
+
+  constructor(workerDir: string, hooks: WorkerHooks = {}) {
+    this.#workerDir = workerDir;
+    this.#hooks = hooks;
+    this.#proxy = createHTTPProxy();
+    this.#initWorker();
+  }
+
+  get ready() {
+    return Boolean(!this.closed && this.#worker && this.#address);
+  }
+
+  handleEvent(event: H3Event) {
+    if (!this.#address) {
+      throw createError({
+        statusCode: 503,
+        message: "worker is not ready yet",
+      });
+    }
+    return this.#proxy.handleEvent(event, { target: this.#address });
+  }
+
+  handleUpgrade(
+    req: IncomingMessage,
+    socket: OutgoingMessage<IncomingMessage> | Duplex,
+    head: any
+  ) {
+    if (!this.ready) {
+      return;
+    }
+    return this.#proxy.proxy.ws(
+      req,
+      socket as OutgoingMessage<IncomingMessage>,
+      { target: this.#address, xfwd: true },
+      head
+    );
+  }
+
+  #initWorker() {
+    const workerEntryPath = join(this.#workerDir, "index.mjs");
+
+    if (!existsSync(workerEntryPath)) {
+      this.close(`worker entry not found in "${workerEntryPath}".`);
+      return;
+    }
+
+    const worker = new Worker(workerEntryPath, {
+      env: { ...process.env, NITRO_DEV_WORKER_DIR: this.#workerDir },
+    });
+
+    worker.once("exit", (code) => {
+      this.close(`worker exited with code ${code}`);
+    });
+
+    worker.once("error", (error) => {
+      this.close(error.stack || error.message);
+    });
+
+    worker.on("message", (message) => {
+      consola.log(message);
+      if (message?.address) {
+        this.#address = message.address;
+        this.#hooks.onReady?.(this, this.#address);
+      }
+    });
+
+    this.#worker = worker;
+  }
+
+  async close(reason?: string) {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+
+    this.#hooks.onClose?.(this, reason);
+
+    if (this.#address?.socketPath) {
+      await rm(this.#address.socketPath).catch(() => {});
+    }
+    this.#address = undefined;
+
+    if (this.#worker) {
+      this.#worker.postMessage({ event: "shutdown" });
+
+      await new Promise<void>((resolve) => {
+        const gracefulShutdownTimeoutSec =
+          Number.parseInt(process.env.NITRO_SHUTDOWN_TIMEOUT || "", 10) || 3;
+        const timeout = setTimeout(() => {
+          consola.warn(
+            `force closing dev worker after ${gracefulShutdownTimeoutSec} seconds...`
+          );
+          resolve();
+        }, gracefulShutdownTimeoutSec * 1000);
+
+        this.#worker?.on("message", (message) => {
+          if (message.event === "exit") {
+            clearTimeout(timeout);
+            resolve();
+          }
+        });
+      });
+
+      this.#worker.removeAllListeners();
+
+      await this.#worker.terminate();
+
+      consola.log("normal close....");
+
+      this.#worker = undefined;
+    }
+  }
+}

--- a/src/core/dev-server/worker.ts
+++ b/src/core/dev-server/worker.ts
@@ -141,8 +141,13 @@ export class NodeDevWorker implements DevWorker {
       this.#worker = undefined;
     }
 
-    if (this.#address?.socketPath) {
-      await rm(this.#address.socketPath).catch(() => {});
+    const socketPath = this.#address?.socketPath;
+    if (
+      socketPath &&
+      socketPath[0] !== "\0" &&
+      !socketPath.startsWith(String.raw`\\.\pipe`)
+    ) {
+      await rm(socketPath).catch(() => {});
     }
     this.#address = undefined;
   }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -10,6 +10,7 @@ export interface NitroHooks {
   "rollup:before": (nitro: Nitro, config: RollupConfig) => HookResult;
   compiled: (nitro: Nitro) => HookResult;
   "dev:reload": () => HookResult;
+  "dev:start": () => HookResult;
   "dev:error": (cause?: unknown) => HookResult;
   "rollup:reload": () => HookResult;
   restart: () => HookResult;

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -10,6 +10,7 @@ export interface NitroHooks {
   "rollup:before": (nitro: Nitro, config: RollupConfig) => HookResult;
   compiled: (nitro: Nitro) => HookResult;
   "dev:reload": () => HookResult;
+  "dev:error": (cause?: unknown) => HookResult;
   "rollup:reload": () => HookResult;
   restart: () => HookResult;
   close: () => HookResult;

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -54,7 +54,7 @@ export interface NitroBuildInfo {
   };
   dev?: {
     pid: number;
-    workerAddress: { host: string; port: number; socketPath?: string };
+    workerAddress?: { host: string; port: number; socketPath?: string };
   };
   config?: Partial<PresetOptions>;
 }


### PR DESCRIPTION
Followup on previous work to improve dev server stability (#2997, #3001, #3003)

This PR changes the internal dev server into 2 components (server, and worker) with much better state control ability for the server.

- Server is responsible for creating the h3 dev instance, listener, and managing workers.
- Worker is responsible for controlling its lifecycle and keeping correct state flags 
- Instead of using (singleton) promise chains like before, the server keeps track of all created workers and picks the latest+active worker to handle the next request. 

Other notable changes:
- The `accessSync` on the socket has been completely removed which should improve Windows stability. 
- Error handling is unified with a single `onError` hook on h3 .
- Using virtual unix sockets in the Linux platform to avoid filesystem write.
- Use incremental socket id instead of using `threadId` (which can be recycled to 0). this avoids chances of conflicting sockets if the same process spawning multiple threads in parallel
- build errors properly propagated as server errors in browser. in case of build errors, `dev:reload` hook won't be called.
- build status is synected to the server. on initial build and reloads there is no longer worker is not ready and cannot find path / errors!
- Build errors are properly rendered in dev server (using little hack to modify stacktrace)

![image](https://github.com/user-attachments/assets/5984430a-eabb-4873-abcd-1a5643460180)

![image](https://github.com/user-attachments/assets/72d15038-3df9-4657-9f18-192a660b4563)
