### PR TITLE
fix(cli): set `NODE_ENV` when running build/dev commands

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -35,7 +35,7 @@ export default defineCommand({
     },
   },
   setup() {
-    overrideEnv('production')
+    overrideEnv("production");
   },
   async run({ args }) {
     const rootDir = resolve((args.dir || args._dir || ".") as string);

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -9,6 +9,7 @@ import {
 } from "nitropack/core";
 import { resolve } from "pathe";
 import { commonArgs } from "../common";
+import { overrideEnv } from "../utils/env";
 
 export default defineCommand({
   meta: {
@@ -32,6 +33,9 @@ export default defineCommand({
       description:
         "The date to use for preset compatibility (you can also use `NITRO_COMPATIBILITY_DATE` environment variable).",
     },
+  },
+  setup() {
+    overrideEnv('production')
   },
   async run({ args }) {
     const rootDir = resolve((args.dir || args._dir || ".") as string);

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -19,7 +19,7 @@ export default defineCommand({
     ...getArgs(),
   },
   setup() {
-    overrideEnv('development')
+    overrideEnv("development");
   },
   async run({ args }) {
     const rootDir = resolve((args.dir || args._dir || ".") as string);

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -5,6 +5,7 @@ import { build, createDevServer, createNitro, prepare } from "nitropack/core";
 import type { Nitro } from "nitropack/types";
 import { resolve } from "pathe";
 import { commonArgs } from "../common";
+import { overrideEnv } from "../utils/env";
 
 const hmrKeyRe = /^runtimeConfig\.|routeRules\./;
 
@@ -16,6 +17,9 @@ export default defineCommand({
   args: {
     ...commonArgs,
     ...getArgs(),
+  },
+  setup() {
+    overrideEnv('development')
   },
   async run({ args }) {
     const rootDir = resolve((args.dir || args._dir || ".") as string);

--- a/src/cli/utils/env.ts
+++ b/src/cli/utils/env.ts
@@ -1,0 +1,12 @@
+import consola from "consola";
+
+export function overrideEnv(targetEnv: string) {
+  const currentEnv = process.env.NODE_ENV;
+  if (currentEnv && currentEnv !== targetEnv) {
+    consola.warn(
+      `Changing \`NODE_ENV\` from \`${currentEnv}\` to \`${targetEnv}\`, to avoid unintended behavior.`
+    );
+  }
+
+  process.env.NODE_ENV = targetEnv;
+}


### PR DESCRIPTION
### 🔗 Linked issue

Fixes https://github.com/nitrojs/nitro/issues/3052

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

When built from Nuxt the `$production` and `$development` config for Nitro is loaded correctly:
```ts
export default defineNuxtConfig({
  $production: {
    nitro: {
      ignore: ['routes/dev/**']
    }
  },
  $development: {
    nitro: {
      ignore: ['routes/dev/**']
    }
  },
});
```

When built using the Nitro CLI, the same config does not work:

```ts
export default defineNitroConfig({
  $production: {
    ignore: ['routes/dev/**']
  },
  $development: {
    ignore: ['routes/dev/**']
  },
});
```

Setting the correct `NODE_ENV` before running the commands (like Nuxt CLI does) resolve this issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
