### PR TITLE
fix(vite): use buildApp hook and construct manifest from bundle

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -1,7 +1,6 @@
-import type { Plugin as VitePlugin } from "vite";
+import { type Plugin as VitePlugin, normalizePath } from "vite";
 import type { Plugin as RollupPlugin } from "rollup";
 import type { NitroPluginConfig, NitroPluginContext } from "./types";
-
 import { join, resolve } from "node:path";
 import { createNitro } from "../..";
 import { getViteRollupConfig } from "./rollup";
@@ -14,6 +13,7 @@ import * as rou3 from "rou3";
 import * as rou3Compiler from "rou3/compiler";
 import { resolveModulePath } from "exsolve";
 import { prettyPath } from "../../utils/fs";
+import path from "node:path";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html
@@ -23,6 +23,8 @@ export async function nitro(
 ): Promise<VitePlugin> {
   const ctx: NitroPluginContext = {
     pluginConfig,
+    _entryPoints: {},
+    _manifest: {},
   };
 
   return {
@@ -124,11 +126,48 @@ export async function nitro(
         builder: {
           /// Share the config instance among environments to align with the behavior of dev server
           sharedConfigBuild: true,
-          async buildApp(builder) {
-            await buildProduction(ctx, builder);
-          },
         },
       };
+    },
+
+    buildApp: {
+      order: "post",
+      handler(builder) {
+        return buildProduction(ctx, builder);
+      },
+    },
+
+    generateBundle: {
+      handler(_options, bundle) {
+        const { root } = this.environment.config;
+        // find entry point of this service
+        let entryFile: string | undefined;
+        for (const [_name, file] of Object.entries(bundle)) {
+          if (file.type === "chunk") {
+            if (file.isEntry) {
+              if (entryFile !== undefined) {
+                this.error(
+                  `Multiple entry points found for service "${this.environment.name}". Only one entry point is allowed.`
+                );
+              }
+              entryFile = file.fileName;
+            }
+            const filteredModuleIds = file.moduleIds.filter((id) =>
+              id.startsWith(root)
+            );
+            for (const id of filteredModuleIds) {
+              const originalFile = path.relative(root, normalizePath(id));
+              ctx._manifest[originalFile] = { file: file.fileName };
+            }
+          }
+        }
+        if (entryFile === undefined) {
+          this.error(
+            `No entry point found for service "${this.environment.name}".`
+          );
+        }
+        ctx._entryPoints![this.environment.name] = entryFile!;
+      },
     },
 
     // Modify environment configs before it's resolved.

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -1,7 +1,7 @@
 import { type Plugin as VitePlugin, normalizePath } from "vite";
 import type { Plugin as RollupPlugin } from "rollup";
 import type { NitroPluginConfig, NitroPluginContext } from "./types";
-import { join, resolve } from "node:path";
+import { join, resolve, relative } from "pathe";
 import { createNitro } from "../..";
 import { getViteRollupConfig } from "./rollup";
 import { buildProduction, prodEntry } from "./prod";
@@ -13,7 +13,6 @@ import * as rou3 from "rou3";
 import * as rou3Compiler from "rou3/compiler";
 import { resolveModulePath } from "exsolve";
 import { prettyPath } from "../../utils/fs";
-import path from "node:path";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html
@@ -162,7 +161,7 @@ export async function nitro(
               id.startsWith(root)
             );
             for (const id of filteredModuleIds) {
-              const originalFile = path.relative(root, normalizePath(id));
+              const originalFile = relative(root, id);
               ctx._manifest[originalFile] = { file: file.fileName };
             }
           }

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -8,7 +8,7 @@ import { formatCompatibilityDate } from "compatx";
 import { copyPublicAssets, prepare, prerender } from "../..";
 import { nitroServerName } from "../../utils/nitro";
 
