### PR TITLE
fix(bun) remove `worker` condition from Bun

### DIFF
--- a/src/presets/bun/preset.ts
+++ b/src/presets/bun/preset.ts
@@ -5,7 +5,7 @@ const bun = defineNitroPreset(
     entry: "./runtime/bun",
     serveStatic: true,
     // https://bun.sh/docs/runtime/modules#resolution
-    exportConditions: ["bun", "worker", "node", "import", "default"],
+    exportConditions: ["bun", "node", "import", "default"],
     commands: {
       preview: "bun run ./server/index.mjs",
     },


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

fixes #3043

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
  - technically it could be classified as breaking, but it shouldn't break much

### 📚 Description

Bun doesn't use the `worker` condition normally. The only time it should be used is when actually using worker on backend and that's a very low chance compared to people using [`@clerk/backend`](https://github.com/clerk/javascript/blob/main/packages/backend/package.json#L18). I decided to fix it here instead of clerk because high chance other packages could be broken.

Now as I mentioned it can hurt people trying to use bun workers *with package that has different code using condition* but I think its an important change because lower chance of usage. At least putting it below node/import could help as more packages define worker than bun (and also assume worker is browser). Also it's bold assumption to make that you would only want to use the worker and then only copy that code, instead a proper fix could be bundling conditions with more context on how its being imported.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
