### PR TITLE
refactor: expose default error to custom handler

### DIFF
--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,3 +1,3 @@
 export default eventHandler(async (event) => {
-  return {};
+  return foo.bar;
 });

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -1,12 +1,13 @@
 import {
+  type H3Event,
+  type H3Error,
   send,
-  sendRedirect,
   getRequestHeader,
   getRequestHeaders,
-  setResponseHeader,
-  setResponseStatus,
   getRequestURL,
   getResponseHeader,
+  setResponseHeaders,
+  setResponseStatus,
 } from "h3";
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
@@ -14,89 +15,115 @@ import consola from "consola";
 import { ErrorParser } from "youch-core";
 import { Youch } from "youch";
 import { SourceMapConsumer } from "source-map";
-import { defineNitroErrorHandler, setSecurityHeaders } from "./utils";
+import { defineNitroErrorHandler } from "./utils";
 
 export default defineNitroErrorHandler(
   async function defaultNitroErrorHandler(error, event) {
-    const isSensitive = error.unhandled || error.fatal;
-    const statusCode = error.statusCode || 500;
-    const statusMessage = error.statusMessage || "Server Error";
-    // prettier-ignore
-    const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
-
-    // Redirects with base URL
-    if (statusCode === 404) {
-      const baseURL = import.meta.baseURL || "/";
-      if (/^\/[^/]/.test(baseURL) && !url.pathname.startsWith(baseURL)) {
-        return sendRedirect(
-          event,
-          `${baseURL}${url.pathname.slice(1)}${url.search}`
-        );
-      }
-    }
-
-    // Load stack trace with source maps
-    await loadStackTrace(error).catch(consola.error);
-
-    // https://github.com/poppinss/youch
-    const youch = new Youch();
-
-    // Console output
-    if (isSensitive) {
-      // prettier-ignore
-      const tags = [error.unhandled && "[unhandled]", error.fatal && "[fatal]"].filter(Boolean).join(" ")
-
-      const columns = process.stderr.columns;
-      const ansiError = await (
-        await youch.toANSI(error)
-      ).replaceAll(process.cwd(), ".");
-      if (!columns) {
-        process.stderr.columns = columns;
-      }
-
-      consola.error(
-        `[request error] ${tags} [${event.method}] ${url}\n\n`,
-        ansiError
-      );
-    }
-
-    // Send response
-    setResponseStatus(event, statusCode, statusMessage);
-    setSecurityHeaders(event, true /* allow js */);
-    if (statusCode === 404 || !getResponseHeader(event, "cache-control")) {
-      setResponseHeader(event, "cache-control", "no-cache");
-    }
-    return getRequestHeader(event, "accept")?.includes("text/html")
-      ? send(
-          event,
-          await youch.toHTML(error, {
-            request: {
-              url: url.href,
-              method: event.method,
-              headers: getRequestHeaders(event),
-            },
-          }),
-          "text/html"
-        )
-      : send(
-          event,
-          JSON.stringify(
-            {
-              error: true,
-              url,
-              statusCode,
-              statusMessage,
-              message: error.message,
-              data: error.data,
-              stack: error.stack?.split("\n").map((line) => line.trim()),
-            },
-            null,
-            2
-          ),
-          "application/json"
-        );
+    const res = await defaultHandler(error, event);
+    setResponseHeaders(event, res.headers);
+    setResponseStatus(event, res.status, res.statusText);
+    return send(
+      event,
+      typeof res.body === "string"
+        ? res.body
+        : JSON.stringify(res.body, null, 2)
+    );
   }
 );
