### PR TITLE
fix(aws-lambda): aws-lambda-streaming set-cookie headers

### DIFF
--- a/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
+++ b/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
@@ -7,10 +7,12 @@ import type {
 import "#nitro-internal-pollyfills";
 import { useNitroApp } from "nitropack/runtime";
 import {
+  normalizeCookieHeader,
   normalizeLambdaIncomingHeaders,
   normalizeLambdaOutgoingHeaders,
 } from "nitropack/runtime/internal";
 import { withQuery } from "ufo";
+import type { StreamingResponse } from "@netlify/functions";
 
 const nitroApp = useNitroApp();
 
@@ -40,8 +42,12 @@ export const handler = awslambda.streamifyResponse(
         ? Buffer.from(event.body || "", "base64").toString("utf8")
         : event.body,
     });
-    const httpResponseMetadata = {
+    const cookies = normalizeCookieHeader(r.headers["set-cookie"]);
+    const httpResponseMetadata: Omit<StreamingResponse, "body"> = {
       statusCode: r.status,
+      multiValueHeaders: {
+        "set-cookie": cookies,
+      },
       headers: {
         ...normalizeLambdaOutgoingHeaders(r.headers, true),
         "Transfer-Encoding": "chunked",


### PR DESCRIPTION
### 🔗 Linked issue

#3228 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `aws-lambda` preset with `awsLamba.streaming` option in `nitro.config.js` used a different handler from `aws-lambda` without streaming enabled. This other handler stripped cookies from the response headers, and did not add them back like the non-streaming handler did.

This PR fixes that behavior, such that aws-lambda-streaming builds will properly set cookies, which is very important for web frameworks like SolidStart and Tanstack Start who use nitro to support authentication in stream-enabled lambdas.

Resolves #3228

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
