### PR TITLE
refactor(cloudflare): strictly enable `nodeCompat` and`deployConfig` under flags

### DIFF
--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -30,29 +30,29 @@ export interface CloudflarePagesRoutes {
 
 export interface CloudflareOptions {
   /**
-   * Configuration for the Cloudflare Deployments
+   * Configuration for the Cloudflare Deployments.
+   *
+   * **NOTE:** This option is only effective if `deployConfig` is enabled.
    */
   wrangler?: WranglerConfig;
 
   /**
-   * Enable native Node.js compatibility support.
+   * Enable automatic generation of `.wrangler/deploy/config.json`.
    *
-   * Requires `nodejs_compat` compatibility flag (Nitro enables it by default).
-   *
-   * If disabled, pure unenv polyfills will be used instead.
-   *
-   * Enabled by default with `compatibilityDate` >= `2025-03-01`.
-   */
-  nodeCompat?: boolean;
-
-  /**
-   * Disable the automatic generation of `.wrangler/deploy/config.json`.
-   *
-   * Enabled by default with `compatibilityDate` >= `2025-03-01` unless explicitly set to `false`.
+   * **IMPORTANT:** Enabling this option will cause settings from cloudflare dashboard (including environment variables) to be disabled and discarded.
    *
    * More info: https://developers.cloudflare.com/workers/wrangler/configuration#generated-wrangler-configuration
    */
-  noWranglerDeployConfig?: boolean;
+  deployConfig?: boolean;
+
+  /**
+   * Enable native Node.js compatibility support.
+   *
+   * If this option disabled, pure unenv polyfills will be used instead.
+   *
+   * If not set, will be auto enabled if `nodejs_compat` or `nodejs_compat_v2` is detected in `wrangler.toml` or `wrangler.json`.
+   */
+  nodeCompat?: boolean;
 
   pages?: {
     /**

--- a/test/fixture/wrangler.toml
+++ b/test/fixture/wrangler.toml
@@ -1,0 +1,1 @@
+compatibility_flags = [ "nodejs_compat" ]


### PR DESCRIPTION
followup on #3064 .. #3065 .. #3067 .. #3140

Enabling native Node.js compatibility support for Cloudflare workers requires a very simple `nodejs_compat` flag to be declared for [workerd](https://github.com/cloudflare/workerd) runtime.

However with a long chain of wrangler and cloudflare API/CI/Dashboard in between, even if Nitro attempts to auto-enable this feature not only cloudflare dashboard features will be disabled and forcing users to use a `wrangler.{toml,json}` instead of the dashboard for anything else, but also causes **all environment variables from the dashboard to be immediately discarded**. 

The latter makes it a very dangerous thing to enable even using compatibility dates (we might enable by default for Nitro v3 only).

With this PR two options are exposed from Nitro:
- `cloudflare.nodeCompat`: Enable Unenv preset for Hybrid/Native Node.js compatibility mode (disabled by default)
   - Users can use dashboard to set `nodejs_compat` flag then enable option
   - Users can use a local `wrangler.toml` config and set `nodejs_compat` this option will be auto inferred in this case
- `cloudflare.deployConfig`: Enable auto-generation of `.wrangler/deploy/config.json`


---

**Example 1:** Use auto config generation (disables dashboard)

```ts
export default defineNitroConfig({
  cloudflare: {
    deployConfig: true,
    nodeCompat: true,
  },
});
```

**Example 2:** Use custom `wrangler.toml` (also disabled dashboard and auto infered by Nitro)

```ts
compatibility_flags = [ "nodejs_compat" ]
```