### PR TITLE
fix(dev): polyfill `globalThis.crypto` for Node.js 18

### DIFF
--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -6,6 +6,7 @@ import { startScheduleRunner } from "nitropack/runtime/internal";
 import { scheduledTasks, tasks } from "#nitro-internal-virtual/tasks";
 import { Server } from "node:http";
 import { join } from "node:path";
+import nodeCrypto from "node:crypto";
 import { parentPort, threadId } from "node:worker_threads";
 import wsAdapter from "crossws/adapters/node";
 import {
@@ -15,6 +16,11 @@ import {
   readBody,
   toNodeListener,
 } from "h3";
+
+// globalThis.crypto support for Node.js 18
+if (!globalThis.crypto) {
+  globalThis.crypto = nodeCrypto as unknown as Crypto;
+}
 
 const {
   NITRO_NO_UNIX_SOCKET,


### PR DESCRIPTION
Node.js <= 18 does not have `globalThis.crypto`. Nitro 2.x supports Node.js 18 and as ecosystem is shifting to 20+, we might face more issues (Youch needs it and crossWS will likely need it too)