### PR TITLE
refactor(cloudflare-durable): expose `publish` from durable object

### DIFF
--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -84,6 +84,13 @@ export class $DurableObject extends DurableObject {
     });
   }
 
+  publish(topic: string, data: unknown, opts: any) {
+    if (!ws) {
+      throw new Error("WebSocket not available");
+    }
+    return ws.publish(topic, data, opts);
+  }
+
   override alarm(): void | Promise<void> {
     this.ctx.waitUntil(
       nitroApp.hooks.callHook("cloudflare:durable:alarm", this)


### PR DESCRIPTION
This PR exposes `publish` to the experimental `cloudflare-durable` preset to allow publishing to all peers globally.

> [!NOTE]
> As this is an experimental preset, API changes can happen!

**Example:**

```ts
 export default eventHandler(async (event) => {
  const { durableFetch, durable } = event.context.cloudflare;

  if (durableFetch) {
    return durableFetch();
  }

  durable.publish("topic", { message: "Hello, world!" });

  return "message sent";
});
```


<details>

<summary>nitro config</summary>

```ts
import { defineNitroConfig } from "nitropack/config";

export default defineNitroConfig({
  compatibilityDate: "latest",
  srcDir: "server",
  experimental: {
    websocket: true
  },
  cloudflare: {
    nodeCompat: true,
    deployConfig: true,
    wrangler: {
      migrations: [
        {
          tag: "v1",
          new_sqlite_classes: ["$DurableObject"],
        },
      ],
      durable_objects: {
        bindings: [
          {
            name: "$DurableObject",
            class_name: "$DurableObject",
          },
        ],
      },
    },
  },
});
```

</details>