### PR TITLE
refactor: allow setting `dotenv` config for `loadOptions`

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -97,7 +97,7 @@ async function _loadUserConfig(
   )({
     name: "nitro",
     cwd: configOverrides.rootDir,
-    dotenv: configOverrides.dev,
+    dotenv: opts.dotenv ?? configOverrides.dev,
     extend: { extendKey: ["extends", "preset"] },
     overrides: {
       ...configOverrides,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -288,7 +288,7 @@ export interface LoadConfigOptions {
   watch?: boolean;
   c12?: WatchConfigOptions;
   compatibilityDate?: CompatibilityDateSpec;
-  dotenv?: DotenvOptions;
+  dotenv?: boolean | DotenvOptions;
 }
 
 // ------------------------------------------------------------

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,5 +1,10 @@
 import type { RollupCommonJSOptions } from "@rollup/plugin-commonjs";
-import type { C12InputConfig, ConfigWatcher, ResolvedConfig } from "c12";
+import type {
+  C12InputConfig,
+  ConfigWatcher,
+  DotenvOptions,
+  ResolvedConfig,
+} from "c12";
 import type { WatchConfigOptions } from "c12";
 import type { ChokidarOptions } from "chokidar";
 import type { CompatibilityDateSpec, CompatibilityDates } from "compatx";
@@ -283,6 +288,7 @@ export interface LoadConfigOptions {
   watch?: boolean;
   c12?: WatchConfigOptions;
   compatibilityDate?: CompatibilityDateSpec;
+  dotenv?: DotenvOptions;
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
this allows configuring the location of the `.env` file, which is needed (for example) with nuxt's `--dotenv` argument. Otherwise, while Nuxt can load from `.env.production` (or similar), nitro will always load in the values from `.env` into `process.env`.

alternatively, it would be just as good to disable Nitro loading a `.env` file.

related: https://github.com/nuxt/cli/pull/381