### PR TITLE
docs(nightly): include `bun.lock` for lockfile

### DIFF
--- a/docs/1.guide/99.nightly.md
+++ b/docs/1.guide/99.nightly.md
@@ -31,4 +31,4 @@ You can opt-in to the nightly release channel by updating your `package.json`:
 If you are using Nuxt, [use the Nuxt nightly channel](https://nuxt.com/docs/guide/going-further/nightly-release-channel#opting-in) as it already includes `nitropack-nightly`.
 ::
 
-Remove the lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb`) and reinstall the dependencies.
+Remove the lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, or `bun.lockb`) and reinstall the dependencies.


### PR DESCRIPTION
bun basically generates `bun.lock` by default now from v1.2. I think we may add `bun.lock` also with `bun.lockb`. 
https://bun.sh/docs/install/lockfile