### PR TITLE
fix(build): resolve `deploy` and `preview` commands

### DIFF
--- a/src/core/build/prod.ts
+++ b/src/core/build/prod.ts
@@ -45,8 +45,8 @@ export async function buildProduction(
       nitro: nitroVersion,
     },
     commands: {
-      preview: nitro.options.commands.preview,
-      deploy: nitro.options.commands.deploy,
+      preview: resolveTmplPath(nitro.options.commands.preview, nitro),
+      deploy: resolveTmplPath(nitro.options.commands.deploy, nitro),
     },
     config: {
       ...Object.fromEntries(
@@ -72,26 +72,14 @@ export async function buildProduction(
   await nitro.hooks.callHook("compiled", nitro);
 
   // Show deploy and preview hints
-  const rOutput = relative(process.cwd(), nitro.options.output.dir);
-  const rewriteRelativePaths = (input: string) => {
-    return input.replace(/([\s:])\.\/(\S*)/g, `$1${rOutput}/$2`);
-  };
-  if (buildInfo.commands!.preview) {
+  if (buildInfo.commands?.preview) {
     nitro.logger.success(
-      `You can preview this build using \`${_compilePathCommandTemplate(
-        rewriteRelativePaths(buildInfo.commands!.preview),
-        nitro.options,
-        nitro.options.rootDir
-      )}\``
+      `You can preview this build using \`${buildInfo.commands?.preview}\``
     );
   }
-  if (buildInfo.commands!.deploy) {
+  if (buildInfo.commands?.deploy) {
     nitro.logger.success(
-      `You can deploy this build using \`${_compilePathCommandTemplate(
-        rewriteRelativePaths(buildInfo.commands!.deploy),
-        nitro.options,
-        nitro.options.rootDir
-      )}\``
+      `You can deploy this build using \`${buildInfo.commands?.deploy}\``
     );
   }
 }
@@ -123,23 +111,17 @@ async function _snapshot(nitro: Nitro) {
   );
 }
 
-function _compilePathCommandTemplate(
-  contents: string,
-  data: Record<string, any>,
-  base: string
-) {
-  if (!contents.includes("{{")) {
-    return contents;
+function resolveTmplPath(input: string | undefined, nitro: Nitro) {
+  if (!input || !input.includes("{{")) {
+    return input;
   }
-
-  return contents.replace(/{{ ?([\w.]+) ?}}/g, (_, match) => {
-    let val = getProperty<Record<string, string>, string>(data, match);
+  return input.replace(/{{ ?([\w.]+) ?}}/g, (_, match) => {
+    let val = getProperty<Record<string, string>, string>(
+      nitro.options as unknown as Record<string, string>,
+      match
+    );
     if (val) {
-      val = relative(base, val);
-    } else {
-      consola.warn(
-        `cannot resolve template param '${match}' in ${contents.slice(0, 20)}`
-      );
+      val = relative(nitro.options.rootDir, val);
     }
     return val || `${match}`;
   });

--- a/src/core/build/prod.ts
+++ b/src/core/build/prod.ts
@@ -13,7 +13,6 @@ import { snapshotStorage } from "../utils/storage";
 import { formatRollupError } from "./error";
 import { writeTypes } from "./types";
 import { getProperty } from "dot-prop";
-import { consola } from "consola";
 
 export async function buildProduction(
   nitro: Nitro,
@@ -122,6 +121,10 @@ function resolveTmplPath(input: string | undefined, nitro: Nitro) {
     );
     if (val) {
       val = relative(nitro.options.rootDir, val);
+    } else {
+      nitro.logger.warn(
+        `cannot resolve template param '${match}' in ${input.slice(0, 20)}`
+      );
     }
     return val || `${match}`;
   });

--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -21,8 +21,8 @@ const cloudflarePages = defineNitroPreset(
     entry: "./runtime/cloudflare-pages",
     exportConditions: ["workerd"],
     commands: {
-      preview: "npx wrangler --cwd ./ pages dev",
-      deploy: "npx wrangler --cwd ./ pages deploy",
+      preview: "npx wrangler --cwd {{ output.dir }} pages dev",
+      deploy: "npx wrangler --cwd {{ output.dir }} pages deploy",
     },
     output: {
       dir: "{{ rootDir }}/dist",
@@ -80,8 +80,8 @@ const cloudflarePagesStatic = defineNitroPreset(
       publicDir: "{{ output.dir }}/{{ baseURL }}",
     },
     commands: {
-      preview: "npx wrangler --cwd ./ pages dev",
-      deploy: "npx wrangler --cwd ./ pages deploy",
+      preview: "npx wrangler --cwd {{ output.dir }} pages dev",
+      deploy: "npx wrangler --cwd {{ output.dir }} pages deploy",
     },
     hooks: {
       "build:before": async (nitro) => {
@@ -132,8 +132,8 @@ const cloudflareModule = defineNitroPreset(
     },
     exportConditions: ["workerd"],
     commands: {
-      preview: "npx wrangler --cwd ./ dev",
-      deploy: "npx wrangler --cwd ./ deploy",
+      preview: "npx wrangler --cwd {{ output.dir }} dev",
+      deploy: "npx wrangler --cwd {{ output.dir }} deploy",
     },
     unenv: [unenvCfExternals],
     rollupConfig: {

--- a/src/presets/deno/preset-legacy.ts
+++ b/src/presets/deno/preset-legacy.ts
@@ -14,7 +14,7 @@ export const denoServerLegacy = defineNitroPreset(
     entry: "./runtime/deno-server",
     exportConditions: ["deno"],
     commands: {
-      preview: "deno task --config ./deno.json start",
+      preview: "deno task --config {{ output.dir }}/deno.json start",
     },
     unenv: {
       inject: {

--- a/src/presets/deno/preset.ts
+++ b/src/presets/deno/preset.ts
@@ -15,7 +15,7 @@ const denoDeploy = defineNitroPreset(
     commands: {
       preview: "",
       deploy:
-        "cd ./ && deployctl deploy --project=<project_name> {{ output.serverDir }}/index.ts",
+        "cd {{ output.dir }} && deployctl deploy --project=<project_name> ./server/index.ts",
     },
     unenv: unenvDenoPreset,
     rollupConfig: {
@@ -41,7 +41,7 @@ const denoServer = defineNitroPreset(
     entry: "./runtime/deno-server",
     exportConditions: ["deno"],
     commands: {
-      preview: "deno task --config ./deno.json start",
+      preview: "deno task --config {{ output.dir }}/deno.json start",
     },
     rollupConfig: {
       external: (id) => id.startsWith("https://"),

--- a/src/presets/edgio/preset.ts
+++ b/src/presets/edgio/preset.ts
@@ -7,8 +7,8 @@ const edgio = defineNitroPreset(
   {
     extends: "node-server",
     commands: {
-      deploy: "cd ./ && npm run deploy",
-      preview: "cd ./ && npm run preview",
+      deploy: "cd {{ output.dir }} && npm run deploy",
+      preview: "cd {{ output.dir }} && npm run preview",
     },
     hooks: {
       async compiled(nitro) {

--- a/src/presets/netlify/legacy/preset.ts
+++ b/src/presets/netlify/legacy/preset.ts
@@ -134,7 +134,7 @@ const netlifyStatic = defineNitroPreset(
       publicDir: "{{ rootDir }}/dist",
     },
     commands: {
-      preview: "npx serve ./",
+      preview: "npx serve {{ output.dir }}",
     },
     hooks: {
       "rollup:before": (nitro: Nitro) => {

--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -123,7 +123,7 @@ const netlifyStatic = defineNitroPreset(
       publicDir: "{{ rootDir }}/dist/{{ baseURL }}",
     },
     commands: {
-      preview: "npx serve ./",
+      preview: "npx serve {{ output.dir }}",
     },
     hooks: {
       async compiled(nitro: Nitro) {

--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -22,8 +22,8 @@ const vercel = defineNitroPreset(
       publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
-      deploy: "",
       preview: "",
+      deploy: "npx vercel deploy --prebuilt",
     },
     hooks: {
       "rollup:before": (nitro: Nitro) => {
@@ -52,8 +52,8 @@ const vercelEdge = defineNitroPreset(
       publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
-      deploy: "",
       preview: "",
+      deploy: "npx vercel deploy --prebuilt",
     },
     unenv: {
       external: builtnNodeModules.flatMap((m) => `node:${m}`),
@@ -99,6 +99,7 @@ const vercelStatic = defineNitroPreset(
     },
     commands: {
       preview: "npx serve {{ output.publicDir }}",
+      deploy: "npx vercel deploy --prebuilt",
     },
     hooks: {
       "rollup:before": (nitro: Nitro) => {


### PR DESCRIPTION
Resolves #3480

With #3388, we have introduced a fix to properly resolve deploy/preview hint commands; however, in the generated `nitro.json`, frameworks need to support this, which might not be straightforward immediately.

This PR:
 - Resolves commands inside `nitro.json`
 - Updates the deploy/deploy command in missing places
 - Uses consistent resolution from rootDir instead of cwd also for CLI output (slight behavior change)

