### PR TITLE
fix(vercel): valid regex for o11y routes

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -377,11 +377,11 @@ function normalizeRouteSrc(route: string): string {
 }
 
 // Valid PCRE capture group name
-function namedGroup(input = "_") {
+function namedGroup(input = "") {
   if (/\d/.test(input[0])) {
-    input = "_" + input;
+    input = `_${input}`;
   }
-  return input.replace(/[^a-zA-Z0-9_]/g, "").replace(/^-/, "");
+  return input.replace(/[^a-zA-Z0-9_]/g, "") || "_";
 }
 
 // Output is a destination pathname to function name

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -359,19 +359,29 @@ function normalizeRouteSrc(route: string): string {
     .split("/")
     .map((segment) => {
       if (segment.startsWith("**")) {
-        return segment === "**" ? "?(?<_>.*)" : `?(?<${segment.slice(3)}>.+)`;
+        return segment === "**"
+          ? "(?:.*)"
+          : `?(?<${namedGroup(segment.slice(3))}>.+)`;
       }
       if (segment === "*") {
         return `(?<_${idCtr++}>[^/]*)`;
       }
       if (segment.includes(":")) {
         return segment
-          .replace(/:(\w+)/g, (_, id) => `(?<${id}>[^/]+)`)
+          .replace(/:(\w+)/g, (_, id) => `(?<${namedGroup(id)}>[^/]+)`)
           .replace(/\./g, String.raw`\.`);
       }
       return segment;
     })
     .join("/");
+}
+
+// Valid PCRE capture group name
+function namedGroup(input = "_") {
+  if (/\d/.test(input[0])) {
+    input = "_" + input;
+  }
+  return input.replace(/[^a-zA-Z0-9_]/g, "").replace(/^-/, "");
 }
 
 // Output is a destination pathname to function name

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -422,7 +422,7 @@ describe("nitro:preset:vercel", async () => {
               },
               {
                 "dest": "/api/typed/todos/[...]",
-                "src": "/api/typed/todos/?(?<_>.*)",
+                "src": "/api/typed/todos/(?:.*)",
               },
               {
                 "dest": "/api/typed/todos/[todoId]/comments/[...commentId]",


### PR DESCRIPTION
Reported in https://github.com/nuxt/nuxt/issues/32718

We have introduced o11y route hints in 2.12 (https://github.com/nitrojs/nitro/pull/3474), it should make sure to generate PCRE-compliant named capture groups (404 in case of reported issue is invalid since it shouldn't start with a digit)

This PR also uses a less conflicting anonymous group for `/**` routes.