### PR TITLE
fix(dev): limit `/_vfs` to local ips only

### DIFF
--- a/src/core/dev-server/vfs.ts
+++ b/src/core/dev-server/vfs.ts
@@ -1,8 +1,17 @@
-import { createError, eventHandler, getRequestHeader } from "h3";
+import { createError, eventHandler, getRequestHeader, getRequestIP } from "h3";
 import type { Nitro } from "nitropack/types";
 
 export function createVFSHandler(nitro: Nitro) {
   return eventHandler(async (event) => {
+    const ip = getRequestIP(event, { xForwardedFor: false });
+    const isLocalRequest = ip && /^::1$|^127\.\d+\.\d+\.\d+$/.test(ip);
+    if (!isLocalRequest) {
+      throw createError({
+        message: `Forbidden IP: "${ip || "?"}"`,
+        statusCode: 403,
+      });
+    }
+
     const vfsEntries = {
       ...nitro.vfs,
       ...nitro.options.virtual,


### PR DESCRIPTION
Nitro dev server has a default `/_vfs` endpoint for debugging virtual templates, however, it can leak some limited information when using `nitro dev --host`.

This PR limits this feature to only when incoming request IP is strictly `::1` or `127.*`.

> [!NOTE]
> this change, limits some valid cases too, like using external IP of same computer to access the endpoint, but considering it is just a debugging feature I think worth doing it and minimizing exposure changes.

Alternative option was validating incoming host but it can be also forged. 

/cc @danielroe @antfu 