### PR TITLE
fix(config): resolve `srcDir` relative to `rootDir`

### DIFF
--- a/src/config/resolvers/paths.ts
+++ b/src/config/resolvers/paths.ts
@@ -11,9 +11,8 @@ export async function resolvePathOptions(options: NitroOptions) {
   options.workspaceDir ||= await findWorkspaceDir(options.rootDir).catch(
     () => options.rootDir
   );
-  options.srcDir = resolve(options.srcDir || options.rootDir);
   for (const key of ["srcDir", "buildDir"] as const) {
-    options[key] = resolve(options.rootDir, options[key]);
+    options[key] = resolve(options.rootDir, options[key] || ".");
   }
 
   // Add aliases


### PR DESCRIPTION
issue revealed in playground after #2775

`srcDir` needs to be resolved relative to `rootDir`, we were previously wrongly resolving it from CWD which is most of the times same as rootDir unless running nitro commands from another dir.