### PR TITLE
fix: depend on unenv `global.` polyfill

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -259,12 +259,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
           ])
         ),
         ...Object.fromEntries(
-          [";", "(", "{", "}", " ", "\t", "\n"].map((d) => [
-            `${d}global.`,
-            `${d}globalThis.`,
-          ])
-        ),
-        ...Object.fromEntries(
           Object.entries(buildEnvVars).map(([key, val]) => [
             `process.env.${key}`,
             JSON.stringify(val),


### PR DESCRIPTION
https://github.com/nuxt/nuxt/pull/32130

Some libraries use `global.` instead of `globalThis.`. `global.` is a **Node.js specific** API.

Nitro used a build-time replace plugin to update usage. But it introduces (smaller) issues like when `global.` being used in a string constant.

Since unenv v2 migration, we always inject a runtime polyfill for `globalThis.global.` (effectively same as `global.`) ([preset](https://github.com/nitrojs/nitro/blob/32e1850760fa19466ab69d31636ead05a856dc6c/src/config/resolvers/unenv.ts#L36)).

This PR removed unnecessary build-time replace workaround.