### PR TITLE
docs(deno-server): add `compatibilityDate` note (#3190)

### DIFF
--- a/src/presets/cloudflare/runtime/_module-handler.ts
+++ b/src/presets/cloudflare/runtime/_module-handler.ts
@@ -123,14 +123,16 @@ export async function fetchHandler(
 
   return nitroApp.localFetch(url.pathname + url.search, {
     context: {
-      cf: (request as any).cf,
-      waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
-      cloudflare: {
-        request,
-        env,
-        context,
-        url,
-        ...ctxExt,
+      _platform: {
+        cf: (request as any).cf,
+        waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
+        cloudflare: {
+          request,
+          env,
+          context,
+          url,
+          ...ctxExt,
+        },
       },
     },
     host: url.hostname,

--- a/src/presets/cloudflare/runtime/cloudflare-pages.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-pages.ts
@@ -63,12 +63,14 @@ export default {
 
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
-        cf: request.cf,
-        waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
-        cloudflare: {
-          request,
-          env,
-          context,
+        _platform: {
+          cf: request.cf,
+          waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
+          cloudflare: {
+            request,
+            env,
+            context,
+          },
         },
       },
       host: url.hostname,

--- a/src/presets/cloudflare/runtime/cloudflare-worker.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-worker.ts
@@ -47,11 +47,13 @@ async function handleEvent(event: FetchEvent) {
 
   return nitroApp.localFetch(url.pathname + url.search, {
     context: {
-      // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
-      cf: (event.request as any).cf,
-      waitUntil: (promise: Promise<any>) => event.waitUntil(promise),
-      cloudflare: {
-        event,
+      _platform: {
+        // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
+        cf: (event.request as any).cf,
+        waitUntil: (promise: Promise<any>) => event.waitUntil(promise),
+        cloudflare: {
+          event,
+        },
       },
     },
     host: url.hostname,

--- a/src/presets/vercel/runtime/vercel-edge.ts
+++ b/src/presets/vercel/runtime/vercel-edge.ts
@@ -18,8 +18,10 @@ export default async function handleEvent(request: Request, event: any) {
     method: request.method,
     body,
     context: {
-      vercel: {
-        event,
+      _platform: {
+        vercel: {
+          event,
+        },
       },
     },
   });

--- a/src/presets/winterjs/runtime/winterjs.ts
+++ b/src/presets/winterjs/runtime/winterjs.ts
@@ -37,9 +37,11 @@ async function _handleEvent(event: FetchEvent) {
       body: event.request.body,
       headers: event.request.headers,
       context: {
-        waitUntil: (promise: Promise<any>) => event.waitUntil(promise),
-        winterjs: {
-          event,
+        _platform: {
+          waitUntil: (promise: Promise<any>) => event.waitUntil(promise),
+          winterjs: {
+            event,
+          },
         },
       },
     });

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -65,11 +65,10 @@ function createNitroApp(): NitroApp {
       event.context.nitro = event.context.nitro || { errors: [] };
 
       // Support platform context provided by local fetch
-      const envContext: { waitUntil?: H3Event["waitUntil"] } | undefined = (
-        event.node.req as unknown as { __unenv__: any }
-      )?.__unenv__;
-      if (envContext) {
-        Object.assign(event.context, envContext);
+      const platformContext: { waitUntil?: H3Event["waitUntil"] } | undefined =
+        (event.node.req as unknown as { __unenv__: any })?.__unenv__?._platform;
+      if (platformContext) {
+        Object.assign(event.context, platformContext);
       }
 
       // Assign bound fetch to context
@@ -200,8 +199,6 @@ function runNitroPlugins(nitroApp: NitroApp) {
     }
   }
 }
-
-export const nitroApp: NitroApp = createNitroApp();
 
 export function useNitroApp() {
   return nitroApp;


### PR DESCRIPTION
https://github.com/nuxt/nuxt/issues/31375

Fixing a regression (revealed) from #3155

When calling a fetch with a relative base URL in a server context, nitro uses an internal fetch mechanism without an actual network round trip. 

Event context has to be (partially) shared so that platform-specific contexts like `event.cf` and `event.waitUntil` are inherited and work. 

However, we should never share other contexts (including the cached value of the route rule that corresponds to the main event, not the sub-event). 

This PR fixes the root cause by only inheriting an internal namespace of the provider context.


(Note: this PR only targets v2 as direct fetch mechanism being updated with h3 v2 migration)
