### PR TITLE
docs(cache): add note about normalizing keys

### DIFF
--- a/docs/1.guide/6.cache.md
+++ b/docs/1.guide/6.cache.md
@@ -303,7 +303,9 @@ await useStorage('cache').removeItem('nitro:functions:getAccessToken:default.jso
 
 ### Normalizing Cache Keys
 
+::important
 **Cache keys are automatically normalized** using an internal utility that removes non-alphanumeric characters such as `/` and `-`. This behavior helps ensure compatibility across various storage backends (e.g., `file systems`, `key-value` stores) that might have restrictions on characters in `keys`, and also prevents potential path traversal vulnerabilities.
+::
 
 For example:
 
@@ -319,11 +321,17 @@ api/productssaleitems.json
 
 This behavior may result in keys that look different from the original route or identifier.
 
-🔑 `escapeKey(key: string): string`
+::tip
+To manually reproduce the same normalized key pattern used by Nitro (e.g., when invalidating cache entries), you can use the `escapeKey` utility function provided below:
+::
 
-To manually reproduce the same normalized key pattern used by Nitro (e.g., when invalidating cache entries), you can use the newly exported `escapeKey` utility:
+```ts
+function escapeKey(key: string | string[]) {
+  return String(key).replace(/\W/g, "");
+}
+```
 
-It is recommended to use `escapeKey()` when invalidating manually using route paths or identifiers to ensure consistency with Nitro's internal key generation.
+It's recommended to use `escapeKey()` when invalidating manually using route paths or identifiers to ensure consistency with Nitro's internal key generation.
 
 For example, if your `getKey` function is:
 

--- a/docs/1.guide/6.cache.md
+++ b/docs/1.guide/6.cache.md
@@ -300,3 +300,40 @@ You can invalidate the cached function entry with:
 ```ts
 await useStorage('cache').removeItem('nitro:functions:getAccessToken:default.json')
 ```
+
+### Normalizing Cache Keys
+
+**Cache keys are automatically normalized** using an internal utility that removes non-alphanumeric characters such as `/` and `-`. This behavior helps ensure compatibility across various storage backends (e.g., `file systems`, `key-value` stores) that might have restrictions on characters in `keys`, and also prevents potential path traversal vulnerabilities.
+
+For example:
+
+```ts
+getKey: () => '/api/products/sale-items'
+```
+
+Would generate a key like:
+
+```ts
+api/productssaleitems.json
+```
+
+This behavior may result in keys that look different from the original route or identifier.
+
+🔑 `escapeKey(key: string): string`
+
+To manually reproduce the same normalized key pattern used by Nitro (e.g., when invalidating cache entries), you can use the newly exported `escapeKey` utility:
+
+It is recommended to use `escapeKey()` when invalidating manually using route paths or identifiers to ensure consistency with Nitro's internal key generation.
+
+For example, if your `getKey` function is:
+
+```ts
+getKey: (id: string) => `product/${id}/details`
+```
+
+And you want to invalidate `product/123/details`, you would do:
+
+```ts
+const normalizedKey = escapeKey('product/123/details')
+await useStorage('cache').removeItem(`nitro:functions:getProductDetails:${normalizedKey}.json`)
+```


### PR DESCRIPTION
# Added documentation for Nitro v2 cache key normalization

This update adds detailed documentation on how Nitro v2 automatically normalizes cache keys to improve compatibility and security.

## Key points included:

- Explanation of the automatic normalization process that removes non-alphanumeric characters such as `/` and `-` from cache keys.
- Examples illustrating how raw keys like `/api/products/sale-items` are transformed into normalized keys such as `api/productssaleitems.json`.
- Introduction of the new `escapeKey(key: string): string` utility function exported by Nitro.
- Guidance on how to use `escapeKey()` to manually reproduce Nitro’s normalized cache key format, especially useful when manually invalidating cache entries.
- Code samples demonstrating both the normalization and manual invalidation processes.

This helps developers better understand cache key handling and ensures consistency when interacting with Nitro's cache storage system.