### PR TITLE
refactor(vercel): rename `__nitro` function to `__fallback`

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -210,14 +210,14 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
           // we need to write a rule to avoid route being shadowed by another cache rule elsewhere
           return {
             src,
-            dest: "/__nitro",
+            dest: "/__fallback",
           };
         }
         return {
           src,
           dest:
             nitro.options.preset === "vercel-edge"
-              ? "/__nitro?url=$url"
+              ? "/__fallback?url=$url"
               : generateEndpoint(key) + "?url=$url",
         };
       }),
@@ -226,7 +226,7 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
       ? [
           {
             src: "(?<url>/)",
-            dest: "/__nitro-index?url=$url",
+            dest: "/__fallback-index?url=$url",
           },
         ]
       : []),
@@ -242,7 +242,7 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
       : [
           {
             src: "/(.*)",
-            dest: "/__nitro",
+            dest: "/__fallback",
           },
         ])
   );
@@ -252,10 +252,10 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
 
 function generateEndpoint(url: string) {
   if (url === "/") {
-    return "/__nitro-index";
+    return "/__fallback-index";
   }
   return url.includes("/**")
-    ? "/__nitro-" +
+    ? "/__fallback-" +
         withoutLeadingSlash(url.replace(/\/\*\*.*/, "").replace(/[^a-z]/g, "-"))
     : url;
 }

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -117,35 +117,35 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/rules/_/noncached/cached",
               },
               {
-                "dest": "/__nitro",
+                "dest": "/__fallback",
                 "src": "/rules/_/cached/noncached",
               },
               {
-                "dest": "/__nitro",
+                "dest": "/__fallback",
                 "src": "(?<url>/rules/_/noncached/.*)",
               },
               {
-                "dest": "/__nitro--rules---cached?url=$url",
+                "dest": "/__fallback--rules---cached?url=$url",
                 "src": "(?<url>/rules/_/cached/.*)",
               },
               {
-                "dest": "/__nitro",
+                "dest": "/__fallback",
                 "src": "/rules/dynamic",
               },
               {
-                "dest": "/__nitro--rules-isr?url=$url",
+                "dest": "/__fallback--rules-isr?url=$url",
                 "src": "(?<url>/rules/isr/.*)",
               },
               {
-                "dest": "/__nitro--rules-isr-ttl?url=$url",
+                "dest": "/__fallback--rules-isr-ttl?url=$url",
                 "src": "(?<url>/rules/isr-ttl/.*)",
               },
               {
-                "dest": "/__nitro--rules-swr?url=$url",
+                "dest": "/__fallback--rules-swr?url=$url",
                 "src": "(?<url>/rules/swr/.*)",
               },
               {
-                "dest": "/__nitro--rules-swr-ttl?url=$url",
+                "dest": "/__fallback--rules-swr-ttl?url=$url",
                 "src": "(?<url>/rules/swr-ttl/.*)",
               },
               {
@@ -437,7 +437,7 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/api/typed/catchall/(?<slug>[^/]+)/?(?<another>.+)",
               },
               {
-                "dest": "/__nitro",
+                "dest": "/__fallback",
                 "src": "/(.*)",
               },
             ],
@@ -450,7 +450,7 @@ describe("nitro:preset:vercel", async () => {
         const isrRouteConfig = await fsp.readFile(
           resolve(
             ctx.outDir,
-            "functions/__nitro--rules-isr.prerender-config.json"
+            "functions/__fallback--rules-isr.prerender-config.json"
           ),
           "utf8"
         );


### PR DESCRIPTION
Nice idea by @tobiaslins ❤️ 

Fallback routes in Vercel o11y panel (that match `/**` or 404 handler) are displayed as `__nitro` which is not much undrestandable. This PR renames it to `__fallback`