### PR TITLE
revert #3394

### DIFF
--- a/src/core/prerender/prerender.ts
+++ b/src/core/prerender/prerender.ts
@@ -5,7 +5,6 @@ import mime from "mime";
 import { writeFile } from "nitropack/kit";
 import type {
   Nitro,
-  NitroConfig,
   NitroRouteRules,
   PrerenderRoute,
   PublicAssetDir,
@@ -69,12 +68,9 @@ export async function prerender(nitro: Nitro) {
     ...nitro.options._config,
     static: false,
     rootDir: nitro.options.rootDir,
-    output: {
-      serverDir: "{{ buildDir }}/prerender",
-    },
     logLevel: 0,
     preset: "nitro-prerender",
-  } satisfies NitroConfig;
+  };
   await nitro.hooks.callHook("prerender:config", prerendererConfig);
   const nitroRenderer = await createNitro(prerendererConfig);
   const prerenderStartTime = Date.now();


### PR DESCRIPTION
/cc @kricsleo

Temporarily reverts nitrojs/nitro#3394 as running tests locally fails (need to properly investigate)

```
[request error] [unhandled] [GET] http://localhost/_swagger
 H3Error: ENOENT: no such file or directory, open '/private/Users/pooya/Code/nitro-v2/test/fixture/.output/public/_swagger/index.html'
    at open (node:internal/fs/promises:638:25)
    ... 8 lines matching cause stack trace ...
    at async Promise.all (index 0) {
  cause: Error: ENOENT: no such file or directory, open '/private/Users/pooya/Code/nitro-v2/test/fixture/.output/public/_swagger/index.html'
      at open (node:internal/fs/promises:638:25)
      at Object.readFile (node:internal/fs/promises:1242:14)
      at file:///Users/pooya/Code/nitro-v2/node_modules/.pnpm/h3@1.15.3/node_modules/h3/dist/index.mjs:2003:19
      at Object.callAsync (file:///Users/pooya/Code/nitro-v2/node_modules/.pnpm/unctx@2.4.1/node_modules/unctx/dist/index.mjs:72:16)
      at toNodeHandle (file:///Users/pooya/Code/nitro-v2/node_modules/.pnpm/h3@1.15.3/node_modules/h3/dist/index.mjs:2295:7)
      at b (file:///Users/pooya/Code/nitro-v2/node_modules/.pnpm/node-mock-http@1.0.1/node_modules/node-mock-http/dist/index.mjs:1:6827)
      at C (file:///Users/pooya/Code/nitro-v2/node_modules/.pnpm/node-mock-http@1.0.1/node_modules/node-mock-http/dist/index.mjs:1:7110)
      at generateRoute (/Users/pooya/Code/nitro-v2/src/core/prerender/prerender.ts:216:17)
      at async Promise.all (index 0)
      at async Promise.all (index 0) {
```