### PR TITLE
fix(dev):  use port for bun on windows

### DIFF
--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -93,7 +93,9 @@ if (import.meta._tasks) {
 
 function listen(
   useRandomPort: boolean = Boolean(
-    NITRO_NO_UNIX_SOCKET || process.versions.webcontainer
+    NITRO_NO_UNIX_SOCKET ||
+      process.versions.webcontainer ||
+      ("Bun" in globalThis && process.platform === "win32")
   )
 ) {
   return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/31293

Bun added support for socket listeners, however seems buggy on windows only.