### PR TITLE
fix(cli): respect `rootDir` config in CLI

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -40,7 +40,8 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const rootDir = resolve((args.dir || args._dir || ".") as string);
+    const cwd = resolve((args.dir || args._dir || ".") as string);
+    const rootDir = args.dir || args._dir ? cwd : undefined;
     const nitro = await createNitro(
       {
         rootDir,
@@ -49,6 +50,7 @@ export default defineCommand({
         preset: args.preset,
       },
       {
+        cwd,
         compatibilityDate: args.compatibilityDate as DateString,
       }
     );

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -24,7 +24,8 @@ export default defineCommand({
     ...getArgs(),
   },
   async run({ args }) {
-    const rootDir = resolve((args.dir || args._dir || ".") as string);
+    const cwd = resolve((args.dir || args._dir || ".") as string);
+    const rootDir = args.dir || args._dir ? cwd : undefined;
     let nitro: Nitro;
     const reload = async () => {
       if (nitro) {
@@ -42,6 +43,7 @@ export default defineCommand({
           _cli: { command: "dev" },
         },
         {
+          cwd,
           watch: true,
           c12: {
             async onUpdate({ getDiff, newConfig }) {

--- a/src/cli/commands/prepare.ts
+++ b/src/cli/commands/prepare.ts
@@ -12,8 +12,9 @@ export default defineCommand({
     ...commonArgs,
   },
   async run({ args }) {
-    const rootDir = resolve((args.dir || args._dir || ".") as string);
-    const nitro = await createNitro({ rootDir });
+    const cwd = resolve((args.dir || args._dir || ".") as string);
+    const rootDir = args.dir || args._dir ? cwd : undefined;
+    const nitro = await createNitro({ rootDir }, { cwd });
     await writeTypes(nitro);
   },
 });

--- a/src/cli/commands/task/list.ts
+++ b/src/cli/commands/task/list.ts
@@ -16,10 +16,13 @@ export default defineCommand({
   },
   async run({ args }) {
     const cwd = resolve((args.dir || args.cwd || ".") as string);
-    const options = await loadOptions({ rootDir: cwd }).catch(() => undefined);
+    const rootDir = args.dir || args.cwd ? cwd : undefined;
+    const options = await loadOptions({ rootDir }, { cwd }).catch(
+      () => undefined
+    );
 
     const tasks = await listTasks({
-      cwd,
+      cwd: options?.rootDir || cwd,
       buildDir: options?.buildDir || ".nitro",
     });
     for (const [name, task] of Object.entries(tasks)) {

--- a/src/cli/commands/task/run.ts
+++ b/src/cli/commands/task/run.ts
@@ -27,7 +27,10 @@ export default defineCommand({
   },
   async run({ args }) {
     const cwd = resolve((args.dir || args.cwd || ".") as string);
-    const options = await loadOptions({ rootDir: cwd }).catch(() => undefined);
+    const rootDir = args.dir || args.cwd ? cwd : undefined;
+    const options = await loadOptions({ rootDir }, { cwd }).catch(
+      () => undefined
+    );
 
     consola.info(`Running task \`${args.name}\`...`);
     let payload: any = destr(args.payload || "{}");
@@ -45,7 +48,7 @@ export default defineCommand({
           payload,
         },
         {
-          cwd,
+          cwd: options?.rootDir || cwd,
           buildDir: options?.buildDir || ".nitro",
         }
       );

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -7,7 +7,7 @@ export const commonArgs = <ArgsDef>{
   },
   _dir: {
     type: "positional",
-    default: ".",
+    required: false,
     description: "project root directory (prefer using `--dir`)",
   },
 };

--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -96,7 +96,7 @@ async function _loadUserConfig(
       : loadConfig<NitroConfig & { _meta?: NitroPresetMeta }>
   )({
     name: "nitro",
-    cwd: configOverrides.rootDir,
+    cwd: opts.cwd,
     dotenv: opts.dotenv ?? configOverrides.dev,
     extend: { extendKey: ["extends", "preset"] },
     overrides: {

--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -96,7 +96,7 @@ async function _loadUserConfig(
       : loadConfig<NitroConfig & { _meta?: NitroPresetMeta }>
   )({
     name: "nitro",
-    cwd: opts.cwd,
+    cwd: opts.cwd || configOverrides.rootDir,
     dotenv: opts.dotenv ?? configOverrides.dev,
     extend: { extendKey: ["extends", "preset"] },
     overrides: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -285,6 +285,7 @@ export interface NitroConfig
 // ------------------------------------------------------------
 
 export interface LoadConfigOptions {
+  cwd?: string;
   watch?: boolean;
   c12?: WatchConfigOptions;
   compatibilityDate?: CompatibilityDateSpec;


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

resolves https://github.com/nitrojs/nitro/issues/3337

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The CLI always overrides `rootDir` with `process.cwd()` when no `dir` argument is specified, ignoring the `rootDir` in the user's config file. But it should respect the user's config when no `dir` is provided and only override the user's config when `dir` is otherwise specified.

(If this fix is okay, I'll port it to v3)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
