### PR TITLE
fix(dev): polyfill `globalThis.crypto` for Node.js 18

### DIFF
--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -9,6 +9,7 @@ import {
   setResponseHeaders,
   setResponseStatus,
 } from "h3";
+import nodeCrypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
@@ -94,6 +95,11 @@ export async function defaultHandler(
   };
   if (statusCode === 404 || !getResponseHeader(event, "cache-control")) {
     headers["cache-control"] = "no-cache";
+  }
+
+  // Crypto polyfill for Node.18 (used by youch > @poppinss+dumper)
+  if (!globalThis.crypto && !useJSON) {
+    globalThis.crypto = nodeCrypto as unknown as Crypto;
   }
 
   // Prepare body


### PR DESCRIPTION
Followup https://github.com/nitrojs/nitro/pull/3166, https://github.com/nitrojs/nitro/pull/3167

Youch used in dev error handler requires `globalThis.crypto` to generate HTML template (nanoid() for tag ids)

While previous PRs fix both dev worker and nitro CLI, any external programmatic usage of Nitro with Node.js 18 can fail for non worker errors (dev server or syntax/build errors). This PR covers this part.