### PR TITLE
refactor!: remove default `~` and `@` aliases

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -106,10 +106,6 @@ export function baseBuildConfig(nitro: Nitro) {
     "#internal/nitro": runtimeDir,
     "nitro/runtime": runtimeDir,
     "nitropack/runtime": runtimeDir, // Backwards compatibility
-    "~": nitro.options.srcDir,
-    "@/": nitro.options.srcDir,
-    "~~": nitro.options.rootDir,
-    "@@/": nitro.options.rootDir,
     ...env.alias,
   });
 

--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -212,30 +212,6 @@ export async function writeTypes(nitro: Nitro) {
           "#imports": [
             relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports")),
           ],
-          "~/*": [
-            relativeWithDot(
-              tsconfigDir,
-              join(nitro.options.alias["~"] || nitro.options.srcDir, "*")
-            ),
-          ],
-          "@/*": [
-            relativeWithDot(
-              tsconfigDir,
-              join(nitro.options.alias["@"] || nitro.options.srcDir, "*")
-            ),
-          ],
-          "~~/*": [
-            relativeWithDot(
-              tsconfigDir,
-              join(nitro.options.alias["~~"] || nitro.options.rootDir, "*")
-            ),
-          ],
-          "@@/*": [
-            relativeWithDot(
-              tsconfigDir,
-              join(nitro.options.alias["@@"] || nitro.options.rootDir, "*")
-            ),
-          ],
           ...(nitro.options.typescript.internalPaths
             ? {
                 "nitro/runtime": [

--- a/src/config/resolvers/paths.ts
+++ b/src/config/resolvers/paths.ts
@@ -14,7 +14,7 @@ export async function resolvePathOptions(options: NitroOptions) {
   for (const key of ["srcDir", "buildDir"] as const) {
     options[key] = resolve(options.rootDir, options[key] || ".");
   }
-  options.alias ??= {}
+  options.alias ??= {};
 
   // Resolve possibly template paths
   if (!options.static && !options.entry) {

--- a/src/config/resolvers/paths.ts
+++ b/src/config/resolvers/paths.ts
@@ -14,15 +14,7 @@ export async function resolvePathOptions(options: NitroOptions) {
   for (const key of ["srcDir", "buildDir"] as const) {
     options[key] = resolve(options.rootDir, options[key] || ".");
   }
-
-  // Add aliases
-  options.alias = {
-    ...options.alias,
-    "~/": join(options.srcDir, "/"),
-    "@/": join(options.srcDir, "/"),
-    "~~/": join(options.rootDir, "/"),
-    "@@/": join(options.rootDir, "/"),
-  };
+  options.alias ??= {}
 
   // Resolve possibly template paths
   if (!options.static && !options.entry) {

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -31,12 +31,12 @@ export default defineNitroConfig({
   handlers: [
     {
       route: "/api/test/*/foo",
-      handler: "~/api/hello.ts",
+      handler: "api/hello.ts",
       method: "GET",
     },
     {
       route: "/api/hello2",
-      handler: "~/api/hello.ts",
+      handler: "api/hello.ts",
     },
   ],
   devProxy: {
@@ -79,7 +79,7 @@ export default defineNitroConfig({
     "db:migrate": { description: "Migrate database" },
     "db:seed": { description: "Seed database" },
   },
-  errorHandler: "~/error.ts",
+  errorHandler: "error.ts",
   routeRules: {
     "/api/param/prerender4": { prerender: true },
     "/api/param/prerender2": { prerender: false },


### PR DESCRIPTION
> (@pi0) 
> We are removing default `~/` and `@/` aliases to make the default Nitro behavior less opinionated and less chance to conflict with user custom aliases.
> We might add them back later, either via a flag or as the lowest priority in resolution. 
> This PR in meanwhile, unblocks vite plugin adoption