### PR TITLE
fix(types): resolve absolute paths for type imports

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -57,7 +57,7 @@ export async function writeTypes(nitro: Nitro) {
 
     const resolvedImportPathMap = new Map<string, string>();
 
-    for (const i of allImports.filter((i) => !i.type)) {
+    for (const i of allImports) {
       if (resolvedImportPathMap.has(i.from)) {
         continue;
       }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/24314

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change allows for type imports to be resolved from an absolute to a relative path. The same was done for Nuxt here:
- https://github.com/nuxt/nuxt/pull/24413

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
