### PR TITLE
fix: add an option to change output `node_modules` permission

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -321,6 +321,9 @@ export function externals(opts: NodeExternalsOptions): Plugin {
           const dst = join(opts.outDir, "node_modules", pkgPath, subpath);
           await fsp.mkdir(dirname(dst), { recursive: true });
           await fsp.copyFile(src, dst);
+          if (opts.chmod) {
+            await fsp.chmod(dst, opts.chmod === true ? 0o644 : opts.chmod);
+          }
         }
 
         // Copy package.json

--- a/src/types/rollup.ts
+++ b/src/types/rollup.ts
@@ -49,6 +49,7 @@ export interface NodeExternalsOptions {
   exportConditions?: string[];
   traceInclude?: string[];
   traceAlias?: Record<string, string>;
+  chmod?: boolean | number;
 }
 
 export interface ServerAssetOptions {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#3418

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When Nitro uses a read-only `node_modules`, the Rollup `externals` plugins copies files and preserves the read-only permissions.
This results in a failure because the plugin needs to modify those files later in the build.

This PR applies `chmod 644` to all copied external files in the `.output/server/node_modules/*` folder.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
