### PR TITLE
fix(cludflare-module): remove baseURL prefix from deploy config dir

### DIFF
--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -278,7 +278,13 @@ export async function writeWranglerConfig(
     );
     overrides.assets = {
       binding: "ASSETS",
-      directory: relative(wranglerConfigDir, nitro.options.output.publicDir),
+      directory: relative(
+        wranglerConfigDir,
+        resolve(
+          nitro.options.output.publicDir,
+          "..".repeat(nitro.options.baseURL.split("/").filter(Boolean).length)
+        )
+      ),
     };
   }
 


### PR DESCRIPTION
followup on #3280

We generate `.output/public/{baseURL}` but deploy config should point to `.output/public` itself to allow serving assets under baseURL