### PR TITLE
fix(dev): use os tmp dir for unix sockets

### DIFF
--- a/src/core/dev-server/worker.ts
+++ b/src/core/dev-server/worker.ts
@@ -91,7 +91,6 @@ export class NodeDevWorker implements DevWorker {
       env: {
         ...process.env,
         NITRO_DEV_WORKER_ID: String(this.#id),
-        NITRO_DEV_WORKER_DIR: this.#workerDir,
       },
     }) as Worker & { _exitCode?: number };
 

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -23,11 +23,7 @@ if (!globalThis.crypto) {
   globalThis.crypto = nodeCrypto as unknown as Crypto;
 }
 
-const {
-  NITRO_NO_UNIX_SOCKET,
-  NITRO_DEV_WORKER_DIR = ".",
-  NITRO_DEV_WORKER_ID,
-} = process.env;
+const { NITRO_NO_UNIX_SOCKET, NITRO_DEV_WORKER_ID } = process.env;
 
 // Trap unhandled errors
 trapUnhandledNodeErrors();

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -1,4 +1,5 @@
 import "#nitro-internal-pollyfills";
+import { tmpdir } from "node:os";
 import { useNitroApp } from "nitropack/runtime";
 import { runTask } from "nitropack/runtime";
 import { trapUnhandledNodeErrors } from "nitropack/runtime/internal";
@@ -9,7 +10,6 @@ import { join } from "node:path";
 import nodeCrypto from "node:crypto";
 import { parentPort, threadId } from "node:worker_threads";
 import wsAdapter from "crossws/adapters/node";
-import { isCI } from "std-env";
 import {
   defineEventHandler,
   getQuery,
@@ -133,7 +133,7 @@ function getSocketAddress() {
     }
   }
   // Unix socket
-  return join(NITRO_DEV_WORKER_DIR, socketName);
+  return join(tmpdir(), socketName);
 }
 
 async function shutdown() {


### PR DESCRIPTION
This PR essentially reverts #2997 fix for 2.11

issue was that, if one linux user stating a nitro server, it was creating `/tmp/nitro/` with permissions for that specific user and any other user would be blocked.

By moving socket to local build dir, we solved this issue but also introduced more possibilities that if permissions of build dir is bad, it causes more issues.

Since after iterations in 2.11, we are now generating an almost reliable unique socket name, we can use `/tmp/nitro-{name}.sock` instead.