### PR TITLE
fix(cloudflare-module): generate `_headers` in dist

### DIFF
--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -7,7 +7,7 @@ import {
   enableNodeCompat,
   writeWranglerConfig,
   writeCFRoutes,
-  writeCFPagesHeaders,
+  writeCFHeaders,
   writeCFPagesRedirects,
 } from "./utils";
 
@@ -53,7 +53,7 @@ const cloudflarePages = defineNitroPreset(
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "pages");
         await writeCFRoutes(nitro);
-        await writeCFPagesHeaders(nitro);
+        await writeCFHeaders(nitro);
         await writeCFPagesRedirects(nitro);
       },
     },
@@ -78,7 +78,7 @@ const cloudflarePagesStatic = defineNitroPreset(
     },
     hooks: {
       async compiled(nitro: Nitro) {
-        await writeCFPagesHeaders(nitro);
+        await writeCFHeaders(nitro);
         await writeCFPagesRedirects(nitro);
       },
     },
@@ -121,6 +121,7 @@ const cloudflareModule = defineNitroPreset(
       },
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "module");
+        await writeCFHeaders(nitro);
 
         await writeFile(
           resolve(nitro.options.output.dir, "package.json"),

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -105,7 +105,7 @@ function comparePaths(a: string, b: string) {
   return a.split("/").length - b.split("/").length || a.localeCompare(b);
 }
 
-export async function writeCFPagesHeaders(nitro: Nitro) {
+export async function writeCFHeaders(nitro: Nitro) {
   const headersPath = join(nitro.options.output.dir, "_headers");
   const contents = [];
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/nitrojs/nitro/issues/3441

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For the `cloudflare-module` preset, Cloudflare now supports `_headers` ([docs](https://developers.cloudflare.com/workers/static-assets/headers/)).

The `cloudflare-module` preset is updated here to support defining custom headers for static js/build assets via `routeRules`, similar to the `cloudflare_pages` preset ([source](https://github.com/nitrojs/nitro/blob/b2276b479784a52b62b66030cff7a38838cb5787/src/presets/cloudflare/utils.ts#L108C23-L108C42)).

I renamed the internal `writeCFPagesHeaders` method to `writeCFHeaders` since it is no longer Cloudflare Pages specific.

Resolves https://github.com/nitrojs/nitro/issues/3441

> [!Important]
> I can verify the `_headers` file is generated, but it would be nice to verify in a deployment before merge.

#### Verification

1. Update the `playground/nitro.config.ts` file with the following content:

    ```ts
    import { defineNitroConfig } from "nitropack/config";
    
    export default defineNitroConfig({
      compatibilityDate: "latest",
      srcDir: "server",
      preset: 'cloudflare-module',
      routeRules: {
        '/_assets/**': { headers: { 'Cache-Control': 'public, max-age=2592000, immutable' } }, /* 30 days */
      }
    });
    ```
2. Build the playground: `pnpm dev:build`
3. Verify the `playground/.output/_headers` file is generated with the following content:

    ```txt
    /_assets/*
      Cache-Control: public, max-age=2592000, immutable
    ```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
