### PR TITLE
fix(cloudflare-module): output _headers file to correct directory

### DIFF
--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -60,7 +60,7 @@ const cloudflarePages = defineNitroPreset(
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "pages");
         await writeCFRoutes(nitro);
-        await writeCFHeaders(nitro, false);
+        await writeCFHeaders(nitro, "output");
         await writeCFPagesRedirects(nitro);
       },
     },
@@ -93,7 +93,7 @@ const cloudflarePagesStatic = defineNitroPreset(
         }
       },
       async compiled(nitro: Nitro) {
-        await writeCFHeaders(nitro, false);
+        await writeCFHeaders(nitro, "output");
         await writeCFPagesRedirects(nitro);
       },
     },
@@ -160,7 +160,7 @@ const cloudflareModule = defineNitroPreset(
       },
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "module");
-        await writeCFHeaders(nitro, true);
+        await writeCFHeaders(nitro, "public");
 
         await writeFile(
           resolve(nitro.options.output.dir, "package.json"),

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -105,14 +105,16 @@ function comparePaths(a: string, b: string) {
   return a.split("/").length - b.split("/").length || a.localeCompare(b);
 }
 
-/**
- * Writes Cloudflare `_headers` file for route rules.
- *
- * @param {Nitro} nitro - Nitro instance
- * @param {boolean} usePublicDir - Whether to write to the public directory, which is required in the CF Worker environment. CF Pages can utilize `false`. Defaults to `false`.
- */
-export async function writeCFHeaders(nitro: Nitro, usePublicDir: boolean = false) {
-  const headersPath = join(usePublicDir ? nitro.options.output.publicDir : nitro.options.output.dir, '_headers');
+export async function writeCFHeaders(
+  nitro: Nitro,
+  outdir: "public" | "output"
+) {
+  const headersPath = join(
+    outdir === "public"
+      ? nitro.options.output.publicDir
+      : nitro.options.output.dir,
+    "_headers"
+  );
   const contents = [];
 
   const rules = Object.entries(nitro.options.routeRules).sort(


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/nitrojs/nitro/issues/3441

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In https://github.com/nitrojs/nitro/pull/3442 we output the `_headers` file for applying `routeRules` when utilizing the `cloudflare-module` build preset.

According to [Cloudflare's documentation](https://developers.cloudflare.com/workers/static-assets/headers/#custom-headers), we should output to the static assets directory (essentially `.output/public/`) rather than the current implementation that writes the file to the root of the `.output/` directory.

**The current output path does not actually apply the headers when deployed.**

When I put up https://github.com/nitrojs/nitro/pull/3442 I had to do a manual upload of the `_headers` file for verification but mistakenly dropped it into the _correct_ directory.

I can verify with the change in the PR outputting to the `.output/public/_headers` path and uploading a worker version to Cloudflare does properly apply the route rule in this example:

```ts
import { defineNitroConfig } from "nitropack/config";

export default defineNitroConfig({
  compatibilityDate: "latest",
  srcDir: "server",
  preset: 'cloudflare-module',
  routeRules: {
    '/_assets/**': { headers: { 'Cache-Control': 'public, max-age=2592000, immutable' } }, /* 30 days */
  }
});
```

<img width="1049" height="88" alt="cache-control verification" src="https://github.com/user-attachments/assets/7ce5ef0d-e3b0-4f55-8eba-bdc8e86349d1" />

@pi0 this will need to be ported forward to `v3` as well.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
