### PR TITLE
fix(config): respect config overrides for defaults

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -105,7 +105,8 @@ async function _loadUserConfig(
     },
     async defaultConfig({ configs }) {
       const getConf = <K extends keyof NitroConfig>(key: K) =>
-        (configs.main?.[key] ??
+        (configOverrides[key] ??
+          configs.main?.[key] ??
           configs.rc?.[key] ??
           configs.packageJson?.[key]) as NitroConfig[K];
 


### PR DESCRIPTION
fixes regression from #2860 in 2.11

Downstream report: https://github.com/nuxt/nuxt/issues/31203

if config overrides setting `static: true`, it should be always respected also for defaults.
