### PR TITLE
feat: dev presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@vercel/nft": "^0.29.4",
     "archiver": "^7.0.1",
-    "c12": "^3.0.4",
+    "c12": "^3.1.0",
     "chokidar": "^4.0.3",
     "citty": "^0.1.6",
     "compatx": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       c12:
-        specifier: ^3.0.4
-        version: 3.0.4(magicast@0.3.5)
+        specifier: ^3.1.0
+        version: 3.1.0(magicast@0.3.5)
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -201,7 +201,7 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       unenv:
-        specifier: 2.0.0-rc.18
+        specifier: ^2.0.0-rc.18
         version: 2.0.0-rc.18
       unimport:
         specifier: ^5.1.0
@@ -2533,8 +2533,8 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  c12@3.0.4:
-    resolution: {integrity: sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==}
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
     peerDependencies:
       magicast: ^0.3.5
     peerDependenciesMeta:
@@ -9010,7 +9010,7 @@ snapshots:
   automd@0.4.0(magicast@0.3.5):
     dependencies:
       '@parcel/watcher': 2.5.1
-      c12: 3.0.4(magicast@0.3.5)
+      c12: 3.1.0(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -9156,7 +9156,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@3.0.4(magicast@0.3.5):
+  c12@3.1.0(magicast@0.3.5):
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.2
@@ -9219,7 +9219,7 @@ snapshots:
 
   changelogen@0.6.2(magicast@0.3.5):
     dependencies:
-      c12: 3.0.4(magicast@0.3.5)
+      c12: 3.1.0(magicast@0.3.5)
       confbox: 0.2.2
       consola: 3.4.2
       convert-gitmoji: 0.1.5

--- a/scripts/gen-presets.ts
+++ b/scripts/gen-presets.ts
@@ -51,7 +51,7 @@ for (const preset of allPresets) {
   const names = [preset._meta.name, ...(preset._meta.aliases || [])];
   for (const name of names) {
     if (_names.has(name)) {
-      if (!preset._meta.compatibilityDate) {
+      if (!preset._meta.compatibilityDate && !preset._meta.dev) {
         consola.warn(`Preset ${name} is duplicated`);
       }
       continue;

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -38,7 +38,6 @@ export default defineCommand({
         {
           rootDir,
           dev: true,
-          preset: "nitro-dev",
           _cli: { command: "dev" },
         },
         {

--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -82,6 +82,9 @@ async function _loadUserConfig(
     "nitropack/" + "presets"
   )) as typeof import("nitropack/presets");
 
+  // prettier-ignore
+  let preset: string | undefined = (configOverrides.preset as string) || process.env.NITRO_PRESET || process.env.SERVER_PRESET
+
   const loadedConfig = await (
     opts.watch
       ? watchConfig<NitroConfig & { _meta?: NitroPresetMeta }>
@@ -110,8 +113,9 @@ async function _loadUserConfig(
       const framework = getConf("framework")
       const isCustomFramework = framework?.name && framework.name !== "nitro";
 
-      // prettier-ignore
-      let preset: string | undefined = (configOverrides.preset as string) || process.env.NITRO_PRESET || process.env.SERVER_PRESET || getConf("preset")
+      if (!preset) {
+        preset = getConf("preset");
+      }
 
       if (configOverrides.dev) {
         // Check if preset has compatible dev support
@@ -166,9 +170,9 @@ async function _loadUserConfig(
   options._config = configOverrides;
   options._c12 = loadedConfig;
 
-  const _presetName = (loadedConfig.layers || []).find(
-    (l) => l.config?._meta?.name
-  )?.config?._meta?.name;
+  const _presetName =
+    (loadedConfig.layers || []).find((l) => l.config?._meta?.name)?.config
+      ?._meta?.name || preset;
   options.preset = _presetName as PresetName;
 
   options.compatibilityDate = resolveCompatibilityDates(

--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -1,4 +1,5 @@
 import { loadConfig, watchConfig } from "c12";
+import consola from "consola";
 import { type CompatibilityDateSpec, resolveCompatibilityDates } from "compatx";
 import { klona } from "klona/full";
 import type { PresetName } from "nitropack/presets";
@@ -62,15 +63,6 @@ async function _loadUserConfig(
   configOverrides: NitroConfig = {},
   opts: LoadConfigOptions = {}
 ): Promise<NitroOptions> {
-  // Preset
-  let presetOverride =
-    (configOverrides.preset as string) ||
-    process.env.NITRO_PRESET ||
-    process.env.SERVER_PRESET;
-  if (configOverrides.dev) {
-    presetOverride = "nitro-dev";
-  }
-
   // Load configuration and preset
   configOverrides = klona(configOverrides);
 
@@ -99,36 +91,6 @@ async function _loadUserConfig(
     cwd: configOverrides.rootDir,
     dotenv: opts.dotenv ?? configOverrides.dev,
     extend: { extendKey: ["extends", "preset"] },
-    overrides: {
-      ...configOverrides,
-      preset: presetOverride,
-    },
-    async defaultConfig({ configs }) {
-      const getConf = <K extends keyof NitroConfig>(key: K) =>
-        (configOverrides[key] ??
-          configs.main?.[key] ??
-          configs.rc?.[key] ??
-          configs.packageJson?.[key]) as NitroConfig[K];
-
-      if (!compatibilityDate) {
-        compatibilityDate = getConf("compatibilityDate");
-      }
-      const framework = configs.overrides?.framework || configs.main?.framework;
-      return {
-        typescript: {
-          generateRuntimeConfigTypes:
-            !framework?.name || framework.name === "nitro",
-        },
-        preset:
-          presetOverride ||
-          (
-            await resolvePreset("" /* auto detect */, {
-              static: getConf("static"),
-              compatibilityDate: compatibilityDate || fallbackCompatibilityDate,
-            })
-          )?._meta?.name,
-      };
-    },
     defaults: NitroDefaults,
     jitiOptions: {
       alias: {
@@ -136,10 +98,59 @@ async function _loadUserConfig(
         "nitropack/config": "nitropack/config",
       },
     },
+    async overrides({ rawConfigs }) {
+      // prettier-ignore
+      const getConf = <K extends keyof NitroConfig>(key: K) => (configOverrides[key] ?? (rawConfigs.main as NitroConfig)?.[key] ?? (rawConfigs.rc as NitroConfig)?.[key] ?? (rawConfigs.packageJson as NitroConfig)?.[key]) as NitroConfig[K];
+
+      if (!compatibilityDate) {
+        compatibilityDate = getConf("compatibilityDate");
+      }
+
+      // prettier-ignore
+      const framework = getConf("framework")
+      const isCustomFramework = framework?.name && framework.name !== "nitro";
+
+      // prettier-ignore
+      let preset: string | undefined = (configOverrides.preset as string) || process.env.NITRO_PRESET || process.env.SERVER_PRESET || getConf("preset")
+
+      if (configOverrides.dev) {
+        // Check if preset has compatible dev support
+        // Otherwise use default nitro-dev preset
+        preset =
+          preset && preset !== "nitro-dev"
+            ? await resolvePreset(preset, {
+                static: getConf("static"),
+                dev: true,
+                compatibilityDate:
+                  compatibilityDate || fallbackCompatibilityDate,
+              })
+                .then((p) => p?._meta?.name)
+                .catch(() => "nitro-dev")
+            : "nitro-dev";
+      } else if (!preset) {
+        // Auto detect production preset
+        preset = await resolvePreset("" /* auto detect */, {
+          static: getConf("static"),
+          dev: false,
+          compatibilityDate: compatibilityDate || fallbackCompatibilityDate,
+        }).then((p) => p?._meta?.name);
+      }
+
+      return {
+        ...configOverrides,
+        preset,
+        typescript: {
+          generateRuntimeConfigTypes: !isCustomFramework,
+          ...getConf("typescript"),
+          ...configOverrides.typescript,
+        },
+      };
+    },
     async resolve(id: string) {
       const preset = await resolvePreset(id, {
         static: configOverrides.static,
         compatibilityDate: compatibilityDate || fallbackCompatibilityDate,
+        dev: configOverrides.dev,
       });
       if (preset) {
         return {
@@ -155,15 +166,21 @@ async function _loadUserConfig(
   options._config = configOverrides;
   options._c12 = loadedConfig;
 
-  const _presetName =
-    (loadedConfig.layers || []).find((l) => l.config?._meta?.name)?.config
-      ?._meta?.name || presetOverride;
+  const _presetName = (loadedConfig.layers || []).find(
+    (l) => l.config?._meta?.name
+  )?.config?._meta?.name;
   options.preset = _presetName as PresetName;
 
   options.compatibilityDate = resolveCompatibilityDates(
     compatibilityDate,
     options.compatibilityDate
   );
+
+  if (options.dev && options.preset !== "nitro-dev") {
+    consola.info(
+      `Enabled \`${options.preset}\` emulation in development mode.`
+    );
+  }
 
   return options;
 }

--- a/src/presets/_nitro/nitro-dev.ts
+++ b/src/presets/_nitro/nitro-dev.ts
@@ -2,7 +2,6 @@ import { defineNitroPreset } from "nitropack/kit";
 
 const nitroDev = defineNitroPreset(
   {
-    extends: "node",
     entry: "./runtime/nitro-dev",
     output: {
       dir: "{{ buildDir }}/dev",
@@ -10,11 +9,13 @@ const nitroDev = defineNitroPreset(
       publicDir: "{{ buildDir }}/dev",
     },
     externals: { trace: false },
+    serveStatic: true,
     inlineDynamicImports: true, // externals plugin limitation
     sourceMap: true,
   },
   {
     name: "nitro-dev" as const,
+    dev: true,
     url: import.meta.url,
   }
 );

--- a/src/presets/_resolve.ts
+++ b/src/presets/_resolve.ts
@@ -18,8 +18,16 @@ const _stdProviderMap: Partial<Record<ProviderName, PlatformName>> = {
 
 export async function resolvePreset(
   name: string,
-  opts: { static?: boolean; compatibilityDate?: false | CompatibilityDateSpec }
+  opts: {
+    static?: boolean;
+    compatibilityDate?: false | CompatibilityDateSpec;
+    dev?: boolean;
+  } = {}
 ): Promise<(NitroPreset & { _meta?: NitroPresetMeta }) | undefined> {
+  if (name === ".") {
+    return undefined; // invalid input
+  }
+
   const _name = kebabCase(name) || provider;
 
   const _compatDates = opts.compatibilityDate
@@ -31,6 +39,11 @@ export async function resolvePreset(
       // prettier-ignore
       const names = [preset._meta.name, preset._meta.stdName, ...(preset._meta.aliases || [])].filter(Boolean);
       if (!names.includes(_name)) {
+        return false;
+      }
+
+      // Match dev|prod
+      if ((opts.dev && !preset._meta.dev) || (!opts.dev && preset._meta.dev)) {
         return false;
       }
 
@@ -69,6 +82,7 @@ export async function resolvePreset(
     return preset();
   }
 
+  // Auto-detect preset
   if (!name && !preset) {
     return opts?.static
       ? resolvePreset("static", opts)

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -10,5 +10,6 @@ export interface NitroPresetMeta {
   stdName?: ProviderName;
   aliases?: string[];
   static?: boolean;
+  dev?: boolean;
   compatibilityDate?: DateString;
 }


### PR DESCRIPTION
This PR adds support for built-in dev presets to be implemented, emulating closer to production environment and adding any additional primitives.

```js
export const presetDev = defineNitroPreset(
  {
    extends: "nitro-dev",
    // hooks and extended config for env emulation
  },
  {
    name: "preset",
    dev: true,
    url: import.meta.url,
  }
);
```

---


This change is a little bit risky, especially for wrapper frameworks but should work well.

Checklist for meta frameworks:
- For dev, `preset: "nitro-dev"` should not be hardcoded
- `typescript.generateRuntimeConfigTypes` should be disabled as before if `framework.name` is set