### PR TITLE
fix: explicitly set moduleType to `js` for raw loader

### DIFF
--- a/src/build/plugins/raw.ts
+++ b/src/build/plugins/raw.ts
@@ -71,9 +71,9 @@ export function raw(opts: RawOptions = {}): Plugin {
         };
       }
       return {
-        code,
+        code: `// ROLLUP_NO_REPLACE \n export default ${JSON.stringify(code)}`,
         map: null,
-        moduleType: "json",
+        moduleType: "js",
       };
     },
   };

--- a/src/build/plugins/raw.ts
+++ b/src/build/plugins/raw.ts
@@ -73,7 +73,7 @@ export function raw(opts: RawOptions = {}): Plugin {
       return {
         code,
         map: null,
-        moduleType: 'json'
+        moduleType: "json",
       };
     },
   };

--- a/src/build/plugins/raw.ts
+++ b/src/build/plugins/raw.ts
@@ -71,8 +71,9 @@ export function raw(opts: RawOptions = {}): Plugin {
         };
       }
       return {
-        code: `// ROLLUP_NO_REPLACE \n export default ${JSON.stringify(code)}`,
+        code,
         map: null,
+        moduleType: 'json'
       };
     },
   };


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro/pull/3211#issuecomment-2820298178

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Resolves the issue that `.json` files are not "handled correctly" by setting the [module type](https://rolldown.rs/guide/in-depth/module-types#how-module-types-affect-users) of all non-binary raw files to `js` while keeping the transform code.

Another option would be setting the `moduleType` to `json` (which is the default for `.json` files) and keep the file as is, removing the need for transforms. In my test, that clashed with other types of files though.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
