### PR TITLE
fix(cludflare-module): respect `baseURL` for public output assets

### DIFF
--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -95,6 +95,9 @@ const cloudflareModule = defineNitroPreset(
   {
     extends: "base-worker",
     entry: "./runtime/cloudflare-module",
+    output: {
+      publicDir: "{{ output.dir }}/public/{{ baseURL }}",
+    },
     exportConditions: ["workerd"],
     commands: {
       preview: "npx wrangler --cwd ./ dev",


### PR DESCRIPTION
Assets generated to `.output/public` need to be prefixed with `baseURL`  for working deployment.