### PR TITLE
Pass args on to validate method in cache options

### DIFF
--- a/test/fixture/api/cachedFunction.ts
+++ b/test/fixture/api/cachedFunction.ts
@@ -1,0 +1,18 @@
+export default defineEventHandler(async (event) => {
+  return { value: await func(Math.random()) };
+});
+
+const func = defineCachedFunction(
+  (testValue: number): number => {
+    return testValue;
+  },
+  {
+    validate(entry, testValue) {
+      return entry.value !== undefined && testValue !== undefined;
+    },
+    maxAge: 10,
+    getKey() {
+      return "testCachedFunction";
+    },
+  }
+);

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -353,6 +353,10 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/api/db",
               },
               {
+                "dest": "/api/cachedFunction",
+                "src": "/api/cachedFunction",
+              },
+              {
                 "dest": "/api/cached",
                 "src": "/api/cached",
               },

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -738,6 +738,26 @@ export function testNitro(
         }
       }
     );
+    describe("cache", () => {
+      it.skipIf(ctx.isIsolated)(
+        "should handle args in the validate function",
+        async () => {
+          const {
+            data: { value },
+          } = await callHandler({ url: "/api/cachedFunction" });
+
+          const calls = await Promise.all([
+            callHandler({ url: "/api/cachedFunction" }),
+            callHandler({ url: "/api/cachedFunction" }),
+            callHandler({ url: "/api/cachedFunction" }),
+          ]);
+
+          for (const call of calls) {
+            expect(call.data.value).toBe(value);
+          }
+        }
+      );
+    });
   });
 
   describe("scanned files", () => {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#3525

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change brings the call to `validate` in the cache options in line with the type definitions by passing the cached function args along as the type definition promises.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.