### PR TITLE
fix: inherit `context._platform` for direct fetch

### DIFF
--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -75,6 +75,7 @@ function createNitroApp(): NitroApp {
           };
       if (fetchContext?._platform) {
         event.context = {
+          _platform: fetchContext?._platform, // #3335
           ...fetchContext._platform,
           ...event.context,
         };


### PR DESCRIPTION
resolves #3335

In direct fetch scenarios (like an SSR route that fetches an API), we need to inherit `_platform` context to make context like `event.context.cloudflare` inherited.