### PR TITLE
fix(dev): use full socket path for windows and linux

### DIFF
--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -19,7 +19,7 @@ import {
 
 const {
   NITRO_NO_UNIX_SOCKET,
-  NITRO_DEV_WORKER_DIR = "",
+  NITRO_DEV_WORKER_DIR = ".",
   NITRO_DEV_WORKER_ID,
 } = process.env;
 
@@ -39,7 +39,7 @@ function getAddress() {
   }
 
   const socketName = `worker-${process.pid}-${threadId}-${NITRO_DEV_WORKER_ID}.sock`;
-  const socketPath = join(NITRO_DEV_WORKER_DIR || ".", socketName);
+  const socketPath = join(NITRO_DEV_WORKER_DIR, socketName);
 
   switch (process.platform) {
     case "win32": {

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -6,7 +6,6 @@ import { startScheduleRunner } from "nitropack/runtime/internal";
 import { scheduledTasks, tasks } from "#nitro-internal-virtual/tasks";
 import { Server } from "node:http";
 import { join } from "node:path";
-import { digest } from "ohash";
 import { parentPort, threadId } from "node:worker_threads";
 import wsAdapter from "crossws/adapters/node";
 import {


### PR DESCRIPTION
If running multiple instances of Nitro dev server (programmatically, in tests) in the same process id, socket names can conflict in Linux and Windows that use abstract Sockets.

This PR uses the same full path as part of the socket name to avoid this.