### PR TITLE
refactor: soft warning for compatibility date

### DIFF
--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -1,6 +1,6 @@
 import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
+  compatibilityDate: "latest",
   srcDir: "server",
-  compatibilityDate: "2025-03-01",
 });

--- a/src/core/config/resolvers/compatibility.ts
+++ b/src/core/config/resolvers/compatibility.ts
@@ -26,8 +26,8 @@ export async function resolveCompatibilityOptions(options: NitroOptions) {
     ) {
       consola.warn(
         [
-          `Please add \`compatibilityDate: '${formatDate("latest")}'\` to the config file. Using \`${fallbackCompatibilityDate}\` as fallback.`,
-          `More info: ${colors.underline("https://nitro.build/deploy#compatibility-date")}`,
+          /* WARN */ `Please add \`compatibilityDate: '${formatDate("latest")}'\` to the config file. Using \`${fallbackCompatibilityDate}\` as fallback.`,
+          `       More info: ${colors.underline("https://nitro.build/deploy#compatibility-date")}`,
         ].join("\n")
       );
       _fallbackInfoShown = true;

--- a/src/core/config/resolvers/compatibility.ts
+++ b/src/core/config/resolvers/compatibility.ts
@@ -1,15 +1,14 @@
-import {
-  type DateString,
-  formatDate,
-  resolveCompatibilityDatesFromEnv,
-} from "compatx";
+import type { DateString } from "compatx";
+import type { NitroOptions } from "nitropack/types";
+import { formatDate, resolveCompatibilityDatesFromEnv } from "compatx";
 import _consola from "consola";
 import { colors } from "consola/utils";
-import type { NitroOptions } from "nitropack/types";
-import { relative } from "pathe";
+import { isTest } from "std-env";
 
 // Nitro v2.9.6 release
 export const fallbackCompatibilityDate = "2024-04-03" as DateString;
+
+let _fallbackInfoShown = false;
 
 export async function resolveCompatibilityOptions(options: NitroOptions) {
   // Normalize and expand compatibility date from environment variables
@@ -18,94 +17,20 @@ export async function resolveCompatibilityOptions(options: NitroOptions) {
   );
 
   // If no compatibility date is specified, prompt or notify the user to set it
-  if (
-    !options.compatibilityDate.default &&
-    options.preset !== "nitro-prerender"
-  ) {
-    options.compatibilityDate.default = await _resolveDefault(options);
-  }
-}
-
-let _fallbackInfoShown = false;
-let _promptedUserToUpdate = false;
-
-async function _resolveDefault(options: NitroOptions): Promise<DateString> {
-  const _todayDate = formatDate(new Date());
-
-  const consola = _consola.withTag("nitro");
-  consola.warn(`No valid compatibility date is specified.`);
-
-  const onFallback = () => {
-    if (!_fallbackInfoShown) {
-      consola.info(
+  if (!options.compatibilityDate.default) {
+    const consola = _consola.withTag("nitro");
+    if (
+      !_fallbackInfoShown &&
+      !isTest &&
+      options.preset !== "nitro-prerender"
+    ) {
+      consola.log(
         [
-          `Using \`${fallbackCompatibilityDate}\` as fallback.`,
-          `  Please specify compatibility date to avoid unwanted behavior changes:`,
-          `     - Add \`compatibilityDate: '${_todayDate}'\` to the config file.`,
-          `     - Or set \`COMPATIBILITY_DATE=${_todayDate}\` environment variable.`,
-          ``,
+          `Please add \`compatibilityDate: '${formatDate("latest")}'\` to the config file. Using \`${fallbackCompatibilityDate}\` as fallback.`,
+          `More info: ${colors.underline("https://nitro.build/deploy#compatibility-date")}`,
         ].join("\n")
       );
       _fallbackInfoShown = true;
     }
-    return fallbackCompatibilityDate;
-  };
-
-  // Prompt user (once) to attempt auto update (only with Nitro CLI dev command)
-  const shallUpdate =
-    options._cli?.command === "dev" &&
-    !_promptedUserToUpdate &&
-    (await consola.prompt(
-      `Do you want to auto update config file to set ${colors.cyan(`compatibilityDate: '${_todayDate}'`)}?`,
-      {
-        type: "confirm",
-        default: true,
-      }
-    ));
-  _promptedUserToUpdate = true;
-  if (!shallUpdate) {
-    return onFallback();
   }
-
-  const { updateConfig } = await import("c12/update");
-  const updateResult = await updateConfig({
-    configFile: "nitro.config",
-    cwd: options.rootDir,
-    async onCreate({ configFile }) {
-      const shallCreate = await consola.prompt(
-        `Do you want to initialize a new config in ${colors.cyan(relative(".", configFile))}?`,
-        {
-          type: "confirm",
-          default: true,
-        }
-      );
-      if (shallCreate !== true) {
-        return false;
-      }
-      return _getDefaultNitroConfig();
-    },
-    async onUpdate(config) {
-      config.compatibilityDate = _todayDate;
-    },
-  }).catch((error) => {
-    consola.error(`Failed to update config: ${error.message}`);
-    return null;
-  });
-
-  if (updateResult?.configFile) {
-    consola.success(
-      `Compatibility date set to \`${_todayDate}\` in \`${relative(".", updateResult.configFile)}\``
-    );
-    return _todayDate;
-  }
-
-  return onFallback();
-}
-
-function _getDefaultNitroConfig() {
-  return /* js */ `
-import { defineNitroConfig } from 'nitropack/config'
-
-export default defineNitroConfig({})
-  `;
 }

--- a/src/core/config/resolvers/compatibility.ts
+++ b/src/core/config/resolvers/compatibility.ts
@@ -24,7 +24,7 @@ export async function resolveCompatibilityOptions(options: NitroOptions) {
       !isTest &&
       options.preset !== "nitro-prerender"
     ) {
-      consola.log(
+      consola.warn(
         [
           `Please add \`compatibilityDate: '${formatDate("latest")}'\` to the config file. Using \`${fallbackCompatibilityDate}\` as fallback.`,
           `More info: ${colors.underline("https://nitro.build/deploy#compatibility-date")}`,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from "node:path";
 
 export default defineNitroConfig({
   compressPublicAssets: true,
-  compatibilityDate: "2025-03-01",
+  compatibilityDate: "latest",
   framework: {
     name: "nitro",
     version: "2.x",

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -254,7 +254,7 @@ describe("API routes", () => {
 describe("defineNitroConfig", () => {
   it("should not accept functions to routeRules.cache", () => {
     defineNitroConfig({
-      compatibilityDate: "2025-03-01",
+      compatibilityDate: "latest",
       routeRules: {
         "/**": {
           cache: {


### PR DESCRIPTION
Prompt for compatibility date can be bothersome in some cases.

This PR replaces the current (force) prompt to update with a simple warning about guiding users for adding the compatibility date + new docs (#3292)

Additionally, `compatibilityDate: "latest"` is a possible value in latest compatx (0.2) for cases like examples or playgrounds where this date does not matter (intentionally not widely documented ;however, auto-complete exists)

Also, silenting warning for test environments.

![image](https://github.com/user-attachments/assets/14032056-0810-4eb3-bae6-97c101cdf3a2)
