### PR TITLE
fix(app): initialize `event.context.nitro` before calling `request` hook

### DIFF
--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -61,6 +61,9 @@ function createNitroApp(): NitroApp {
       return errorHandler(error as H3Error, event);
     },
     onRequest: async (event) => {
+      // Init nitro context
+      event.context.nitro = event.context.nitro || { errors: [] };
+      
       await nitroApp.hooks.callHook("request", event).catch((error) => {
         captureError(error, { event, tags: ["request"] });
       });
@@ -114,9 +117,6 @@ function createNitroApp(): NitroApp {
   // A generic event handler give nitro access to the requests
   h3App.use(
     eventHandler((event) => {
-      // Init nitro context
-      event.context.nitro = event.context.nitro || { errors: [] };
-
       // Support platform context provided by local fetch
       const envContext: { waitUntil?: H3Event["waitUntil"] } | undefined = (
         event.node.req as unknown as { __unenv__: any }


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Fixes https://github.com/nitrojs/nitro/issues/3150

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`event.context.nitro` is currently initialized in the generic event handler of `h3App`.
The `request` hook is called in `h3App.onRequest()` which runs before the generic event handler.
By moving the nitro context initialization there, we can provide the context for the listeners of the `request` hook.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
