### PR TITLE
build: use `youch-redist`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
         with:
           deno-version: v2.x
       - run: pnpm install
-      - run: pnpm build
       - run: pnpm test:types
         if: ${{ matrix.os != 'windows-latest' }}
+      - run: pnpm build
       - run: pnpm vitest --coverage
         env:
           NODE_OPTIONS: --experimental-vm-modules --enable-source-maps

--- a/build.config.ts
+++ b/build.config.ts
@@ -63,7 +63,6 @@ export default defineBuildConfig({
     "nitro",
     "nitropack",
     "nitropack/runtime/meta",
-    "nitropack/internal/deps/youch",
     ...subpaths.map((subpath) => `nitropack/${subpath}`),
     "firebase-functions",
     "@scalar/api-reference",

--- a/build.config.ts
+++ b/build.config.ts
@@ -3,13 +3,8 @@ import { fileURLToPath } from "node:url";
 import { resolve } from "pathe";
 import { normalize } from "pathe";
 import { defineBuildConfig } from "unbuild";
-import { build } from "esbuild";
-import { cp } from "node:fs/promises";
-import { readPackageJSON } from "pkg-types";
 
 const srcDir = fileURLToPath(new URL("src", import.meta.url));
-
-const ver = (id: string) => readPackageJSON(id).then((m) => m.version);
 
 export const subpaths = [
   "cli",
@@ -55,9 +50,6 @@ export default defineBuildConfig({
         );
       }
     },
-    async "rollup:done"(ctx) {
-      await buildYouch();
-    },
   },
   externals: [
     "nitro",
@@ -94,31 +86,3 @@ export default defineBuildConfig({
     },
   },
 });
-
-async function buildYouch() {
-  await build({
-    stdin: {
-      contents: /* js */ `export { Youch } from "youch"; export { ErrorParser } from "youch-core";`,
-      resolveDir: process.cwd(),
-    },
-    banner: {
-      js: [
-        "Copyright (c) virk.officials@gmail.com",
-        `Bundled https://github.com/poppinss/youch ${await ver("youch")} (MIT)`,
-        `Bundled https://github.com/poppinss/youch-core ${await ver("youch-core")} (MIT)`,
-      ]
-        .map((line) => `// ${line}`)
-        .join("\n"),
-    },
-    bundle: true,
-    outfile: "dist/deps/youch/youch.mjs",
-    platform: "node",
-    target: "esnext",
-    format: "esm",
-    legalComments: "inline",
-    minifyWhitespace: true,
-  });
-
-  const youchDir = new URL("public", import.meta.resolve("youch"));
-  await cp(youchDir, "dist/deps/youch/public", { recursive: true });
-}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
       "types": "./types.d.ts",
       "import": "./dist/types/index.mjs"
     },
-    "./internal/deps/youch": "./dist/deps/youch/youch.mjs",
     "./package.json": "./package.json"
   },
   "main": "./dist/core/index.mjs",
@@ -170,7 +169,9 @@
     "unplugin-utils": "^0.2.4",
     "unstorage": "^1.15.0",
     "untyped": "^2.0.0",
