### PR TITLE
feat(aws-amplify): add support for Node.js 20.x runtime in configuration

### DIFF
--- a/docs/2.deploy/20.providers/aws-amplify.md
+++ b/docs/2.deploy/20.providers/aws-amplify.md
@@ -31,6 +31,7 @@ export default defineNitroConfig({
       // catchAllStaticFallback: true,
       // imageOptimization: { path: "/_image", cacheControl: "public, max-age=3600, immutable" },
       // imageSettings: { ... },
+      // runtime: "nodejs18.x", // default: "nodejs18.x" | "nodejs16.x" | "nodejs20.x"
   }
 })
 ```
@@ -42,6 +43,7 @@ export default defineNuxtConfig({
       // catchAllStaticFallback: true,
       // imageOptimization: { "/_image", cacheControl: "public, max-age=3600, immutable" },
       // imageSettings: { ... },
+      // runtime: "nodejs18.x", // default: "nodejs18.x" | "nodejs16.x" | "nodejs20.x"
     }
   }
 })

--- a/src/presets/aws-amplify/types.ts
+++ b/src/presets/aws-amplify/types.ts
@@ -8,7 +8,7 @@ export interface AmplifyComputeConfig {
    * The runtime property dictates the runtime of the provisioned compute resource.
    * Values are subset of https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
    */
-  runtime: "nodejs16.x" | "nodejs18.x";
+  runtime: "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
 
   /**
    * Specifies the starting file from which code will run for the given compute resource.
@@ -158,4 +158,5 @@ export interface AWSAmplifyOptions {
     cacheControl?: string;
   };
   imageSettings?: AmplifyImageSettings;
+  runtime?: "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
 }

--- a/src/presets/aws-amplify/utils.ts
+++ b/src/presets/aws-amplify/utils.ts
@@ -89,7 +89,7 @@ export async function writeAmplifyFiles(nitro: Nitro) {
           {
             name: "default",
             entrypoint: "server.js",
-            runtime: "nodejs18.x",
+            runtime: nitro.options.awsAmplify?.runtime || "nodejs18.x",
           },
         ],
     framework: {


### PR DESCRIPTION
### 🔗 Linked issue

NA

### ❓ Type of change


- [x ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ x] 👌 Enhancement (improving an existing functionality like performance)
- [ x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

AWS Amplify supports different compute runtimes. So we should be able to choose which one to use

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x ] I have updated the documentation accordingly.
