### PR TITLE
fix(dev): conditionally set headers for error handler

### DIFF
--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -20,8 +20,10 @@ import { defineNitroErrorHandler, type InternalHandlerResponse } from "./utils";
 export default defineNitroErrorHandler(
   async function defaultNitroErrorHandler(error, event) {
     const res = await defaultHandler(error, event);
-    setResponseHeaders(event, res.headers!);
-    setResponseStatus(event, res.status, res.statusText);
+    if (!event.node?.res.headersSent) {
+      setResponseHeaders(event, res.headers!);
+      setResponseStatus(event, res.status, res.statusText);
+    }
     return send(
       event,
       typeof res.body === "string"


### PR DESCRIPTION
Context: https://github.com/nuxt/nuxt/issues/31478

Reproduction (strangely only reproducible against external repo -- tested on Node.js v22.14.0)

```ts
export default eventHandler(async (event) => {
  setHeader(event, "content-length", 1);
  return "Hello, world!";
});
```

When an internal error happens (in the case above wrong `content-length`), `node.res.headersSent` flag will be set and force closes with an error (that is likely related to the dev proxy layer)

This PR adds a hotfix for this situation.