-    "unwasm": "^0.3.9"
+    "unwasm": "^0.3.9",
+    "youch": "4.1.0-beta.5",
+    "youch-core": "^0.3.1"
   },
   "devDependencies": {
     "@azure/functions": "^3.5.1",
@@ -206,9 +207,7 @@
     "unbuild": "^3.5.0",
     "undici": "^7.4.0",
     "vitest": "^3.0.7",
-    "xml2js": "^0.6.2",
-    "youch": "4.1.0-beta.5",
-    "youch-core": "^0.3.1"
+    "xml2js": "^0.6.2"
   },
   "peerDependencies": {
     "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -170,8 +170,7 @@
     "unstorage": "^1.15.0",
     "untyped": "^2.0.0",
     "unwasm": "^0.3.9",
-    "youch": "4.1.0-beta.5",
-    "youch-core": "^0.3.1"
+    "youch-redist": "4.1.0-beta.5-1"
   },
   "devDependencies": {
     "@azure/functions": "^3.5.1",
@@ -207,7 +206,9 @@
     "unbuild": "^3.5.0",
     "undici": "^7.4.0",
     "vitest": "^3.0.7",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "youch": "^4.1.0-beta.5",
+    "youch-core": "^0.3.1"
   },
   "peerDependencies": {
     "xml2js": "^0.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,12 +227,9 @@ importers:
       unwasm:
         specifier: ^0.3.9
         version: 0.3.9
-      youch:
-        specifier: 4.1.0-beta.5
-        version: 4.1.0-beta.5
-      youch-core:
-        specifier: ^0.3.1
-        version: 0.3.1
+      youch-redist:
+        specifier: 4.1.0-beta.5-1
+        version: 4.1.0-beta.5-1
     devDependencies:
       '@azure/functions':
         specifier: ^3.5.1
@@ -336,6 +333,12 @@ importers:
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
+      youch:
+        specifier: ^4.1.0-beta.5
+        version: 4.1.0-beta.5
+      youch-core:
+        specifier: ^0.3.1
+        version: 0.3.1
 
   examples/api-routes:
     devDependencies:
@@ -5896,6 +5899,9 @@ packages:
   youch-core@0.3.1:
     resolution: {integrity: sha512-KOAmtABz17fgK+uBBJYIzaPpIgX+JgTRgY4t3zXH18akc5rRtFkRmcNTMCuSxLdbOJDY9+T/O3nyA/EQuN4EWA==}
     engines: {node: '>=20.6.0'}
+
+  youch-redist@4.1.0-beta.5-1:
+    resolution: {integrity: sha512-IlNgclEfelti10dh7yzGfQxhowEasVPr4zEN/At+uOzfWv74HiRx2Uz4gyvCRcez0dk1PDerl5aQhKxUKXKClg==}
 
   youch@3.2.3:
     resolution: {integrity: sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==}
@@ -12218,6 +12224,8 @@ snapshots:
     dependencies:
       '@poppinss/exception': 1.2.0
       error-stack-parser-es: 0.1.5
+
+  youch-redist@4.1.0-beta.5-1: {}
 
   youch@3.2.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,12 @@ importers:
       unwasm:
         specifier: ^0.3.9
         version: 0.3.9
+      youch:
+        specifier: 4.1.0-beta.5
+        version: 4.1.0-beta.5
+      youch-core:
+        specifier: ^0.3.1
+        version: 0.3.1
     devDependencies:
       '@azure/functions':
         specifier: ^3.5.1
@@ -330,12 +336,6 @@ importers:
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
-      youch:
-        specifier: 4.1.0-beta.5
-        version: 4.1.0-beta.5
-      youch-core:
-        specifier: ^0.3.1
-        version: 0.3.1
 
   examples/api-routes:
     devDependencies:

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -13,8 +13,8 @@ import nodeCrypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
-import * as _youch from "nitropack/internal/deps/youch";
-import type { ErrorParser } from "youch-core";
+import { ErrorParser } from "youch-core";
+import { Youch } from "youch";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
 
@@ -61,7 +61,7 @@ export async function defaultHandler(
   await loadStackTrace(error).catch(consola.error);
 
   // https://github.com/poppinss/youch
-  const youch = new _youch.Youch();
+  const youch = new Youch();
 
   // Console output
   if (isSensitive && !opts?.silent) {
@@ -135,7 +135,7 @@ export async function loadStackTrace(error: any) {
   if (!(error instanceof Error)) {
     return;
   }
-  const parsed = await new _youch.ErrorParser()
+  const parsed = await new ErrorParser()
     .defineSourceLoader(sourceLoader)
     .parse(error);
 

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -13,10 +13,17 @@ import nodeCrypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
-import { ErrorParser } from "youch-core";
-import { Youch } from "youch";
+import type { ErrorParser as ErrorParserT } from "youch-core";
+import type { Youch as YouchT } from "youch";
+// @ts-ignore
+import * as _youch from "youch-redist";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
+
+const { Youch, ErrorParser } = _youch as {
+  Youch: { new (): YouchT };
+  ErrorParser: { new (): ErrorParserT };
+};
 
 export default defineNitroErrorHandler(
   async function defaultNitroErrorHandler(error, event) {
@@ -151,7 +158,7 @@ export async function loadStackTrace(error: any) {
   }
 }
 
-type SourceLoader = Parameters<ErrorParser["defineSourceLoader"]>[0];
+type SourceLoader = Parameters<ErrorParserT["defineSourceLoader"]>[0];
 type StackFrame = Parameters<SourceLoader>[0];
 async function sourceLoader(frame: StackFrame) {
   if (!frame.fileName || frame.fileType !== "fs" || frame.type === "native") {


### PR DESCRIPTION
rework of #3169 with the diffrence of using external/temporary [youch-redist](https://github.com/pi0/youch-redist)

The reason is that Nuxt has a bug when it fails nitro builds when nitro tries to import another of it's internal. fixed by https://github.com/nuxt/nuxt/pull/31246 but older nuxt versions have problem so...