### PR TITLE
refactor(vite): use worker without wrapper for nitro env in dev

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -6,13 +6,10 @@ import type {
   ViteDevServer,
 } from "vite";
 
-import { resolve } from "node:path";
 import { createServer } from "node:http";
-import { runtimeDir } from "nitro/runtime/meta";
 import { NodeRequest, sendNodeResponse } from "srvx/node";
 import { getSocketAddress, isSocketSupported } from "get-port-please";
 import { DevEnvironment } from "vite";
-import { NitroDevServer } from "../../dev/server";
 
 // https://vite.dev/guide/api-environment-runtimes.html#modulerunner
 
@@ -91,30 +88,6 @@ function createTransport(hooks: TransportHooks): HotChannel {
       }
     },
   };
-}
-
-// ---- Nitro Dev Environment ----
-
-export async function createNitroDevEnvironment(
-  ctx: NitroPluginContext,
-  name: string,
-  config: ResolvedConfig
-): Promise<FetchableDevEnvironment> {
-  const nitroDev = new NitroDevServer(ctx.nitro!);
-  return createFetchableDevEnvironment(name, config, {
-    fetch: nitroDev.fetch.bind(nitroDev),
-    onMessage: nitroDev.onMessage.bind(nitroDev),
-    offMessage: nitroDev.offMessage.bind(nitroDev),
-    sendMessage: nitroDev.sendMessage.bind(nitroDev),
-    async init() {
-      await ctx.nitro!.hooks.callHook("dev:reload", {
-        entry: resolve(runtimeDir, "internal/vite/worker.mjs"),
-        workerData: {
-          viteEntry: ctx.nitro!.options.entry,
-        },
-      });
-    },
-  });
 }
 
 // ---- Vite Dev Server Integration ----

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -5,10 +5,7 @@ import { NodeDevWorker } from "../../dev/worker";
 import { join, resolve } from "node:path";
 import { runtimeDir } from "nitro/runtime/meta";
 import { resolveModulePath } from "exsolve";
-import {
-  createFetchableDevEnvironment,
-  createNitroDevEnvironment,
-} from "./dev";
+import { createFetchableDevEnvironment } from "./dev";
 
 export function createNitroEnvironment(
   ctx: NitroPluginContext
@@ -31,8 +28,24 @@ export function createNitroEnvironment(
       externalConditions: ctx.nitro!.options.exportConditions,
     },
     dev: {
-      createEnvironment: (name, config) =>
-        createNitroDevEnvironment(ctx, name, config),
+      createEnvironment: (envName, envConfig) =>
+        createFetchableDevEnvironment(
+          envName,
+          envConfig,
+          new NodeDevWorker({
+            name: envName,
+            entry: resolve(runtimeDir, "internal/vite/worker.mjs"),
+            data: {
+              name: envName,
+              server: true,
+              viteEntry: resolve(runtimeDir, "internal/vite/nitro-dev.mjs"),
+              globals: {
+                __NITRO_RUNTIME_CONFIG__: ctx.nitro!.options.runtimeConfig,
+              },
+            },
+            hooks: {},
+          })
+        ),
     },
   };
 }

--- a/src/runtime/internal/vite/nitro-dev.mjs
+++ b/src/runtime/internal/vite/nitro-dev.mjs
@@ -1,0 +1,6 @@
+import "#nitro-internal-pollyfills";
+import { useNitroApp } from "nitro/runtime";
+
+const nitroApp = useNitroApp();
+
+export const fetch = nitroApp.fetch;


### PR DESCRIPTION
#3461

Classic nitro has a full-featured dev server entry with support for devHandlers. serving staticc assets, etc + a multi-worker manager, as with classic full-bundle rollup builds in dev, we need to swap workers to reload.

With vite plugin, we use it's runner RPC for HMR and also vite's dev server for dev middleware therefore we can also avoid using wrapper to simplify setup.


