### PR TITLE
fix(static): only add vary response header when serving public assets if compression is enabled

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -222,6 +222,15 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     DEBUG: nitro.options.dev,
   };
 
+  const getCompressPublicAssetsOption = () => {
+    const option = nitro.options.compressPublicAssets;
+    if (typeof option === "boolean") {
+      return option;
+    }
+    const values = Object.values(option);
+    return values.length === 0 ? true : values.some(Boolean);
+  };
+
   const staticFlags: NitroStaticBuildFlags = {
     dev: nitro.options.dev,
     preset: nitro.options.preset,
@@ -237,6 +246,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     _asyncContext: nitro.options.experimental.asyncContext,
     _websocket: nitro.options.experimental.websocket,
     _tasks: nitro.options.experimental.tasks,
+    _compressPublicAssets: getCompressPublicAssetsOption(),
   };
 
   // Universal import.meta

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -5,6 +5,7 @@ export interface NitroStaticBuildFlags {
   _asyncContext?: boolean;
   _websocket?: boolean;
   _tasks?: boolean;
+  _compressPublicAssets?: boolean;
   dev?: boolean;
   client?: boolean;
   nitro?: boolean;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -334,7 +334,11 @@ export function testNitro(
           headers: { "Accept-Encoding": "" },
         })
       ).headers;
-      if (headers["vary"]) expect(headers["vary"]).toBe("Origin");
+      if (headers["vary"])
+        expect(
+          headers["vary"].includes("Origin") &&
+            headers["vary"].includes("Accept-Encoding")
+        ).toBeTruthy();
 
       headers = (
         await callHandler({


### PR DESCRIPTION
### 🔗 Linked issue

#3501

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR aims to fix the current implementation of the `vary` response header from the nitro server.

Right now, every request that includes the `accept-encoding` header will get back a response with `vary: accept-encoding` despite nitro not serving different content. This should only happen when nitro serves different compressed (on build time) versions of public assets (when the `compressPublicAssets` config option is enabled).

This PR fixes that and also handles this other related issue #3077, where the vary header is wrongly omitted if the encoding request header is not sent (or if set to a different value than the ones supported by EncodingMap) for compressed assets.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
