### PR TITLE
Pass args on to validate method in cache options

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -37,11 +37,11 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   const group = opts.group || "nitro/functions";
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, opts]);
-  const validate = opts.validate || ((entry) => entry.value !== undefined);
 
   async function get(
     key: string,
     resolver: () => T | Promise<T>,
+    validate: (entry: CacheEntry) => boolean,
     shouldInvalidateCache?: boolean,
     event?: H3Event
   ): Promise<ResolvedCacheEntry<T>> {
@@ -154,10 +154,12 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       return fn(...args);
     }
     const key = await (opts.getKey || getKey)(...args);
+    const validate = opts.validate || ((entry) => entry.value !== undefined);
     const shouldInvalidateCache = await opts.shouldInvalidateCache?.(...args);
     const entry = await get(
       key,
       () => fn(...args),
+      (entry) => validate(entry, ...args),
       shouldInvalidateCache,
       args[0] && isEvent(args[0]) ? args[0] : undefined
     );


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#3525

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change brings the call to `validate` in the cache options in line with the type definitions by passing the cached function args along as the type definition promises.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
