### PR TITLE
feat: add `build:before` hook

### DIFF
--- a/src/core/build/build.ts
+++ b/src/core/build/build.ts
@@ -4,6 +4,7 @@ import { watchDev } from "./dev";
 import { buildProduction } from "./prod";
 
 export async function build(nitro: Nitro) {
+  await nitro.hooks.callHook("build:before", nitro);
   const rollupConfig = getRollupConfig(nitro);
   await nitro.hooks.callHook("rollup:before", nitro, rollupConfig);
   return nitro.options.dev

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -7,6 +7,7 @@ type HookResult = void | Promise<void>;
 
 export interface NitroHooks {
   "types:extend": (types: NitroTypes) => HookResult;
+  "build:before": (nitro: Nitro) => HookResult;
   "rollup:before": (nitro: Nitro, config: RollupConfig) => HookResult;
   compiled: (nitro: Nitro) => HookResult;
   "dev:reload": () => HookResult;


### PR DESCRIPTION
Add a `build:before` hook that gets called before rollup config being prepared to allow customizing nitro options. requirement for #3140