### PR TITLE
feat(cloudflare): wrangler.json custom output dir

### DIFF
--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -46,6 +46,13 @@ export interface CloudflareOptions {
   deployConfig?: boolean;
 
   /**
+   * Specify directory where to put `wrangler.json` file.
+   *
+   * **NOTE:** This option is only effective if `deployConfig` is enabled.
+   */
+  deployConfigDir?: string;
+
+  /**
    * Enable native Node.js compatibility support.
    *
    * If this option disabled, pure unenv polyfills will be used instead.

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -250,8 +250,9 @@ export async function writeWranglerConfig(
   }
 
   // Compute path to generated wrangler.json
-  const wranglerConfigDir = nitro.options.output.serverDir;
-  const wranglerConfigPath = join(wranglerConfigDir, "wrangler.json");
+  const wranglerFileName = 'wrangler.json'
+  const wranglerConfigDir = nitro.options.cloudflare.deployConfigDir || nitro.options.rootDir;
+  const wranglerConfigPath = join(wranglerConfigDir, wranglerFileName);
 
   // Default configs
   const defaults: WranglerConfig = {};
@@ -345,18 +346,21 @@ export async function writeWranglerConfig(
     true
   );
 
-  const configPath = join(
-    nitro.options.rootDir,
-    ".wrangler/deploy/config.json"
-  );
-
-  await writeFile(
-    configPath,
-    JSON.stringify({
-      configPath: relative(dirname(configPath), wranglerConfigPath),
-    }),
-    true
-  );
+  if (wranglerConfigPath !== join(nitro.options.rootDir, wranglerFileName)) {
+    // The custom path is unnecessary if the file is in the root
+    const configPath = join(
+      nitro.options.rootDir,
+      ".wrangler/deploy/config.json"
+    );
+  
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        configPath: relative(dirname(configPath), wranglerConfigPath),
+      }),
+      true
+    );
+  }
 }
 
 async function generateWorkerName(nitro: Nitro) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro-cloudflare-dev/issues/57

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

- Related repo with issues:
    - Monorepo with Nuxt layers: https://github.com/serhii-chernenko/nuxt-layers-cloudflare?tab=readme-ov-file
    - Nuxt app: https://github.com/serhii-chernenko/falling-hall-643e?tab=readme-ov-file
- Fix PR: https://github.com/serhii-chernenko/falling-hall-643e/pull/1
- URL to preview: https://falling-hall-643e.pages.dev

The main issue is in destination of auto-generated `wrangler.json` file that available only in:
```bash
dist/_worker.js/wrangler.json
```
It could be automatically found for the commands like:
```bash
npx wrangler pages dev
npx wrangler pages deploy
```
But it could NOT be found for the command:
```
npx wrangler d1 migrations apply falling-hall-643e
```
![Image](https://github.com/user-attachments/assets/aeda30f3-2821-43b5-bfda-327911c5b6fd)
There are no errors, but also there are no any actions as well.

To fix it, I have to specify `wrangler.json` file path:
```
npx wrangler d1 migrations apply falling-hall-643e -c dist/_worker.js/wrangler.json
```
![Image](https://github.com/user-attachments/assets/2fbb5ce2-cab3-42fb-9ffc-57a206b8aac5)
But as you can see on the screen, it generates the state to
```
./dist/_worker.js/.wrangler/state/v3/d1
```
instead of
```
.wrangler/state/v3/d1
```
So, to make it working, I have to manually move it to the root dir
```
rm -rf .wrangler/state
mv dist/_worker.js/.wrangler/state .wrangler
```
I also tried to set the state path via `persistDir`
```ts
// nuxt.config.ts
nitro: {
  cloudflareDev: {
    configPath: 'dist/_worker.js/wrangler.json',
    persistDir: 'dist/_worker.js/.wrangler/state/v3', // this one
  },
},
```
But it's not the option, because the `dist` directory is recreated every time and I lose my state.
At least, I already know the nature of the recent issues. 

I'd suggest a solution for the Nitro repository:
Allow to specify `wrangler.json` path where it has to be generated. Not where it's located for `cloudflareDev` in the repository of [`nitro-cloudflare-dev`](https://github.com/nitrojs/nitro-cloudflare-dev/):

```ts
nitro: {
  preset: 'cloudflare-pages',
  cloudflare: {
    deployConfigPath: './' // it will be the root directory by default, no need to specify
  }
}
```
Because currently it depends on `serverDir`:
https://github.com/nitrojs/nitro/blob/v3/src/presets/cloudflare/utils.ts#L253C1-L254C71
```ts
const wranglerConfigDir = nitro.options.output.serverDir;
const wranglerConfigPath = join(wranglerConfigDir, "wrangler.json");
```

That's a reason why I created this PR. 

It allows to specify a nitro root dir as a directory where the `wrangler.json` file has to be located. It avoids usage of custom option `-c dist/_worker.js/wrangler.json` for commands `npx wrangler`. 
And, it solves the issue of saving state in the right root directory that won't be wiped every time on build.

### 📝 Checklist

- [x] I have linked an issue or discussion.
