### PR TITLE
build: inline youch dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
         with:
           deno-version: v2.x
       - run: pnpm install
+      - run: pnpm build
       - run: pnpm test:types
         if: ${{ matrix.os != 'windows-latest' }}
-      - run: pnpm build
       - run: pnpm vitest --coverage
         env:
           NODE_OPTIONS: --experimental-vm-modules --enable-source-maps

--- a/build.config.ts
+++ b/build.config.ts
@@ -55,7 +55,7 @@ export default defineBuildConfig({
         );
       }
     },
-    async "build:done"(ctx) {
+    async "rollup:done"(ctx) {
       await buildYouch();
     },
   },

--- a/build.config.ts
+++ b/build.config.ts
@@ -3,8 +3,13 @@ import { fileURLToPath } from "node:url";
 import { resolve } from "pathe";
 import { normalize } from "pathe";
 import { defineBuildConfig } from "unbuild";
+import { build } from "esbuild";
+import { cp } from "node:fs/promises";
+import { readPackageJSON } from "pkg-types";
 
 const srcDir = fileURLToPath(new URL("src", import.meta.url));
+
+const ver = (id: string) => readPackageJSON(id).then((m) => m.version);
 
 export const subpaths = [
   "cli",
@@ -50,6 +55,9 @@ export default defineBuildConfig({
         );
       }
     },
+    async "build:done"(ctx) {
+      await buildYouch();
+    },
   },
   externals: [
     "nitro",
@@ -86,3 +94,31 @@ export default defineBuildConfig({
     },
   },
 });
+
+async function buildYouch() {
+  await build({
+    stdin: {
+      contents: /* js */ `export { Youch } from "youch"; export { ErrorParser } from "youch-core";`,
+      resolveDir: process.cwd(),
+    },
+    banner: {
+      js: [
+        "Copyright (c) virk.officials@gmail.com",
+        `Bundled https://github.com/poppinss/youch ${await ver("youch")} (MIT)`,
+        `Bundled https://github.com/poppinss/youch-core ${await ver("youch-core")} (MIT)`,
+      ]
+        .map((line) => `// ${line}`)
+        .join("\n"),
+    },
+    bundle: true,
+    outfile: "dist/deps/youch/youch.mjs",
+    platform: "node",
+    target: "esnext",
+    format: "esm",
+    legalComments: "inline",
+    minifyWhitespace: true,
+  });
+
+  const youchDir = new URL("public", import.meta.resolve("youch"));
+  await cp(youchDir, "dist/deps/youch/public", { recursive: true });
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "nitrojs/nitro",
   "license": "MIT",
   "type": "module",
+  "imports": {
+    "#deps/youch": "./dist/deps/youch/youch.mjs"
+  },
   "exports": {
     "./cli": {
       "types": "./cli.d.ts",
@@ -169,9 +172,7 @@
     "unplugin-utils": "^0.2.4",
     "unstorage": "^1.15.0",
     "untyped": "^2.0.0",
-    "unwasm": "^0.3.9",
-    "youch": "4.1.0-beta.5",
-    "youch-core": "^0.3.1"
+    "unwasm": "^0.3.9"
   },
   "devDependencies": {
     "@azure/functions": "^3.5.1",
@@ -207,7 +208,9 @@
     "unbuild": "^3.5.0",
     "undici": "^7.4.0",
     "vitest": "^3.0.7",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "youch": "4.1.0-beta.5",
+    "youch-core": "^0.3.1"
   },
   "peerDependencies": {
     "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "repository": "nitrojs/nitro",
   "license": "MIT",
   "type": "module",
-  "imports": {
-    "#deps/youch": "./dist/deps/youch/youch.mjs"
-  },
   "exports": {
     "./cli": {
       "types": "./cli.d.ts",
@@ -65,6 +62,7 @@
       "types": "./types.d.ts",
       "import": "./dist/types/index.mjs"
     },
+    "./internal/deps/youch": "./dist/deps/youch/youch.mjs",
     "./package.json": "./package.json"
   },
   "main": "./dist/core/index.mjs",

--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,3 +1,3 @@
 export default eventHandler(async (event) => {
-  return foo.bar;
+  return {};
 });

--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,3 +1,3 @@
 export default eventHandler(async (event) => {
-  return {};
+  return foo.bar;
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,12 +227,6 @@ importers:
       unwasm:
         specifier: ^0.3.9
         version: 0.3.9
-      youch:
-        specifier: 4.1.0-beta.5
-        version: 4.1.0-beta.5
-      youch-core:
-        specifier: ^0.3.1
-        version: 0.3.1
     devDependencies:
       '@azure/functions':
         specifier: ^3.5.1
@@ -336,6 +330,12 @@ importers:
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
+      youch:
+        specifier: 4.1.0-beta.5
+        version: 4.1.0-beta.5
+      youch-core:
+        specifier: ^0.3.1
+        version: 0.3.1
 
   examples/api-routes:
     devDependencies:

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -12,7 +12,8 @@ import {
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
-import { Youch, ErrorParser } from "#deps/youch";
+import * as _youch from "#deps/youch";
+import type { ErrorParser } from "youch-core";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
 
@@ -59,7 +60,7 @@ export async function defaultHandler(
   await loadStackTrace(error).catch(consola.error);
 
   // https://github.com/poppinss/youch
-  const youch = new Youch();
+  const youch = new _youch.Youch();
 
   // Console output
   if (isSensitive && !opts?.silent) {
@@ -128,7 +129,7 @@ export async function loadStackTrace(error: any) {
   if (!(error instanceof Error)) {
     return;
   }
-  const parsed = await new ErrorParser()
+  const parsed = await new _youch.ErrorParser()
     .defineSourceLoader(sourceLoader)
     .parse(error);
 

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -12,8 +12,7 @@ import {
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
-import { ErrorParser } from "youch-core";
-import { Youch } from "#deps/youch";
+import { Youch, ErrorParser } from "#deps/youch";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
 

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -13,7 +13,7 @@ import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
 import { ErrorParser } from "youch-core";
-import { Youch } from "youch";
+import { Youch } from "#deps/youch";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
 

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -12,7 +12,7 @@ import {
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
-import * as _youch from "#deps/youch";
+import * as _youch from "nitropack/internal/deps/youch";
 import type { ErrorParser } from "youch-core";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";


### PR DESCRIPTION
Because youch 4.x requires Node.js 18 (by engines field), having it as dependency makes ecosystem issues and requiring requires `--no-engine-checks` for Node.js 18 support (even tough we add required runtime polyfill #3168)

(Note: This is only for Nitro v2 backward compact. Nitro v3 will be back to normal dep)