### PR TITLE
feat(cache): add serialize option to CacheOptions for custom serialization

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -46,13 +46,14 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, opts]);
   const validate = opts.validate || ((entry) => entry.value !== undefined);
-  const serializeValue = opts.serializeValue || ((value) => value);
+  const serialize = opts.serialize || (async (entry) => entry);
 
   async function get(
     key: string,
     resolver: () => T | Promise<T>,
     shouldInvalidateCache?: boolean,
-    event?: H3Event
+    event?: H3Event,
+    args: ArgsT = [] as any
   ): Promise<ResolvedCacheEntry<T>> {
     // Use extension for key to avoid conflicting with parent namespace (foo/bar and foo/bar/baz)
     const cacheKey = [opts.base, group, name, key + ".json"]
@@ -105,7 +106,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       }
 
       try {
-        entry.value = await serializeValue(await pending[key]);
+        entry.value = await pending[key];
       } catch (error) {
         // Make sure entries that reject get removed.
         if (!isPending) {
@@ -125,12 +126,17 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           if (opts.maxAge && !opts.swr /* TODO: respect staleMaxAge */) {
             setOpts = { ttl: opts.maxAge };
           }
-          const promise = useStorage()
-            .setItem(cacheKey, entry, setOpts)
-            .catch((error) => {
-              console.error(`[cache] Cache write error.`, error);
-              useNitroApp().captureError(error, { event, tags: ["cache"] });
-            });
+
+          const promise = Promise.resolve(serialize(entry, ...args)).then(
+            (entry) =>
+              useStorage()
+                .setItem(cacheKey, entry, setOpts)
+                .catch((error) => {
+                  console.error(`[cache] Cache write error.`, error);
+                  useNitroApp().captureError(error, { event, tags: ["cache"] });
+                })
+          );
+
           if (event?.waitUntil) {
             event.waitUntil(promise);
           }
@@ -168,7 +174,8 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       key,
       () => fn(...args),
       shouldInvalidateCache,
-      args[0] && isEvent(args[0]) ? args[0] : undefined
+      args[0] && isEvent(args[0]) ? args[0] : undefined,
+      args
     );
     let value = entry.value;
     if (opts.transform) {

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -46,6 +46,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, opts]);
   const validate = opts.validate || ((entry) => entry.value !== undefined);
+  const serializeValue = opts.serializeValue || ((value) => value);
 
   async function get(
     key: string,
@@ -104,7 +105,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       }
 
       try {
-        entry.value = await pending[key];
+        entry.value = await serializeValue(await pending[key]);
       } catch (error) {
         // Make sure entries that reject get removed.
         if (!isPending) {

--- a/src/types/runtime/cache.ts
+++ b/src/types/runtime/cache.ts
@@ -11,6 +11,7 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   name?: string;
   getKey?: (...args: ArgsT) => string | Promise<string>;
   transform?: (entry: CacheEntry<T>, ...args: ArgsT) => any;
+  serializeValue?: (value: CacheEntry<T>["value"], ...args: ArgsT) => any;
   validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean;
   shouldInvalidateCache?: (...args: ArgsT) => boolean | Promise<boolean>;
   shouldBypassCache?: (...args: ArgsT) => boolean | Promise<boolean>;

--- a/src/types/runtime/cache.ts
+++ b/src/types/runtime/cache.ts
@@ -11,7 +11,10 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   name?: string;
   getKey?: (...args: ArgsT) => string | Promise<string>;
   transform?: (entry: CacheEntry<T>, ...args: ArgsT) => any;
-  serializeValue?: (value: CacheEntry<T>["value"], ...args: ArgsT) => any;
+  serialize?: (
+    value: CacheEntry<T>,
+    ...args: ArgsT
+  ) => CacheEntry<T> | Promise<CacheEntry<T>>;
   validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean;
   shouldInvalidateCache?: (...args: ArgsT) => boolean | Promise<boolean>;
   shouldBypassCache?: (...args: ArgsT) => boolean | Promise<boolean>;


### PR DESCRIPTION
### 🔗 Linked issue

#3367, #2932, #2933

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

In some cases, we return a `ReadableStream` as the result of a request (such as when streaming React DOM), and the response needs to be cached. However, `ReadableStream` instances are not directly serializable, and attempting to cache them as-is results in an empty `{}` being stored.

To handle such cases, I’ve introduced a new method called `serialize` to the `CacheOptions` interface. This method allows defining custom serialization logic before storing the cache entry in the store. For example, you can convert a stream into a full HTML string or apply any other custom transformation as needed.

The existing `transform` method can then be used to deserialize the stored value when reading from the cache.

This change enables proper support for caching stream-based or otherwise non-serializable data structures.

Event handler example:
```tsx
// routes/index.tsx
export default defineCachedEventHandler(
  (e) => {
    return renderToReadableStream(<App />);
  },
  {
    swr: true,
    maxAge: 60,
    async serialize(entry, e) {
      if (entry.value.body instanceof ReadableStream) {
        const reader = entry.value.body
          .pipeThrough(new TextDecoderStream())
          .getReader();
        let html = "";
        while (true) {
          const { value, done } = await reader.read();
          if (done) break;
          html += value;
        }
        entry.value.body = html;
      }
      return entry;
    },
  }
);
```

Cached function example:
```tsx
const renderPage = defineCachedFunction(
  async (e: H3Event) => {
    return renderRoute(e); // which renders the route and returns a ReadableStream
  },
  {
    swr: true,
    maxAge: 60,
    getKey(e) {
      return `path-${btoa(e.path)}`;
    },
    async serialize(entry, e) {
      if (entry.value instanceof ReadableStream) {
        const reader = entry.value
          .pipeThrough(new TextDecoderStream())
          .getReader();
        let html = "";
        while (true) {
          const { value, done } = await reader.read();
          if (done) break;
          html += value;
        }
        entry.value = html;
      }
      return entry;
    },
  }
);

export default defineEventHandler(renderPage)
```


Resolves #3367, #2932, #2933

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
