### PR TITLE
fix(open-api): load virtual files from rollup rather than fs

### DIFF
--- a/src/rollup/plugins/handlers-meta.ts
+++ b/src/rollup/plugins/handlers-meta.ts
@@ -34,9 +34,14 @@ export function handlersMeta(nitro: Nitro) {
         return virtualPrefix + resolved.id;
       }
     },
-    load(id) {
+    async load(id) {
       if (id.startsWith(virtualPrefix)) {
         const fullPath = id.slice(virtualPrefix.length);
+        // bail out to rollup for virtual files
+        if (fullPath.startsWith("\0")) {
+          const { code } = await this.load({ id: fullPath });
+          return code;
+        }
         return readFile(fullPath, { encoding: "utf8" });
       }
     },

--- a/src/rollup/plugins/handlers-meta.ts
+++ b/src/rollup/plugins/handlers-meta.ts
@@ -37,7 +37,7 @@ export function handlersMeta(nitro: Nitro) {
     async load(id) {
       if (id.startsWith(virtualPrefix)) {
         const fullPath = id.slice(virtualPrefix.length);
-        // bail out to rollup for virtual files
+        // Bail out to rollup for virtual files (#3324)
         if (fullPath.startsWith("\0")) {
           const { code } = await this.load({ id: fullPath });
           return code;


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this addresses an issue found by @atinux in https://github.com/nuxt-ui-pro/chat/pull/10.

minimal reproduction: https://stackblitz.com/edit/github-eddeyrez?file=nitro.config.ts

the issue is that the handlersMeta plugin always tries to load files from disk, but in some cases this is impossible. We bail out if a null byte is detected, which will cover nitro virtual files as well as any virtual files present from other plugins.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
