### PR TITLE
feat(config): support `unenv` array

### DIFF
--- a/src/core/config/defaults.ts
+++ b/src/core/config/defaults.ts
@@ -73,7 +73,6 @@ export const NitroDefaults: NitroConfig = {
   },
 
   // Rollup
-  unenv: {},
   analyze: false,
   moduleSideEffects: [
     "unenv/polyfill/",

--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -28,6 +28,7 @@ import { resolveRuntimeConfigOptions } from "./resolvers/runtime-config";
 import { resolveStorageOptions } from "./resolvers/storage";
 import { resolveURLOptions } from "./resolvers/url";
 import { resolveErrorOptions } from "./resolvers/error";
+import { resolveUnenv } from "./resolvers/unenv";
 
 const configResolvers = [
   resolveCompatibilityOptions,
@@ -43,6 +44,7 @@ const configResolvers = [
   resolveAssetsOptions,
   resolveStorageOptions,
   resolveErrorOptions,
+  resolveUnenv,
 ] as const;
 
 export async function loadOptions(

--- a/src/core/config/resolvers/unenv.ts
+++ b/src/core/config/resolvers/unenv.ts
@@ -46,6 +46,4 @@ export async function resolveUnenv(options: NitroOptions) {
     options.unenv.unshift(nodeless);
   }
   options.unenv.unshift(common);
-
-  console.log(options.unenv.length, options.unenv);
 }

--- a/src/core/config/resolvers/unenv.ts
+++ b/src/core/config/resolvers/unenv.ts
@@ -1,6 +1,10 @@
+import type { NitroOptions } from "nitropack/types";
 import type { Preset } from "unenv";
 
 export const common: Preset = {
+  meta: {
+    name: "nitro-common",
+  },
   alias: {
     "node-mock-http/_polyfill/events": "node:events",
     "node-mock-http/_polyfill/buffer": "node:buffer",
@@ -10,9 +14,10 @@ export const common: Preset = {
   },
 };
 
-export const node: Preset = {};
-
 export const nodeless: Preset = {
+  meta: {
+    name: "nitro-nodeless",
+  },
   inject: {
     global: "unenv/polyfill/globalthis",
     process: "node:process",
@@ -30,3 +35,17 @@ export const nodeless: Preset = {
     "unenv/polyfill/timers",
   ],
 };
+
+export async function resolveUnenv(options: NitroOptions) {
+  options.unenv ??= [];
+  if (!Array.isArray(options.unenv)) {
+    options.unenv = [options.unenv];
+  }
+  options.unenv = options.unenv.filter(Boolean);
+  if (!options.node) {
+    options.unenv.unshift(nodeless);
+  }
+  options.unenv.unshift(common);
+
+  console.log(options.unenv.length, options.unenv);
+}

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -23,7 +23,6 @@ import type { Plugin } from "rollup";
 import { visualizer } from "rollup-plugin-visualizer";
 import { isTest, isWindows } from "std-env";
 import { defineEnv } from "unenv";
-import * as unenvPresets from "./unenv";
 import unimportPlugin from "unimport/unplugin";
 import { rollup as unwasm } from "unwasm/plugin";
 import { appConfig } from "./plugins/app-config";
@@ -63,11 +62,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     nodeCompat: isNodeless,
     npmShims: true,
     resolve: true,
-    presets: [
-      unenvPresets.common,
-      isNodeless ? unenvPresets.nodeless : unenvPresets.node,
-      nitro.options.unenv,
-    ],
+    presets: nitro.options.unenv,
     overrides: {
       alias: nitro.options.alias,
     },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -211,7 +211,7 @@ export interface NitroOptions extends PresetOptions {
   // Rollup
   rollupConfig?: RollupConfig;
   entry: string;
-  unenv: UnenvPreset;
+  unenv: UnenvPreset[];
   alias: Record<string, string>;
   minify: boolean;
   inlineDynamicImports: boolean;
@@ -262,7 +262,7 @@ export interface NitroConfig
   extends DeepPartial<
       Omit<
         NitroOptions,
-        "routeRules" | "rollupConfig" | "preset" | "compatibilityDate"
+        "routeRules" | "rollupConfig" | "preset" | "compatibilityDate" | "unenv"
       >
     >,
     C12InputConfig<NitroConfig> {
@@ -271,6 +271,7 @@ export interface NitroConfig
   routeRules?: { [path: string]: NitroRouteConfig };
   rollupConfig?: Partial<RollupConfig>;
   compatibilityDate?: CompatibilityDateSpec;
+  unenv?: UnenvPreset | UnenvPreset[];
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
Cases like #3140 require dynamic unenv preset injection. (without this, we need to manually handle merging logic before unenv)

This PR makes `options.unenv` to be an array of presets.