### PR TITLE
types: mark `$global` optional for `NitroRouteMeta`

### DIFF
--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -7,7 +7,7 @@ type MaybeArray<T> = T | T[];
 /** @exprerimental */
 export interface NitroRouteMeta {
   openAPI?: OperationObject & {
-    $global: Pick<OpenAPI3, "components">;
+    $global?: Pick<OpenAPI3, "components">;
   };
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro/issues/3173

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Make $global optional for openAPI route meta so apps upgrading from niro 2.10 to 2.11 don't get typecheck to fail.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
