### PR TITLE
feat: `ssrRoutes`

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -287,11 +287,12 @@ type ObservibilityRoute = {
 function getObservibilityRoutes(nitro: Nitro): ObservibilityRoute[] {
   // Sort routes by how much specific they are
   const routePatterns = [
-    ...new Set(
-      [...nitro.scannedHandlers, ...nitro.options.handlers]
+    ...new Set([
+      ...(nitro.options.ssrRoutes || []),
+      ...[...nitro.scannedHandlers, ...nitro.options.handlers]
         .filter((h) => !h.middleware && h.route)
-        .map((h) => h.route!)
-    ),
+        .map((h) => h.route!),
+    ]),
   ];
 
   const staticRoutes: string[] = [];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -89,6 +89,7 @@ export interface NitroOptions extends PresetOptions {
   bundledStorage: string[];
   timing: boolean;
   renderer?: string;
+  ssrRoutes: string[];
   serveStatic: boolean | "node" | "deno" | "inline";
   noPublicDir: boolean;
 


### PR DESCRIPTION
Related to #3474

This PR adds an agnostic config for frameworks like Nuxt to declare their SSR routes, usable to integrate with platform observability to split routes. 

The expected pattern is same as [rou3](https://github.com/unjs/rou3) which is more limiting but more consistent and guaranteed to work with possibile future places that have limited pattern support and also possibly to integrate with built-in router.