### PR TITLE
feat: auto redirect to base url

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -230,6 +230,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     server: true,
     client: false,
     nitro: true,
+    baseURL: nitro.options.baseURL,
     // @ts-expect-error
     "versions.nitro": "",
     "versions?.nitro": "",

--- a/src/runtime/internal/error/prod.ts
+++ b/src/runtime/internal/error/prod.ts
@@ -2,6 +2,7 @@ import {
   getRequestURL,
   getResponseHeader,
   send,
+  sendRedirect,
   setResponseHeader,
   setResponseStatus,
 } from "h3";
@@ -13,7 +14,17 @@ export default defineNitroErrorHandler(
     const statusCode = error.statusCode || 500;
     const statusMessage = error.statusMessage || "Server Error";
     // prettier-ignore
-    const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true }).toString();
+    const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
+
+    if (statusCode === 404) {
+      const baseURL = import.meta.baseURL || "/";
+      if (baseURL.length > 1 && !url.pathname.startsWith(baseURL)) {
+        return sendRedirect(
+          event,
+          `${baseURL}${url.pathname.slice(1)}${url.search}`
+        );
+      }
+    }
 
     // Console output
     if (isSensitive) {
@@ -36,7 +47,7 @@ export default defineNitroErrorHandler(
       JSON.stringify(
         {
           error: true,
-          url,
+          url: url.href,
           statusCode,
           statusMessage,
           message: isSensitive ? "Server Error" : error.message,

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -8,6 +8,7 @@ export interface NitroStaticBuildFlags {
   dev?: boolean;
   client?: boolean;
   nitro?: boolean;
+  baseURL?: string;
   prerender?: boolean;
   preset?: NitroOptions["preset"];
   server?: boolean;


### PR DESCRIPTION
#2980

This PR is a rework of #2713 to enable auto-redirect requests made outside of nitro configured `baseURL`, for both dev and prod but on final error handler 404 so any other custom hook or route rule could intercept if needed.

This PR also adds (build-time static) `import.meta.baseURL` so the code in error handler remains fully standalone from runtime logic.