### PR TITLE
types: omit `rootDir` in `defineNitroConfig()`

### DIFF
--- a/lib/config.d.mts
+++ b/lib/config.d.mts
@@ -2,6 +2,8 @@ import { NitroConfig } from "nitro/types";
 
 export { NitroConfig } from "nitro/types";
 
-declare function defineNitroConfig(config: NitroConfig): NitroConfig;
+declare function defineNitroConfig(
+  config: Omit<NitroConfig, "rootDir">
+): Omit<NitroConfig, "rootDir">;
 
 export { defineNitroConfig };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -271,8 +271,6 @@ export interface NitroConfig
   unenv?: UnenvPreset | UnenvPreset[];
 }
 
-export type NitroConfigInput = Omit<NitroConfig, "rootDir">;
-
 // ------------------------------------------------------------
 // Config Loader
 // ------------------------------------------------------------

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -271,6 +271,8 @@ export interface NitroConfig
   unenv?: UnenvPreset | UnenvPreset[];
 }
 
+export type NitroConfigInput = Omit<NitroConfig, "rootDir">;
+
 // ------------------------------------------------------------
 // Config Loader
 // ------------------------------------------------------------

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -27,7 +27,9 @@ declare global {
 }
 
 declare global {
-  const defineNitroConfig: (config: NitroConfig) => NitroConfig;
+  const defineNitroConfig: (
+    config: Omit<NitroConfig, "rootDir">
+  ) => Omit<NitroConfig, "rootDir">;
   const defineNitroModule: (definition: NitroModule) => NitroModule;
 }
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

resolves #3337

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the `rootDir` from `defineNitroConfig` as this option should ony be used in programmatic usage, as discussed in https://github.com/nitrojs/nitro/pull/3344#discussion_r2073348863.

Note that only the top-level `rootDir` type is removed, while the nested `rootDir` within `C12InputConfig` and `NitroPreset` is kept for simplicity. Because `NitroConfig` is a bit complicated, we'd otherwise have to redeclare a new type (e.g., `NitroConfigInput`) to replicate `NitroConfig`'s definition to fully remove `rootDir`. WDYT 🤔

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
