### PR TITLE
chore: use explicit type for generated edge-function manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@azure/static-web-apps-cli": "^2.0.5",
     "@cloudflare/workers-types": "^4.20250414.0",
     "@deno/types": "^0.0.1",
-    "@netlify/edge-functions": "^2.11.1",
+    "@netlify/edge-functions": "^2.12.0",
     "@netlify/functions": "^3.0.4",
     "@scalar/api-reference": "^1.28.19",
     "@types/archiver": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,8 +232,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       '@netlify/edge-functions':
-        specifier: ^2.11.1
-        version: 2.11.1
+        specifier: ^2.12.0
+        version: 2.12.0
       '@netlify/functions':
         specifier: ^3.0.4
         version: 3.0.4
@@ -970,8 +970,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.8':
     resolution: {integrity: sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg==}
 
-  '@netlify/edge-functions@2.11.1':
-    resolution: {integrity: sha512-pyQOTZ8a+ge5lZlE+H/UAHyuqQqtL5gE0pXrHT9mOykr3YQqnkB2hZMtx12odatZ87gHg4EA+UPyMZUbLfnXvw==}
+  '@netlify/edge-functions@2.12.0':
+    resolution: {integrity: sha512-6EWKqCQvOWyM6CHOofvDglX8qkBL2xcMF2T0h7kzZRrdBvHMRgxTk6BmPlBGt8z4LubSQo6vDAb46MYNJ7ZyaA==}
 
   '@netlify/functions@3.0.4':
     resolution: {integrity: sha512-Ox8+ABI+nsLK+c4/oC5dpquXuEIjzfTlJrdQKgQijCsDQoje7inXFAtKDLvvaGvuvE+PVpMLwQcIUL6P9Ob1hQ==}
@@ -6111,7 +6111,7 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@netlify/edge-functions@2.11.1': {}
+  '@netlify/edge-functions@2.12.0': {}
 
   '@netlify/functions@3.0.4':
     dependencies:

--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -1,6 +1,7 @@
 import { promises as fsp } from "node:fs";
 import { defineNitroPreset } from "../_utils/preset";
 import type { Nitro } from "nitro/types";
+import type { Config, Manifest } from "@netlify/edge-functions";
 import { dirname, join } from "pathe";
 import { unenvDenoPreset } from "../_unenv/preset-deno";
 import {
@@ -81,7 +82,7 @@ const netlifyEdge = defineNitroPreset(
         await writeRedirects(nitro);
 
         // https://docs.netlify.com/edge-functions/create-integration/
-        const manifest = {
+        const manifest: Manifest = {
           version: 1,
           functions: [
             {
@@ -89,7 +90,7 @@ const netlifyEdge = defineNitroPreset(
               excludedPath: getStaticPaths(
                 nitro.options.publicAssets,
                 nitro.options.baseURL
-              ),
+              ) as Config['excludedPath'],
               name: "edge server handler",
               function: "server",
               generator: getGeneratorString(nitro),


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Adds typing for the generated edge-function manifest to help support future code changes in this area

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
