### PR TITLE
feat(vite): detect server entry

### DIFF
--- a/playground/vite.config.mjs
+++ b/playground/vite.config.mjs
@@ -2,11 +2,5 @@ import { defineConfig } from "vite";
 import { nitro } from "nitro/vite";
 
 export default defineConfig({
-  plugins: [
-    nitro({
-      services: {
-        ssr: { entry: "./server.ts" },
-      },
-    }),
-  ],
+  plugins: [nitro()],
 });

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -5,7 +5,7 @@ import type { NitroPluginContext } from "./types";
 import { relative, resolve } from "pathe";
 import { readFile, rm } from "node:fs/promises";
 import { formatCompatibilityDate } from "compatx";
-import { copyPublicAssets, prerender } from "../..";
+import { copyPublicAssets, prepare, prerender } from "../..";
 import { nitroServerName } from "../../utils/nitro";
 
 export async function buildProduction(
@@ -52,6 +52,9 @@ export async function buildProduction(
   nitro.logger.start(
     `Building \`${nitroServerName(nitro)}\` (preset: \`${nitro.options.preset}\`, compatibility date: \`${formatCompatibilityDate(nitro.options.compatibilityDate)}\`)`
   );
+
+  // Cleanup build directories
+  await prepare(nitro);
 
   // Call the rollup:before hook for compatibility
   await nitro.hooks.callHook(


### PR DESCRIPTION
#3461

Working on [vite-examples](https://github.com/nitrojs/vite-examples) it is more convinient for custom services to have a simple `server` entry (provided for vite's default `ssr` env)

With this feature, only if users don't already explicitly define `ssr` service or `ssr` environment, and if a `server.{ext}` exists in project root (similar to `index.html`) will be used as entrypoint for SSR.

In case of metaframework integrations, they usually most implement `ssr` service themeselves so this future is mainly for direct nitro plugin users.