### PR TITLE
feat(node-server): implement socket activation

### DIFF
--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -1,9 +1,10 @@
 import "#nitro-internal-pollyfills";
+import { fstatSync } from "node:fs";
 import { Server as HttpServer } from "node:http";
 import { Server as HttpsServer } from "node:https";
-import type { AddressInfo } from "node:net";
+import type { ListenOptions } from "node:net";
+import { pid } from "node:process";
 import wsAdapter from "crossws/adapters/node";
-import destr from "destr";
 import { toNodeListener } from "h3";
 import { useNitroApp, useRuntimeConfig } from "nitro/runtime";
 import {
@@ -22,25 +23,79 @@ const server =
     ? new HttpsServer({ key, cert }, toNodeListener(nitroApp.h3App))
     : new HttpServer(toNodeListener(nitroApp.h3App));
 
-const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
-  3000) as number;
-const host = process.env.NITRO_HOST || process.env.HOST;
+const SD_LISTEN_FDS_START = 3;
 
-const path = process.env.NITRO_UNIX_SOCKET;
+function getListenFds(): number[] {
+  // Implement sd_listen_fds handling from systemd which passes
+  // already opened and configured sockets to the server starting at FD 3.
+  // See https://systemd.io/SD_LISTEN_FDS/
+  const listen_pid = Number.parseInt(process.env.LISTEN_PID || "", 10);
+  const listen_fds = Number.parseInt(process.env.LISTEN_FDS || "", 10);
+  delete process.env.LISTEN_PID;
+  delete process.env.LISTEN_FDS;
+  delete process.env.LISTEN_FDNAMES;
+
+  if (listen_pid !== pid) return [];
+  if (listen_fds <= 0) return [];
+
+  // Ideally, we would set the FD_CLOEXEC flag on all passed the FDs.
+  // However, this requires calling out to fcntl which is not available in Node.
+  return Array.from({ length: listen_fds }, (_, i) => SD_LISTEN_FDS_START + i);
+}
+
+function getServerListenOptions(): ListenOptions | { fd: number } {
+  const fds = getListenFds();
+  if (fds.length) {
+    if (fds.length > 1) {
+      console.warn(
+        `Multiple file descriptors (${fds.length}) passed to the server. Only the first one will be used.`
+      );
+    }
+
+    const fd = fds[0];
+    if (!fstatSync(fd).isSocket) {
+      console.error(
+        `File descriptor ${fd} is not a socket. Ignoring it and using fallback listeners.`
+      );
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    }
+
+    // We would also like to check SO_TYPE and SO_ACCEPTCONN to confirm
+    // that the socket is configured correctly (type SOCK_STREAM, and listening),
+    // but this requires getsockopt which is not available in Node either.
+    return { fd };
+  }
+
+  const path = process.env.NITRO_UNIX_SOCKET;
+  if (path) {
+    return { path };
+  }
+
+  const port = Number.parseInt(
+    process.env.NITRO_PORT || process.env.PORT || "3000"
+  );
+  const host = process.env.NITRO_HOST || process.env.HOST;
+  return { port, host };
+}
 
 // @ts-ignore
-const listener = server.listen(path ? { path } : { port, host }, (err) => {
+const listener = server.listen(getServerListenOptions(), (err) => {
   if (err) {
     console.error(err);
     // eslint-disable-next-line unicorn/no-process-exit
     process.exit(1);
   }
-  const protocol = cert && key ? "https" : "http";
-  const addressInfo = listener.address() as AddressInfo;
+  const addressInfo = listener.address();
+  if (addressInfo === null) {
+    console.log("Failed to get address info");
+    return;
+  }
   if (typeof addressInfo === "string") {
     console.log(`Listening on unix socket ${addressInfo}`);
     return;
   }
+  const protocol = cert && key ? "https" : "http";
   const baseURL = (useRuntimeConfig().app.baseURL || "").replace(/\/$/, "");
   const url = `${protocol}://${
     addressInfo.family === "IPv6"

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -45,7 +45,7 @@ function getListenFds(): number[] {
 
 function getServerListenOptions(): ListenOptions | { fd: number } {
   const fds = getListenFds();
-  if (fds.length) {
+  if (fds.length > 0) {
     if (fds.length > 1) {
       console.warn(
         `Multiple file descriptors (${fds.length}) passed to the server. Only the first one will be used.`


### PR DESCRIPTION
### 🔗 Linked issue

This expands upon #1129.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This implements the LISTEN_FDs socket activation protocol to allow starting the server by passing a preconfigured socket file descriptor. This is useful to allow an unprivileged process to bind to privileged ports or addresses outside the namespace.

Testing can be done using the following commands:

```shell
# Bind to single port
systemd-socket-activate -l 8000 node playground/.output/server/index.mjs
# Bind to unix socket (this triggers the `addressInfo === null` codepath)
systemd-socket-activate -l ./socketname node playground/.output/server/index.mjs
# Bind to multiple ports, only first passed FD will be used (see code)
systemd-socket-activate -l 8000 -l 9000 node playground/.output/server/index.mjs
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.