### PR TITLE
feat(storage): export escapeKey utility v2

### DIFF
--- a/src/core/config/resolvers/imports.ts
+++ b/src/core/config/resolvers/imports.ts
@@ -76,6 +76,7 @@ function getNitroImportsPreset(): Preset[] {
         "defineCachedEventHandler",
         "cachedFunction",
         "cachedEventHandler",
+        "escapeKey",
       ],
     },
     {

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -5,4 +5,6 @@ export {
   cachedFunction,
   defineCachedEventHandler,
   defineCachedFunction,
+  escapeKey
 } from "./internal/cache";
+

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -35,4 +35,5 @@ export {
   defineCachedEventHandler,
   cachedFunction,
   cachedEventHandler,
+  escapeKey,
 } from "./internal/cache";

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -188,7 +188,7 @@ function getKey(...args: unknown[]) {
   return args.length > 0 ? hash(args) : "";
 }
 
-function escapeKey(key: string | string[]) {
+export function escapeKey(key: string | string[]) {
   return String(key).replace(/\W/g, "");
 }
 


### PR DESCRIPTION
## 🔧 Export `escapeKey` Utility from Storage

### 🧩 Summary

This PR exports the internal `escapeKey()` function from `runtime/storage/utils` so it can be reused externally in custom logic, particularly for managing cache keys consistently with Nitro's internal behavior.

---

### 💡 Why This Is Needed

Nitro internally uses `escapeKey()` to normalize request paths (e.g. `/api/products/123-abc`) into cache-safe keys like `apiproducts123abc`. This behavior is critical for consistent caching and storage operations.

However, without access to this function, developers can't reliably:

- Reconstruct the key used for a given path or route
- Remove a specific cache item by path
- Avoid inefficient broad cache clearing (`getKeys + removeItem`)
- Maintain consistency with Nitro's internal storage conventions

By exporting `escapeKey()`, developers can now convert a known `route.path` or endpoint into the actual key used in Nitro’s storage layer — enabling precise cache invalidation or direct cache manipulation.

---

### ✅ Example Use Case

```ts
import { escapeKey } from 'nitropack'

const key = escapeKey('/api/products/123-abc')
// key = "apiproducts123abc"

await useStorage('cache').removeItem(`products:productsData:${key}.json`)
