### PR TITLE
build: use upstream `youch` back

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
     "unstorage": "^1.15.0",
     "untyped": "^2.0.0",
     "unwasm": "^0.3.9",
-    "youch-redist": "4.1.0-beta.5-1"
+    "youch": "^4.1.0-beta.6",
+    "youch-core": "^0.3.1"
   },
   "devDependencies": {
     "@azure/functions": "^3.5.1",
@@ -206,9 +207,7 @@
     "unbuild": "^3.5.0",
     "undici": "^7.4.0",
     "vitest": "^3.0.7",
-    "xml2js": "^0.6.2",
-    "youch": "^4.1.0-beta.5",
-    "youch-core": "^0.3.1"
+    "xml2js": "^0.6.2"
   },
   "peerDependencies": {
     "xml2js": "^0.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,9 +227,12 @@ importers:
       unwasm:
         specifier: ^0.3.9
         version: 0.3.9
-      youch-redist:
-        specifier: 4.1.0-beta.5-1
-        version: 4.1.0-beta.5-1
+      youch:
+        specifier: ^4.1.0-beta.6
+        version: 4.1.0-beta.6
+      youch-core:
+        specifier: ^0.3.1
+        version: 0.3.1
     devDependencies:
       '@azure/functions':
         specifier: ^3.5.1
@@ -333,12 +336,6 @@ importers:
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
-      youch:
-        specifier: ^4.1.0-beta.5
-        version: 4.1.0-beta.5
-      youch-core:
-        specifier: ^0.3.1
-        version: 0.3.1
 
   examples/api-routes:
     devDependencies:
@@ -1319,8 +1316,8 @@ packages:
     resolution: {integrity: sha512-FA+nTU8p6OcSH4tLDY5JilGYr1bVWHpNmcLr7xmMEdbWmKHa+3QZ+DqefrXKmdjO/brHTnQZo20lLSjaO7ydog==}
     engines: {node: '>=18.16.0'}
 
-  '@poppinss/dumper@0.6.2':
-    resolution: {integrity: sha512-FhE9rY15aZ6Qp6ltQ0NZjseVRhwgWZ7+sg16343FqnjdUQvvBBi5eSeH/aZA4LF1ZOV5779DYrJXTHT42JlHNg==}
+  '@poppinss/dumper@0.6.3':
+    resolution: {integrity: sha512-iombbn8ckOixMtuV1p3f8jN6vqhXefNjJttoPaJDMeIk/yIGhkkL3OrHkEjE9SRsgoAx1vBUU2GtgggjvA5hCA==}
 
   '@poppinss/exception@1.2.0':
     resolution: {integrity: sha512-WLneXKQYNClhaMXccO111VQmZahSrcSRDaHRbV6KL5R4pTvK87fMn/MXLUcvOjk0X5dTHDPKF61tM7j826wrjQ==}
@@ -5900,15 +5897,12 @@ packages:
     resolution: {integrity: sha512-KOAmtABz17fgK+uBBJYIzaPpIgX+JgTRgY4t3zXH18akc5rRtFkRmcNTMCuSxLdbOJDY9+T/O3nyA/EQuN4EWA==}
     engines: {node: '>=20.6.0'}
 
-  youch-redist@4.1.0-beta.5-1:
-    resolution: {integrity: sha512-IlNgclEfelti10dh7yzGfQxhowEasVPr4zEN/At+uOzfWv74HiRx2Uz4gyvCRcez0dk1PDerl5aQhKxUKXKClg==}
-
   youch@3.2.3:
     resolution: {integrity: sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==}
 
-  youch@4.1.0-beta.5:
-    resolution: {integrity: sha512-92+bvKtAjm18S2o+IP0aLBpLtzY332Ji9geNLp07cLgHsK3aHVjWrg2eyE5LIKMv6j+GWu+Ehx4My7BTXxMbsA==}
-    engines: {node: '>=20.6.0'}
+  youch@4.1.0-beta.6:
+    resolution: {integrity: sha512-y1aNsEeoLXnWb6pI9TvfNPIxySyo4Un3OGxKn7rsNj8+tgSquzXEWkzfA5y6gU0fvzmQgvx3JBn/p51qQ8Xg9A==}
+    engines: {node: '>=18'}
 
   zhead@2.2.4:
     resolution: {integrity: sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==}
@@ -6878,7 +6872,7 @@ snapshots:
     dependencies:
       kleur: 4.1.5
 
-  '@poppinss/dumper@0.6.2':
+  '@poppinss/dumper@0.6.3':
     dependencies:
       '@poppinss/colors': 4.1.4
       '@sindresorhus/is': 7.0.1
@@ -12225,17 +12219,15 @@ snapshots:
       '@poppinss/exception': 1.2.0
       error-stack-parser-es: 0.1.5
 
-  youch-redist@4.1.0-beta.5-1: {}
-
   youch@3.2.3:
     dependencies:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  youch@4.1.0-beta.5:
+  youch@4.1.0-beta.6:
     dependencies:
-      '@poppinss/dumper': 0.6.2
+      '@poppinss/dumper': 0.6.3
       '@speed-highlight/core': 1.2.7
       cookie: 1.0.2
       youch-core: 0.3.1

--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -13,17 +13,10 @@ import nodeCrypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import consola from "consola";
-import type { ErrorParser as ErrorParserT } from "youch-core";
-import type { Youch as YouchT } from "youch";
-// @ts-ignore
-import * as _youch from "youch-redist";
+import { ErrorParser } from "youch-core";
+import { Youch } from "youch";
 import { SourceMapConsumer } from "source-map";
 import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
-
-const { Youch, ErrorParser } = _youch as {
-  Youch: { new (): YouchT };
-  ErrorParser: { new (): ErrorParserT };
-};
 
 export default defineNitroErrorHandler(
   async function defaultNitroErrorHandler(error, event) {
@@ -158,7 +151,7 @@ export async function loadStackTrace(error: any) {
   }
 }
 
-type SourceLoader = Parameters<ErrorParserT["defineSourceLoader"]>[0];
+type SourceLoader = Parameters<ErrorParser["defineSourceLoader"]>[0];
 type StackFrame = Parameters<SourceLoader>[0];
 async function sourceLoader(frame: StackFrame) {
   if (!frame.fileName || frame.fileType !== "fs" || frame.type === "native") {


### PR DESCRIPTION
With upstream fix (https://github.com/poppinss/youch/pull/69) in youch 4 beta.6 we no longer need temporary redist 🎊 

