### PR TITLE
docs: correct example paths for  `serverAssets` option

### DIFF
--- a/docs/1.guide/8.assets.md
+++ b/docs/1.guide/8.assets.md
@@ -67,14 +67,14 @@ export default defineEventHandler(async () => {
 
 ### Custom server assets
 
-In order to add assets from a custom directory, you will need to define a path in your nitro config. This allows you to add assets from a directory outside of the `assets/` directory.
+In order to add assets from a custom directory, you will need to define a path in your nitro config. This allows you to add assets from a directory outside of the `server/assets/` directory.
 
 ::code-group
 ```js [nitro.config.ts]
 export default defineNitroConfig({
   serverAssets: [{
     baseName: 'my_directory',
-    dir: './server/my_directory'
+    dir: './my_directory' // Relative to `srcDir`
   }]
 })
 ```
@@ -83,21 +83,21 @@ export default defineNuxtConfig({
   nitro: {
     serverAssets: [{
       baseName: 'my_directory',
-      dir: './server/my_directory'
+      dir: './my_directory' // Relative to Nitro `srcDir`
     }]
   }
 })
 ```
 ::
 
-You could want to add a directory with html templates for example.
+You could want to add a directory (`server/templates/`) with html templates for example.
 
 ::code-group
 ```js [nitro.config.ts]
 export default defineNitroConfig({
   serverAssets: [{
     baseName: 'templates',
-    dir: './server/templates'
+    dir: './templates' // Relative to `srcDir`
   }]
 })
 ```
@@ -106,7 +106,7 @@ export default defineNuxtConfig({
   nitro: {
     serverAssets: [{
       baseName: 'templates',
-      dir: './server/templates'
+      dir: './templates' // Relative to Nitro `srcDir`
     }]
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nitrojs/nitro/issues/3272

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)

### 📚 Description

https://github.com/nitrojs/nitro/pull/2775 changed the `dir` paths in these examples by mistake.
I reverted these changes and tried to make it more clear what paths should be used.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
