### PR TITLE
refactor: better error for scanned dirs being a file

### DIFF
--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -161,6 +161,15 @@ async function scanDir(
     dot: true,
     ignore: nitro.options.ignore,
     absolute: true,
+  }).catch((error) => {
+    if (error?.code !== "ENOTDIR") {
+      throw error;
+    }
+
+    nitro.logger.warn(
+      `File \`${name}\` in directory \`${dir}\` must be a folder.`
+    );
+    return [];
   });
   return fileNames
     .map((fullPath) => {

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -162,14 +162,13 @@ async function scanDir(
     ignore: nitro.options.ignore,
     absolute: true,
   }).catch((error) => {
-    if (error?.code !== "ENOTDIR") {
-      throw error;
+    if (error?.code === "ENOTDIR") {
+      nitro.logger.warn(
+        `Ignoring \`${join(dir, name)}\`. It must be a directory.`
+      );
+      return [];
     }
-
-    nitro.logger.warn(
-      `File \`${name}\` in directory \`${dir}\` must be a folder.`
-    );
-    return [];
+    throw error;
   });
   return fileNames
     .map((fullPath) => {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#3248 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
`scanDir` now handles `ENOTDIR` system errors, logging a simple warning, any other error still gets thrown.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
