### PR TITLE
fix(dev): auto fallback to port if socket listening failed

### DIFF
--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -108,7 +108,6 @@ function listen(
     try {
       listener = server.listen(useRandomPort ? 0 : getSocketAddress(), () => {
         const address = server.address();
-        console.log(address);
         parentPort?.postMessage({
           event: "listen",
           address:

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -41,7 +41,7 @@ listen()
   .catch(() => listen(true /* use random port */))
   // eslint-disable-next-line unicorn/prefer-top-level-await
   .catch((error) => {
-    console.error("Failed to listen on any port", error);
+    console.error("Dev worker failed to listen:", error);
     return shutdown();
   });
 

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -91,7 +91,7 @@ async function shutdown() {
   parentPort?.postMessage({ event: "exit" });
 }
 
-parentPort?.on("message", async (msg) => {
+parentPort?.on("message", (msg) => {
   if (msg && msg.event === "shutdown") {
     shutdown();
   }

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -126,9 +126,6 @@ function listen(
 function getSocketAddress() {
   const socketName = `worker-${process.pid}-${threadId}-${Math.round(Math.random() * 10_000)}-${NITRO_DEV_WORKER_ID}.sock`;
   const socketPath = join(NITRO_DEV_WORKER_DIR, socketName);
-  if (Math.random() > 0.5) {
-    throw new Error("Random error");
-  }
   switch (process.platform) {
     case "win32": {
       return join(String.raw`\\.\pipe\nitro`, socketPath);


### PR DESCRIPTION
For hardly reproducing issues (found from nuxt CIs), listening to the socket can fail. This PR adds a auto fallback to dev worker listener to use port if first socket try failed.

Also refactoring general order in logic for dev worker entry