### PR TITLE
fix(vite): don't force client manifest

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -198,7 +198,6 @@ function mainPlugin(ctx: NitroPluginContext): VitePlugin {
     // Modify environment configs before it's resolved.
     configEnvironment(name, config) {
       if (config.consumer === "client") {
-        config.build!.manifest = true;
         config.build!.emptyOutDir = false;
         config.build!.outDir = ctx.nitro!.options.output.publicDir;
       }


### PR DESCRIPTION
it's not necessary for the nitro vite plugin to function

