### PR TITLE
refactor(vercel): update function config types

### DIFF
--- a/src/presets/vercel/types.ts
+++ b/src/presets/vercel/types.ts
@@ -54,7 +54,8 @@ export interface VercelBuildConfigV3 {
 }
 
 /**
- * https://vercel.com/docs/build-output-api/v3/primitives#serverless-function-configuration
+ * https://vercel.com/docs/build-output-api/primitives#serverless-function-configuration
+ * https://vercel.com/docs/build-output-api/primitives#node.js-config
  */
 export interface VercelServerlessFunctionConfig {
   /**
@@ -63,9 +64,27 @@ export interface VercelServerlessFunctionConfig {
   memory?: number;
 
   /**
+   * Specifies the instruction set "architecture" the Vercel Function supports.
+   *
+   * Either `x86_64` or `arm64`. The default value is `x86_64`
+   */
+  architecture?: "x86_64" | "arm64";
+
+  /**
    * Maximum execution duration (in seconds) that will be allowed for the Serverless Function.
    */
   maxDuration?: number;
+
+  /**
+   * Map of additional environment variables that will be available to the Vercel Function,
+   * in addition to the env vars specified in the Project Settings.
+   */
+  environment?: Record<string, string>;
+
+  /**
+   * List of Vercel Regions where the Vercel Function will be deployed to.
+   */
+  regions?: string[];
 
   /**
    * True if a custom runtime has support for Lambda runtime wrappers.
@@ -76,6 +95,11 @@ export interface VercelServerlessFunctionConfig {
    * When true, the Serverless Function will stream the response to the client.
    */
   supportsResponseStreaming?: boolean;
+
+  /**
+   * Enables source map generation.
+   */
+  shouldAddSourcemapSupport?: boolean;
 
   [key: string]: unknown;
 }


### PR DESCRIPTION
Add missing types for newly supported vercel function config types:
- architecture
- environment
- regions (not new, not sure why not included before)
- shouldAddSourcemapSupport