### PR TITLE
fix(serveStatic): automatically use `Content-Encoding: gzip` for `.gz` static files

### DIFF
--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -223,6 +223,12 @@ class DevServer {
         fromNodeMiddleware(
           serveStatic(asset.dir, {
             dotfiles: "allow",
+            setHeaders(res, path) {
+              if(path.endsWith('.gz')) {
+                res.setHeader("Content-Encoding", "gzip");
+              }
+              // Or expand to other encodings if needed
+            }
           })
         )
       );


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nitrojs/nitro/issues/3379

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR improves the serving of static files for `.gz` files with automatically set `Content-Encoding: gzip` response headers. We can also add other types of encodings for compressed files if needed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
