### PR TITLE
refactor: remove extra tag

### DIFF
--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,3 +1,3 @@
 export default eventHandler(async (event) => {
-  return {};
+  return a / 0;
 });

--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,3 +1,3 @@
 export default eventHandler(async (event) => {
-  return a / 0;
+  return {};
 });

--- a/src/core/prerender/prerender.ts
+++ b/src/core/prerender/prerender.ts
@@ -24,8 +24,8 @@ const linkParents = new Map<string, Set<string>>();
 
 export async function prerender(nitro: Nitro) {
   if (nitro.options.noPublicDir) {
-    console.warn(
-      "[nitro] Skipping prerender since `noPublicDir` option is enabled."
+    nitro.logger.warn(
+      "Skipping prerender since `noPublicDir` option is enabled."
     );
     return;
   }

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -261,7 +261,7 @@ export async function writeWranglerConfig(
   for (const key in overrides) {
     if (key in userConfig || key in ctxConfig) {
       nitro.logger.warn(
-        `[nitro] [cloudflare] Wrangler config \`${key}\`${key in ctxConfig ? "set by config or modules" : ""} is overridden and will be ignored.`
+        `Cloudflare] Wrangler config \`${key}\`${key in ctxConfig ? "set by config or modules" : ""} is overridden and will be ignored.`
       );
     }
   }
@@ -283,13 +283,13 @@ export async function writeWranglerConfig(
       compatFlags.has("no_nodejs_compat_v2")
     ) {
       nitro.logger.warn(
-        "[nitro] [cloudflare] Wrangler config `compatibility_flags` contains both `nodejs_compat_v2` and `no_nodejs_compat_v2`. Ignoring `nodejs_compat_v2`."
+        "[cloudflare] Wrangler config `compatibility_flags` contains both `nodejs_compat_v2` and `no_nodejs_compat_v2`. Ignoring `nodejs_compat_v2`."
       );
       compatFlags.delete("nodejs_compat_v2");
     }
     if (compatFlags.has("nodejs_compat_v2")) {
       nitro.logger.warn(
-        "[nitro] [cloudflare] Please consider replacing `nodejs_compat_v2` with `nodejs_compat` in your `compatibility_flags` or USE IT AT YOUR OWN RISK as it can cause issues with nitro."
+        "[cloudflare] Please consider replacing `nodejs_compat_v2` with `nodejs_compat` in your `compatibility_flags` or USE IT AT YOUR OWN RISK as it can cause issues with nitro."
       );
     } else {
       // Add default compatibility flags

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -261,7 +261,7 @@ export async function writeWranglerConfig(
   for (const key in overrides) {
     if (key in userConfig || key in ctxConfig) {
       nitro.logger.warn(
-        `Cloudflare] Wrangler config \`${key}\`${key in ctxConfig ? "set by config or modules" : ""} is overridden and will be ignored.`
+        `[cloudflare] Wrangler config \`${key}\`${key in ctxConfig ? "set by config or modules" : ""} is overridden and will be ignored.`
       );
     }
   }

--- a/src/presets/deno/runtime/deno-server.ts
+++ b/src/presets/deno/runtime/deno-server.ts
@@ -17,17 +17,17 @@ const nitroApp = useNitroApp();
 
 if (Deno.env.get("DEBUG")) {
   addEventListener("unhandledrejection", (event: any) =>
-    console.error("[nitro] [dev] [unhandledRejection]", event.reason)
+    console.error("[unhandledRejection]", event.reason)
   );
   addEventListener("error", (event: any) =>
-    console.error("[nitro] [dev] [uncaughtException]", event.error)
+    console.error("[uncaughtException]", event.error)
   );
 } else {
   addEventListener("unhandledrejection", (err: any) =>
-    console.error("[nitro] [production] [unhandledRejection] " + err)
+    console.error("[unhandledRejection] " + err)
   );
   addEventListener("error", (event: any) =>
-    console.error("[nitro] [production] [uncaughtException] " + event.error)
+    console.error("[uncaughtException] " + event.error)
   );
 }
 

--- a/src/presets/netlify/legacy/utils.ts
+++ b/src/presets/netlify/legacy/utils.ts
@@ -153,8 +153,8 @@ export function deprecateSWR(nitro: Nitro) {
     }
   }
   if (hasLegacyOptions && !isTest) {
-    console.warn(
-      "[nitro] Nitro now uses `isr` option to configure ISR behavior on Netlify. Backwards-compatible support for `static` and `swr` support with Builder Functions will be removed in the future versions. Set `future.nativeSWR: true` nitro config disable this warning."
+    nitro.logger.warn(
+      "Nitro now uses `isr` option to configure ISR behavior on Netlify. Backwards-compatible support for `static` and `swr` support with Builder Functions will be removed in the future versions. Set `future.nativeSWR: true` nitro config disable this warning."
     );
   }
 }

--- a/src/presets/node/runtime/node-cluster.ts
+++ b/src/presets/node/runtime/node-cluster.ts
@@ -32,9 +32,7 @@ function runMaster() {
       isShuttingDown = true;
       await new Promise<void>((resolve) => {
         const timeout = setTimeout(() => {
-          console.warn(
-            "[nitro] [cluster] Timeout reached for graceful shutdown. Forcing exit."
-          );
+          console.warn("Timeout reached for graceful shutdown. Forcing exit.");
           resolve();
         }, shutdownConfig.timeout);
 

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -242,8 +242,8 @@ export function deprecateSWR(nitro: Nitro) {
     }
   }
   if (hasLegacyOptions && !isTest) {
-    console.warn(
-      "[nitro] Nitro now uses `isr` option to configure ISR behavior on Vercel. Backwards-compatible support for `static` and `swr` options within the Vercel Build Options API will be removed in the future versions. Set `future.nativeSWR: true` nitro config disable this warning."
+    nitro.logger.warn(
+      "Nitro now uses `isr` option to configure ISR behavior on Vercel. Backwards-compatible support for `static` and `swr` options within the Vercel Build Options API will be removed in the future versions. Set `future.nativeSWR: true` nitro config disable this warning."
     );
   }
 }

--- a/src/rollup/plugins/handlers-meta.ts
+++ b/src/rollup/plugins/handlers-meta.ts
@@ -66,8 +66,8 @@ export function handlersMeta(nitro: Nitro) {
           }
         }
       } catch (error) {
-        console.warn(
-          `[nitro] [handlers-meta] Cannot extra route meta for: ${id}: ${error}`
+        nitro.logger.warn(
+          `[handlers-meta] Cannot extra route meta for: ${id}: ${error}`
         );
       }
 

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -44,7 +44,6 @@ export default defineNitroErrorHandler(
     // Console output
     if (error.unhandled || error.fatal) {
       const tags = [
-        "[nitro]",
         "[request error]",
         error.unhandled && "[unhandled]",
         error.fatal && "[fatal]",

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -63,7 +63,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       ((await useStorage()
         .getItem(cacheKey)
         .catch((error) => {
-          console.error(`[nitro] [cache] Cache read error.`, error);
+          console.error(`[cache] Cache read error.`, error);
           useNitroApp().captureError(error, { event, tags: ["cache"] });
         })) as unknown) || {};
 
@@ -71,7 +71,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     if (typeof entry !== "object") {
       entry = {};
       const error = new Error("Malformed data read from cache.");
-      console.error("[nitro] [cache]", error);
+      console.error("[cache]", error);
       useNitroApp().captureError(error, { event, tags: ["cache"] });
     }
 
@@ -127,7 +127,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           const promise = useStorage()
             .setItem(cacheKey, entry, setOpts)
             .catch((error) => {
-              console.error(`[nitro] [cache] Cache write error.`, error);
+              console.error(`[cache] Cache write error.`, error);
               useNitroApp().captureError(error, { event, tags: ["cache"] });
             });
           if (event?.waitUntil) {
@@ -147,7 +147,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
     if (opts.swr && validate(entry) !== false) {
       _resolvePromise.catch((error) => {
-        console.error(`[nitro] [cache] SWR handler error.`, error);
+        console.error(`[cache] SWR handler error.`, error);
         useNitroApp().captureError(error, { event, tags: ["cache"] });
       });
       return entry as ResolvedCacheEntry<T>;

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -43,7 +43,7 @@ export default defineNitroErrorHandler(
       }
 
       consola.error(
-        `[nitro] [request error] ${tags} [${event.method}] ${url}\n\n`,
+        `[request error] ${tags} [${event.method}] ${url}\n\n`,
         ansiError
       );
     }

--- a/src/runtime/internal/error/prod.ts
+++ b/src/runtime/internal/error/prod.ts
@@ -20,7 +20,7 @@ export default defineNitroErrorHandler(
       // prettier-ignore
       const tags = [error.unhandled && "[unhandled]", error.fatal && "[fatal]"].filter(Boolean).join(" ")
       console.error(
-        `[nitro] [request error] ${tags} [${event.method}] ${url}\n`,
+        `[request error] ${tags} [${event.method}] ${url}\n`,
         error
       );
     }

--- a/src/runtime/internal/task.ts
+++ b/src/runtime/internal/task.ts
@@ -79,7 +79,7 @@ export function startScheduleRunner() {
             context: {},
           }).catch((error) => {
             console.error(
-              `[nitro] Error while running scheduled task "${name}"`,
+              `Error while running scheduled task "${name}"`,
               error
             );
           })

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -34,7 +34,7 @@ export async function useRequestBody(
 }
 
 function _captureError(error: Error, type: string) {
-  console.error(`[nitro] [${type}]`, error);
+  console.error(`[${type}]`, error);
   useNitroApp().captureError(error, { tags: [type] });
 }
 


### PR DESCRIPTION
Remove extra `[nitro]` tags in various places and prefer `nitro.logger` or no tag (`[nitro] [request error]` can be confusing for source)