### PR TITLE
fix(dev): always throw proxy errors

### DIFF
--- a/src/dev/proxy.ts
+++ b/src/dev/proxy.ts
@@ -1,6 +1,6 @@
 import type { TLSSocket } from "node:tls";
 import type { ProxyServerOptions, ProxyServer } from "httpxy";
-import type { H3Event } from "h3";
+import { createError, type H3Event } from "h3";
 
 import { createProxyServer } from "httpxy";
 
@@ -36,9 +36,11 @@ export function createHTTPProxy(defaults: ProxyServerOptions = {}): HTTPProxy {
       event._handled = true;
       await proxy.web(event.node.req, event.node.res, opts);
     } catch (error: any) {
-      if (error?.code !== "ECONNRESET") {
-        throw error;
-      }
+      throw createError({
+        statusCode: 503,
+        message: "Proxy error.",
+        cause: error,
+      });
     }
   };
 

--- a/src/dev/proxy.ts
+++ b/src/dev/proxy.ts
@@ -36,9 +36,14 @@ export function createHTTPProxy(defaults: ProxyServerOptions = {}): HTTPProxy {
       event._handled = true;
       await proxy.web(event.node.req, event.node.res, opts);
     } catch (error: any) {
+      try {
+        event.node.res.setHeader("refresh", "3");
+      } catch {
+        // Ignore
+      }
       throw createError({
         statusCode: 503,
-        message: "Proxy error.",
+        message: "Dev server is unavailable.",
         cause: error,
       });
     }

--- a/src/dev/worker.ts
+++ b/src/dev/worker.ts
@@ -120,11 +120,10 @@ export class NodeDevWorker implements DevWorker {
     this.closed = true;
     this.#hooks.onClose?.(this, cause);
     this.#hooks = {};
-    await Promise.all(
-      [this.#closeProxy(), this.#closeSocket(), this.#closeWorker()].map((p) =>
-        p.catch((error) => consola.error(error))
-      )
-    );
+    const onError = (error: unknown) => consola.error(error);
+    await this.#closeWorker().catch(onError);
+    await this.#closeProxy().catch(onError);
+    await this.#closeSocket().catch(onError);
   }
 
   async #closeProxy() {


### PR DESCRIPTION
Nitro dev server can cause browser tabs to be stuck in case there is a proxy on top of it (docker or nuxt dev wrapper for example)

This PR fixes this problem by always propagation errors to upper layers instead of silently ignoring `ECONNRESET` into a pending state.

Also small fix that server is fully closed before destroying socket (could not find any diff just additional fix in case)