### PR TITLE
fix(rolldown): use rollup replace plugin for now

### DIFF
--- a/src/build/rolldown/config.ts
+++ b/src/build/rolldown/config.ts
@@ -32,7 +32,10 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
     ],
     plugins: [
       ...(baseBuildPlugins(nitro, base) as RolldownPlugin[]),
-      replace({ preventAssignment: true, values: base.replacements }) as RolldownPlugin,
+      replace({
+        preventAssignment: true,
+        values: base.replacements,
+      }) as RolldownPlugin,
       json() as RolldownPlugin,
     ],
     resolve: {

--- a/src/build/rolldown/config.ts
+++ b/src/build/rolldown/config.ts
@@ -32,6 +32,7 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
     ],
     plugins: [
       ...(baseBuildPlugins(nitro, base) as RolldownPlugin[]),
+      // https://github.com/rolldown/rolldown/issues/4257
       replace({
         preventAssignment: true,
         values: base.replacements,

--- a/src/build/rolldown/config.ts
+++ b/src/build/rolldown/config.ts
@@ -7,6 +7,7 @@ import { runtimeDir } from "nitro/runtime/meta";
 import json from "@rollup/plugin-json";
 import { baseBuildConfig } from "../config";
 import { baseBuildPlugins } from "../plugins";
+import { replace } from "../plugins/replace";
 import { builtinModules } from "node:module";
 
 export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
@@ -31,6 +32,7 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
     ],
     plugins: [
       ...(baseBuildPlugins(nitro, base) as RolldownPlugin[]),
+      replace({ preventAssignment: true, values: base.replacements }) as RolldownPlugin,
       json() as RolldownPlugin,
     ],
     resolve: {
@@ -45,21 +47,6 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
     },
     // @ts-expect-error (readonly values)
     inject: base.env.inject,
-    define: {
-      ...Object.fromEntries(
-        Object.entries(base.replacements)
-          .filter(
-            ([key, val]) =>
-              val &&
-              (key.startsWith("import.meta.env.") ||
-                key.startsWith("process.env."))
-          )
-          .map(([key, value]) => [
-            key,
-            typeof value === "function" ? value() : value,
-          ])
-      ),
-    },
     jsx: "react-jsx",
     onwarn(warning, warn) {
       if (


### PR DESCRIPTION
Related Issue/PR: https://github.com/nitrojs/nitro/pull/3211

This PR resorts back to the rollup replace plugin for now. After https://github.com/rolldown/rolldown/issues/4257 is resolved, switching to the rolldown one should be drop-in.

I'd still consider using `define` for most scenarios as it is less brittle (AST replacement instead of direct one). It does *not* support functions though.