+
+export async function defaultHandler(
+  error: H3Error,
+  event: H3Event,
+  opts?: { silent?: boolean; json?: boolean }
+) {
+  const isSensitive = error.unhandled || error.fatal;
+  const statusCode = error.statusCode || 500;
+  const statusMessage = error.statusMessage || "Server Error";
+  // prettier-ignore
+  const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
+
+  // Redirects with base URL
+  if (statusCode === 404) {
+    const baseURL = import.meta.baseURL || "/";
+    if (/^\/[^/]/.test(baseURL) && !url.pathname.startsWith(baseURL)) {
+      const redirectTo = `${baseURL}${url.pathname.slice(1)}${url.search}`;
+      return {
+        status: 302,
+        statusText: "Found",
+        headers: { location: redirectTo },
+        body: `Redirecting...`,
+      };
+    }
+  }
+
+  // Load stack trace with source maps
+  await loadStackTrace(error).catch(consola.error);
+
+  // https://github.com/poppinss/youch
+  const youch = new Youch();
+
+  // Console output
+  if (isSensitive && !opts?.silent) {
+    // prettier-ignore
+    const tags = [error.unhandled && "[unhandled]", error.fatal && "[fatal]"].filter(Boolean).join(" ")
+    const ansiError = await (
+      await youch.toANSI(error)
+    ).replaceAll(process.cwd(), ".");
+    consola.error(
+      `[request error] ${tags} [${event.method}] ${url}\n\n`,
+      ansiError
+    );
+  }
+
+  // Use HTML response only when user-agent expects it (browsers)
+  const useJSON =
+    opts?.json || !getRequestHeader(event, "accept")?.includes("text/html");
+
+  // Prepare headers
+  const headers: HeadersInit = {
+    "content-type": useJSON ? "application/json" : "text/html",
+    // Prevent browser from guessing the MIME types of resources.
+    "x-content-type-options": "nosniff",
+    // Prevent error page from being embedded in an iframe
+    "x-frame-options": "DENY",
+    // Prevent browsers from sending the Referer header
+    "referrer-policy": "no-referrer",
+    // Disable the execution of any js
+    "content-security-policy":
+      "script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self';",
+  };
+  if (statusCode === 404 || !getResponseHeader(event, "cache-control")) {
+    headers["Cache-Control"] = "no-cache";
+  }
+
+  // Prepare body
+  const body = useJSON
+    ? {
+        error: true,
+        url,
+        statusCode,
+        statusMessage,
+        message: error.message,
+        data: error.data,
+        stack: error.stack?.split("\n").map((line) => line.trim()),
+      }
+    : await youch.toHTML(error, {
+        request: {
+          url: url.href,
+          method: event.method,
+          headers: getRequestHeaders(event),
+        },
+      });
+
+  return {
+    status: statusCode,
+    statusText: statusMessage,
+    headers,
+    body,
+  } satisfies Omit<ResponseInit, "body"> & {
+    body: string | Record<string, any>;
+  };
+}
 
 // ---- Source Map support ----
 

--- a/src/runtime/internal/error/prod.ts
+++ b/src/runtime/internal/error/prod.ts
@@ -1,62 +1,85 @@
 import {
+  type H3Error,
+  type H3Event,
   getRequestURL,
   getResponseHeader,
   send,
-  sendRedirect,
-  setResponseHeader,
+  setResponseHeaders,
   setResponseStatus,
 } from "h3";
-import { defineNitroErrorHandler, setSecurityHeaders } from "./utils";
+import { defineNitroErrorHandler } from "./utils";
 
 export default defineNitroErrorHandler(
   function defaultNitroErrorHandler(error, event) {
-    const isSensitive = error.unhandled || error.fatal;
-    const statusCode = error.statusCode || 500;
-    const statusMessage = error.statusMessage || "Server Error";
-    // prettier-ignore
-    const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
-
-    if (statusCode === 404) {
-      const baseURL = import.meta.baseURL || "/";
-      if (/^\/[^/]/.test(baseURL) && !url.pathname.startsWith(baseURL)) {
-        return sendRedirect(
-          event,
-          `${baseURL}${url.pathname.slice(1)}${url.search}`
-        );
-      }
-    }
-
-    // Console output
-    if (isSensitive) {
-      // prettier-ignore
-      const tags = [error.unhandled && "[unhandled]", error.fatal && "[fatal]"].filter(Boolean).join(" ")
-      console.error(
-        `[request error] ${tags} [${event.method}] ${url}\n`,
-        error
-      );
-    }
-
-    // Send response
-    setSecurityHeaders(event, false /* no js */);
-    setResponseStatus(event, statusCode, statusMessage);
-    if (statusCode === 404 || !getResponseHeader(event, "cache-control")) {
-      setResponseHeader(event, "cache-control", "no-cache");
-    }
-    return send(
-      event,
-      JSON.stringify(
-        {
-          error: true,
-          url: url.href,
-          statusCode,
-          statusMessage,
-          message: isSensitive ? "Server Error" : error.message,
-          data: isSensitive ? undefined : error.data,
-        },
-        null,
-        2
-      ),
-      "application/json"
-    );
+    const res = defaultHandler(error, event);
+    setResponseHeaders(event, res.headers);
+    setResponseStatus(event, res.status, res.statusText);
+    return send(event, JSON.stringify(res.body, null, 2));
   }
 );
