### PR TITLE
fix: plugins can break prerenderer

### DIFF
--- a/src/prerender/prerender.ts
+++ b/src/prerender/prerender.ts
@@ -46,17 +46,17 @@ export async function prerender(nitro: Nitro) {
     routes.add(route);
   }
 
+  // Crawl / at least if no routes are specified
+  if (routes.size === 0 && nitro.options.prerender.crawlLinks) {
+    routes.add("/");
+  }
+
   // Allow extending prerender routes
   await nitro.hooks.callHook("prerender:routes", routes);
 
   // Skip if no prerender routes specified
   if (routes.size === 0) {
-    // Crawl / at least if no routes are specified
-    if (nitro.options.prerender.crawlLinks) {
-      routes.add("/");
-    } else {
-      return;
-    }
+    return;
   }
 
   // Build with prerender preset


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

There's no issue, because it's a small bug, but still annoying.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This is a small annoying bug, when you use the prerender feature.

Normally when you don't specify a route and just tell it to crawl all the links, it works perfectly fine.

But I stumbled upon this, when I installed `nuxt-llms`. This plugin adds a prerender hook, which adds the `llms.txt` file, which upon itself is fine. But in this context, it breaks the application's already working prerenderer.

This PR fixes this issue and adds the index route, after the application has no defined routes and `crawlLinks` is turned on, but the hooked routes, which come from plugins most of the time, are only applied afterwards.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
