### PR TITLE
refactor!: do not set default `statusText` (#3409)

### DIFF
--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -28,7 +28,6 @@ export async function defaultHandler(
 ): Promise<InternalHandlerResponse> {
   const isSensitive = error.unhandled;
   const status = error.status || 500;
-  const statusText = error.statusText || "Server Error";
   // prettier-ignore
   const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
 
@@ -92,7 +91,7 @@ export async function defaultHandler(
         error: true,
         url,
         status,
-        statusText,
+        statusText: error.statusText,
         message: error.message,
         data: error.data,
         stack: error.stack?.split("\n").map((line) => line.trim()),
@@ -106,8 +105,8 @@ export async function defaultHandler(
       });
 
   return {
-    status: status,
-    statusText: statusText,
+    status,
+    statusText: error.statusText,
     headers,
     body,
   };

--- a/src/runtime/internal/error/prod.ts
+++ b/src/runtime/internal/error/prod.ts
@@ -20,7 +20,6 @@ export function defaultHandler(
 ): InternalHandlerResponse {
   const isSensitive = error.unhandled;
   const status = error.status || 500;
-  const statusText = error.statusText || "Server Error";
   // prettier-ignore
   const url = getRequestURL(event, { xForwardedHost: true, xForwardedProto: true })
 
@@ -60,7 +59,7 @@ export function defaultHandler(
     "content-security-policy": "script-src 'none'; frame-ancestors 'none';",
   };
   event.res.status = status;
-  event.res.statusText = statusText;
+  event.res.statusText = error.statusText;
   if (status === 404 || !event.res.headers.has("cache-control")) {
     headers["cache-control"] = "no-cache";
   }
@@ -69,14 +68,14 @@ export function defaultHandler(
     error: true,
     url: url.href,
     status,
-    statusText,
+    statusText: error.statusText,
     message: isSensitive ? "Server Error" : error.message,
     data: isSensitive ? undefined : error.data,
   };
 
   return {
-    status: status,
-    statusText: statusText,
+    status,
+    statusText: error.statusText,
     headers,
     body,
   };

--- a/src/runtime/internal/error/utils.ts
+++ b/src/runtime/internal/error/utils.ts
@@ -8,7 +8,7 @@ export function defineNitroErrorHandler(
 
 export type InternalHandlerResponse = {
   status: number;
-  statusText: string;
+  statusText: string | undefined;
   headers: Record<string, string>;
   body: string | Record<string, any>;
 };

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -81,7 +81,7 @@ export type NitroErrorHandler = (
       opts?: { silent?: boolean; json?: boolean }
     ) => MaybePromise<{
       status: number;
-      statusText: string;
+      statusText: string | undefined;
       headers: Record<string, string>;
       body: string | Record<string, any>;
     }>;


### PR DESCRIPTION
Setting a generic message when the error
does not have an explicit message associated
suppresses correct inferrence by user-agents.

### 🔗 Linked issue

#3409

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Not setting a generic fallback message will instead leave it to the client to show a reasonable message. These are generally inferred from the status code (e.g. 404 -> "Not found"). There might be clients which do not have an internal lookup table and instead don't show any message but we don't really lose anything there over the generic "Server Error". Browsers and modern tools are generally capable of deducing a message because HTTP/2 does not even send these message any longer.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
