### PR TITLE
fix(config): fallback to `nitro-dev` for older compatibility dates

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -128,7 +128,7 @@ async function _loadUserConfig(
                 compatibilityDate:
                   compatibilityDate || fallbackCompatibilityDate,
               })
-                .then((p) => p?._meta?.name)
+                .then((p) => p?._meta?.name || "nitro-dev")
                 .catch(() => "nitro-dev")
             : "nitro-dev";
       } else if (!preset) {


### PR DESCRIPTION
Resolves #3485 (regression from #3467 in 2.12)

In dev mode, if a preset has compatible dev variant but only under an older compatibility date `resolvePreset` won't throw and we need to still fallback to `"nitro-dev"` as default (it is only reproducable in external repos)

