### PR TITLE
fix(dev): safer socket name

### DIFF
--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -47,6 +47,8 @@ export function createDevServer(nitro: Nitro): NitroDevServer {
   };
 }
 
+let workerIdCtr = 0;
+
 class DevServer {
   nitro: Nitro;
   workerDir: string;
@@ -55,7 +57,6 @@ class DevServer {
   reloadPromise?: Promise<void>;
   watcher?: FSWatcher;
   workers: DevWorker[] = [];
-  workerIdCtr: number = 0;
 
   workerError?: unknown;
 
@@ -136,7 +137,7 @@ class DevServer {
     for (const worker of this.workers) {
       worker.close();
     }
-    const worker = new NodeDevWorker(++this.workerIdCtr, this.workerDir, {
+    const worker = new NodeDevWorker(++workerIdCtr, this.workerDir, {
       onClose: (worker, cause) => {
         this.workerError = cause;
         const index = this.workers.indexOf(worker);

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -6,7 +6,7 @@ import { startScheduleRunner } from "nitropack/runtime/internal";
 import { scheduledTasks, tasks } from "#nitro-internal-virtual/tasks";
 import { Server } from "node:http";
 import { join } from "node:path";
-import { parentPort } from "node:worker_threads";
+import { parentPort, threadId } from "node:worker_threads";
 import wsAdapter from "crossws/adapters/node";
 import {
   defineEventHandler,
@@ -34,7 +34,7 @@ function getAddress() {
     return 0;
   }
 
-  const socketName = `worker-${process.pid}-${NITRO_DEV_WORKER_ID}.sock`;
+  const socketName = `worker-${process.pid}-${threadId}-${NITRO_DEV_WORKER_ID}.sock`;
 
   switch (process.platform) {
     case "win32": {

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -6,6 +6,7 @@ import { readFile } from "node:fs/promises";
 import { relative, dirname } from "node:path";
 import { writeFile } from "nitropack/kit";
 import { parseTOML } from "confbox";
+import { readGitConfig, readPackageJSON } from "pkg-types";
 import { defu } from "defu";
 import { globby } from "globby";
 import { join, resolve } from "pathe";
@@ -274,6 +275,14 @@ export async function writeWranglerConfig(
     defaults
   ) as WranglerConfig;
 
+  // Name is required
+  if (!wranglerConfig.name) {
+    wranglerConfig.name = await generateWorkerName(nitro)!;
+    nitro.logger.info(
+      `Using auto generated worker name: \`${wranglerConfig.name}\``
+    );
+  }
+
   // Compatibility flags
   // prettier-ignore
   const compatFlags = new Set(wranglerConfig.compatibility_flags || [])
@@ -343,4 +352,15 @@ async function resolveWranglerConfig(dir: string): Promise<WranglerConfig> {
     return config;
   }
   return {};
+}
+
+async function generateWorkerName(nitro: Nitro) {
+  const gitConfig = await readGitConfig(nitro.options.rootDir).catch(() => {});
+  const gitRepo = gitConfig?.remote?.origin?.url
+    ?.replace(/\.git$/, "")
+    .match(/[/:]([^/]+\/[^/]+)$/)?.[1];
+  const pkgJSON = await readPackageJSON(nitro.options.rootDir).catch(() => {});
+  const pkgName = pkgJSON?.name;
+  const subpath = relative(nitro.options.workspaceDir, nitro.options.rootDir);
+  return `${gitRepo || pkgName}/${subpath}`.replace(/[^a-zA-Z0-9-]/g, "-");
 }


### PR DESCRIPTION
When cloudflare wrangler config is being generated (#3064), having `name` will be mandatory in config. If user hasn't provided one, this PR generates one based on git config or package name.

<img width="621" alt="image" src="https://github.com/user-attachments/assets/a5b499c5-7a8a-445c-ba3e-99a77459c821" />
