### PR TITLE
fix(cache): fixed `defineCachedFunction` to use the function name

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -37,13 +37,14 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   fn: (...args: ArgsT) => T | Promise<T>,
   opts: CacheOptions<T, ArgsT> = {}
 ): (...args: ArgsT) => Promise<T> {
-  opts = { ...defaultCacheOptions(), ...opts };
+  const defaults = defaultCacheOptions();
+  opts = { ...defaults, name: undefined, ...opts };
 
   const pending: { [key: string]: Promise<T> } = {};
 
   // Normalize cache params
   const group = opts.group || "nitro/functions";
-  const name = opts.name || fn.name || "_";
+  const name = opts.name || fn.name || defaults.name;
   const integrity = opts.integrity || hash([fn, opts]);
   const validate = opts.validate || ((entry) => entry.value !== undefined);
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes https://github.com/nitrojs/nitro/issues/3019

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

The provided function name was overwritten by the defaults.
I fixed that by removing it from the defaults when it's merged with the options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
