### PR TITLE
fix(app): import user code last to avoid initialization order issues

### DIFF
--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -19,14 +19,16 @@ import {
   callNodeRequestHandler,
   type AbstractRequest,
 } from "node-mock-http";
-import errorHandler from "#nitro-internal-virtual/error-handler";
-import { plugins } from "#nitro-internal-virtual/plugins";
-import { handlers } from "#nitro-internal-virtual/server-handlers";
 import { cachedEventHandler } from "./cache";
 import { useRuntimeConfig } from "./config";
 import { nitroAsyncContext } from "./context";
 import { createRouteRulesHandler, getRouteRulesForPath } from "./route-rules";
 import { normalizeFetchResponse } from "./utils";
+
+// IMPORTANT: virtuals and user code should be imported last to avoid initialization order issues
+import errorHandler from "#nitro-internal-virtual/error-handler";
+import { plugins } from "#nitro-internal-virtual/plugins";
+import { handlers } from "#nitro-internal-virtual/server-handlers";
 
 function createNitroApp(): NitroApp {
   const config = useRuntimeConfig();


### PR DESCRIPTION
resolves #3225

If user code is not imported last, nitro app entry can partially import it's internals that will be added first to the rollup entry but won't be available until after user code. 

This can cause issues like `Error: Cannot access ... before initialization`