### PR TITLE
fix(dev): use abstract sockets on linux with node.js >=20

### DIFF
--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -123,7 +123,7 @@ function getSocketAddress() {
   const socketName = `nitro-worker-${process.pid}-${threadId}-${NITRO_DEV_WORKER_ID}-${Math.round(Math.random() * 10_000)}.sock`;
   // Windows: pipe
   if (process.platform === "win32") {
-    return join(String.raw`\\.\pipe`, NITRO_DEV_WORKER_DIR, socketName);
+    return join(String.raw`\\.\pipe`, socketName);
   }
   // Linux: abstract namespace
   if (process.platform === "linux") {

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -120,18 +120,20 @@ function listen(
 }
 
 function getSocketAddress() {
-  const socketName = `worker-${process.pid}-${threadId}-${Math.round(Math.random() * 10_000)}-${NITRO_DEV_WORKER_ID}.sock`;
+  const socketName = `nitro-worker-${process.pid}-${threadId}-${NITRO_DEV_WORKER_ID}-${Math.round(Math.random() * 10_000)}.sock`;
   // Windows: pipe
-  const socketPath = join(NITRO_DEV_WORKER_DIR, socketName);
   if (process.platform === "win32") {
-    return join(String.raw`\\.\pipe\nitro`, socketPath);
+    return join(String.raw`\\.\pipe\nitro`, NITRO_DEV_WORKER_DIR, socketName);
   }
   // Linux: abstract namespace
-  if (process.platform === "linux" && !isCI) {
-    return `\0${socketPath}`;
+  if (process.platform === "linux") {
+    const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+    if (nodeMajor >= 20) {
+      return `\0${socketName}`;
+    }
   }
-  // MacOS and CI: Unix socket
-  return socketPath;
+  // Unix socket
+  return join(NITRO_DEV_WORKER_DIR, socketName);
 }
 
 async function shutdown() {

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -123,7 +123,7 @@ function getSocketAddress() {
   const socketName = `nitro-worker-${process.pid}-${threadId}-${NITRO_DEV_WORKER_ID}-${Math.round(Math.random() * 10_000)}.sock`;
   // Windows: pipe
   if (process.platform === "win32") {
-    return join(String.raw`\\.\pipe\nitro`, NITRO_DEV_WORKER_DIR, socketName);
+    return join(String.raw`\\.\pipe`, NITRO_DEV_WORKER_DIR, socketName);
   }
   // Linux: abstract namespace
   if (process.platform === "linux") {


### PR DESCRIPTION
Since 2.11 we have switched to abstract linux sockets to avoid filesystem related issues.

After (dozens of) trial and error, it seems a major behavior in Node.js between 18, 20 and 22 (first line filled with `@` (zero) is 18 which is completely broken, 20 slightly different and 22 working well)

This PR:
- Uses short abstract socket names in linux all the time to remove need of truncate in any level
- Only leverages abstract Socket for Node.js >= 20

before:

![image](https://github.com/user-attachments/assets/fb4bd35f-2273-4e2f-ab7a-5b676b0c8864)


after:

![image](https://github.com/user-attachments/assets/10eafd48-bd35-4a3f-a33e-96754b75b0c9)

windows pipes (while don't have limit like linux) are also simplified to be consistent:

![image](https://github.com/user-attachments/assets/3742c481-5422-42de-87a1-54ea7b4d1b3d)