-export async function buildProduction(
+export async function buildOtherEnvironments(
   ctx: NitroPluginContext,
   builder: ViteBuilder
 ) {
@@ -17,24 +17,7 @@ export async function buildProduction(
   // Cleanup build directories before building
   await prepare(nitro);
 
-  // Vite generates public/.vite/manifest.json, for each environment
-  // We need to collect it progressively
-  ctx._manifest = {};
-  const manifestPath = resolve(
-    nitro.options.output.publicDir,
-    ".vite/manifest.json"
-  );
-  const collectManifest = async () => {
-    Object.assign(
-      ctx._manifest!,
-      await readFile(manifestPath, "utf8")
-        .catch(() => "{}")
-        .then((r) => JSON.parse(r))
-    );
-  };
-
-  // Build all environments before to the final Nitro server bundle
-  ctx._buildResults = {};
+  // Build all environments before the final Nitro server bundle
   for (const [name, env] of Object.entries(builder.environments)) {
     // prettier-ignore
     const fmtName = name.length <= 3 ? name.toUpperCase() : name[0].toUpperCase() + name.slice(1);
@@ -53,10 +36,16 @@ export async function buildProduction(
       continue;
     }
     nitro.logger.start(`Building \`${fmtName}\`...`);
-    ctx._buildResults![name] = ((await builder.build(env)) as RollupOutput)
-      .output[0] as OutputChunk;
-    await collectManifest();
+    await builder.build(env);
   }
+}
+export async function buildProduction(
+  ctx: NitroPluginContext,
+  builder: ViteBuilder
+) {
+  const nitro = ctx.nitro!;
+
+  await buildOtherEnvironments(ctx, builder);
 
   nitro.logger.start(
     `Building \`${nitroServerName(nitro)}\` (preset: \`${nitro.options.preset}\`, compatibility date: \`${formatCompatibilityDate(nitro.options.compatibilityDate)}\`)`
@@ -77,8 +66,6 @@ export async function buildProduction(
 
   // Build the Nitro server bundle
   await builder.build(builder.environments.nitro);
-  await collectManifest();
-  await rm(manifestPath, { force: true });
 
   // Close the Nitro instance
   await nitro.close();
@@ -110,9 +97,9 @@ export async function buildProduction(
 export function prodEntry(ctx: NitroPluginContext): string {
   const services = ctx.pluginConfig.services || {};
   const serviceNames = Object.keys(services);
-  return [
+  const result = [
     // Fetchable services
-    `const services = { ${serviceNames.map((name) => `[${JSON.stringify(name)}]: () => import("${resolve(ctx.nitro!.options.buildDir, "vite/services", name, ctx._buildResults![name].fileName)}")`)}};`,
+    `const services = { ${serviceNames.map((name) => `[${JSON.stringify(name)}]: () => import("${resolve(ctx.nitro!.options.buildDir, "vite/services", name, ctx._entryPoints[name])}")`)}};`,
     /* js */ `
               const serviceHandlers = {};
               const originalFetch = globalThis.fetch;
@@ -138,9 +125,11 @@ export function prodEntry(ctx: NitroPluginContext): string {
                 });
               };
             `,
+    // TODO: expose resolveEntry utility to resolve entry points
     // SSR Manifest
     ctx._manifest
       ? `globalThis.__VITE_MANIFEST__ = ${JSON.stringify(ctx._manifest)};`
       : "",
   ].join("\n");
+  return result;
 }

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -46,7 +46,7 @@ export interface NitroPluginContext {
   pluginConfig: NitroPluginConfig;
   rollupConfig?: ReturnType<typeof getViteRollupConfig>;
 
-  _manifest?: Record<string, any>;
+  _manifest: Record<string, { file: string }>;
   _publicDistDir?: string;
-  _buildResults?: Record<string, OutputChunk>;
+  _entryPoints: Record<string, string>;
 }


### PR DESCRIPTION
use `buildApp` hook from vite 7 instead of configuring a builder

this ensures compatibility with frameworks that configure a builder themselves