### PR TITLE
fix(cli): add `globalThis.crypto` polyfill for Node.js 18

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,3 +1,4 @@
+import nodeCrypto from "node:crypto";
 import { defineCommand } from "citty";
 import type { DateString } from "compatx";
 import {
@@ -9,6 +10,11 @@ import {
 } from "nitropack/core";
 import { resolve } from "pathe";
 import { commonArgs } from "../common";
+
+// globalThis.crypto support for Node.js 18
+if (!globalThis.crypto) {
+  globalThis.crypto = nodeCrypto as unknown as Crypto;
+}
 
 export default defineCommand({
   meta: {

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -1,3 +1,4 @@
+import nodeCrypto from "node:crypto";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 import { getArgs, parseArgs } from "listhen/cli";
@@ -7,6 +8,11 @@ import { resolve } from "pathe";
 import { commonArgs } from "../common";
 
 const hmrKeyRe = /^runtimeConfig\.|routeRules\./;
+
+// globalThis.crypto support for Node.js 18
+if (!globalThis.crypto) {
+  globalThis.crypto = nodeCrypto as unknown as Crypto;
+}
 
 export default defineCommand({
   meta: {


### PR DESCRIPTION
Followup on #3166

As Node.js 18 getting EOL and more dependencies might depend on `globalThis.crypto`, this PR ensures more backward compatibility with CLI build time env.