### PR TITLE
build!: minimum Node.js 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
   },
   "packageManager": "pnpm@10.3.0",
   "engines": {
-    "node": "^16.11.0 || >=17.0.0"
+    "node": ">=20.11.1"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
Node.js 18 is EOL in lass than 1 month and for long-term support for Nitro v3, it makes sense to require minimum Node.js 20 (if _runtime_ polyfills will be needed for ecosystem adoption, it will be provided, engines is a precaution)