+
+export function defaultHandler(
+  error: H3Error,
+  event: H3Event,
+  opts?: { silent?: boolean; json?: boolean }
+) {
+  const isSensitive = error.unhandled || error.fatal;
+  const statusCode = error.statusCode || 500;
+  const statusMessage = error.statusMessage || "Server Error";
+  // prettier-ignore
+  const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
+
+  if (statusCode === 404) {
+    const baseURL = import.meta.baseURL || "/";
+    if (/^\/[^/]/.test(baseURL) && !url.pathname.startsWith(baseURL)) {
+      const redirectTo = `${baseURL}${url.pathname.slice(1)}${url.search}`;
+      return {
+        status: 302,
+        headers: { location: redirectTo },
+        body: `Redirecting...`,
+      };
+    }
+  }
+
+  // Console output
+  if (isSensitive && !opts?.silent) {
+    // prettier-ignore
+    const tags = [error.unhandled && "[unhandled]", error.fatal && "[fatal]"].filter(Boolean).join(" ")
+    console.error(`[request error] ${tags} [${event.method}] ${url}\n`, error);
+  }
+
+  // Send response
+  const headers: HeadersInit = {
+    "content-type": "application/json",
+    // Prevent browser from guessing the MIME types of resources.
+    "x-content-type-options": "nosniff",
+    // Prevent error page from being embedded in an iframe
+    "x-frame-options": "DENY",
+    // Prevent browsers from sending the Referer header
+    "referrer-policy": "no-referrer",
+    // Disable the execution of any js
+    "content-security-policy": "script-src 'none'; frame-ancestors 'none';",
+  };
+  setResponseStatus(event, statusCode, statusMessage);
+  if (statusCode === 404 || !getResponseHeader(event, "cache-control")) {
+    headers["cache-control"] = "no-cache";
+  }
+
+  const body = {
+    error: true,
+    url: url.href,
+    statusCode,
+    statusMessage,
+    message: isSensitive ? "Server Error" : error.message,
+    data: isSensitive ? undefined : error.data,
+  };
+
+  return {
+    status: statusCode,
+    statusText: statusMessage,
+    headers,
+    body,
+  } satisfies Omit<ResponseInit, "body"> & {
+    body: string | Record<string, any>;
+  };
+}

--- a/src/runtime/internal/error/utils.ts
+++ b/src/runtime/internal/error/utils.ts
@@ -1,31 +1,7 @@
 import type { NitroErrorHandler } from "nitropack/types";
-import type { H3Event } from "h3";
-import { getRequestHeader, setResponseHeaders } from "h3";
 
 export function defineNitroErrorHandler(
   handler: NitroErrorHandler
 ): NitroErrorHandler {
   return handler;
-}
-
-export function setSecurityHeaders(event: H3Event, allowjs = false) {
-  setResponseHeaders(event, {
-    // Prevent browser from guessing the MIME types of resources.
-    "X-Content-Type-Options": "nosniff",
-    // Prevent error page from being embedded in an iframe
-    "X-Frame-Options": "DENY",
-    // Prevent browsers from sending the Referer header
-    "Referrer-Policy": "no-referrer",
-    // Disable the execution of any js
-    "Content-Security-Policy": allowjs
-      ? "script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self';"
-      : "script-src 'none'; frame-ancestors 'none';",
-  });
-}
-
-function hasReqHeader(event: H3Event, name: string, includes: string) {
-  const value = getRequestHeader(event, name);
-  return (
-    value && typeof value === "string" && value.toLowerCase().includes(includes)
-  );
 }

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -67,5 +67,14 @@ export interface NitroDevEventHandler {
 
 export type NitroErrorHandler = (
   error: H3Error,
-  event: H3Event
+  event: H3Event,
+  _: {
+    defaultHandler: (
+      error: H3Error,
+      event: H3Event,
+      opts?: { silent?: boolean; json?: boolean }
+    ) => Omit<ResponseInit, "body"> & {
+      body: string | Record<string, any>;
+    };
+  }
 ) => void | Promise<void>;

--- a/test/fixture/error.ts
+++ b/test/fixture/error.ts
@@ -1,5 +1,10 @@
-export default defineNitroErrorHandler((error, event) => {
-  if (event.path.includes("?custom_error_handler")) {
-    return send(event, "custom_error_handler");
+import { defineNitroErrorHandler } from "nitropack/runtime";
+import { send } from "h3";
+export default defineNitroErrorHandler(
+  async (error, event, { defaultHandler }) => {
+    if (event.path.includes("?json")) {
+      const response = await defaultHandler(error, event, { json: true });
+      return send(event, JSON.stringify({ json: response.body }, null, 2));
+    }
   }
-});
+);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -396,10 +396,10 @@ export function testNitro(
     });
 
     const { data } = await callHandler({
-      url: "/api/error?custom_error_handler",
+      url: "/api/error?json",
     });
     expect(status).toBe(503);
-    expect(data).toBe("custom_error_handler");
+    expect(data.json.error).toBe(true);
   });
 
   it.skipIf(isWindows && ctx.preset === "nitro-dev")(


### PR DESCRIPTION
This is really a feature introduced as a refactor mainly to allow frameworks conditionally use nitro default error handler without fallback method.

With this PR, custom `errorHandler` can get result of built-in handler for custom response handling.

**Example:**

export default defineNitroErrorHandler(
  async (error, event, { defaultHandler }) => {
    if (event.path.includes("?json")) {
      const response = await defaultHandler(error, event, { json: true });
      return send(event, JSON.stringify({ json: response.body }, null, 2));
    }
  }
);


> [!IMPORTANT]
> Behavior with Nitro v3 is likely to change to return a `Response` instead an object.

