### PR TITLE
fix(netlify-edge): enable function caching

### DIFF
--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -95,6 +95,7 @@ const netlifyEdge = defineNitroPreset(
               name: "edge server handler",
               function: "server",
               generator: getGeneratorString(nitro),
+              cache: "manual",
             },
           ],
         };


### PR DESCRIPTION
Currently, netlify is ignoring any cache directives because caching is not enabled via the integration manifest.
A config like the following would have no effect:
```
  routeRules: {
    '/hello-cache': {
      cache: {
        maxAge: 38400,
      },
    },
  }
```

See: https://docs.netlify.com/edge-functions/optional-configuration/#response-caching

### 🔗 Linked issue

#3256 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR contributes to getting the netlify preset to properly support caching (see #3256). It should be backwards compatible in the sense that the preset change has no effect for existing deployments.

Follow up work would still be needed as, after the patch, the only way to control edge function caching is through additional header config in `routeRules`:
```
    '/hello-cache-headers': {
      headers: {
        'Cache-Control': 'public, max-age=3600, must-revalidate',
        'Netlify-CDN-Cache-Control': 'public, max-age=38400, stale-while-revalidate=60, durable',
      },
    }
```
 
### 📝 Checklist


- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
