### PR TITLE
fix(vercel): workaround for isr route rule with `passQuery: true`

### DIFF
--- a/src/presets/vercel/runtime/vercel.ts
+++ b/src/presets/vercel/runtime/vercel.ts
@@ -2,18 +2,26 @@ import "#nitro-internal-pollyfills";
 import { useNitroApp } from "nitropack/runtime";
 
 import { type NodeListener, toNodeListener } from "h3";
-import { parseQuery } from "ufo";
+import { parseQuery, withQuery } from "ufo";
 
 const nitroApp = useNitroApp();
 
 const handler = toNodeListener(nitroApp.h3App);
 
 const listener: NodeListener = function (req, res) {
-  const query = req.headers["x-now-route-matches"] as string;
-  if (query) {
-    const { url } = parseQuery(query);
+  const isrRoute = req.headers["x-now-route-matches"] as string;
+  if (isrRoute) {
+    const { url } = parseQuery(isrRoute);
     if (url) {
       req.url = url as string;
+    }
+  } else if (req.url?.startsWith("/__fallback")) {
+    // Workaround for ISR functions with passQuery: true
+    // /__fallback--api-weather?url=%2Fapi%2Fweather%2Famsterdam&units=123"
+    const urlQueryIndex = req.url.indexOf("?url=");
+    if (urlQueryIndex !== -1) {
+      const { url, ...params } = parseQuery(req.url.slice(urlQueryIndex));
+      req.url = withQuery((url as string) || "/", params);
     }
   }
   return handler(req, res);


### PR DESCRIPTION
Normally, with ISR matched routes, there is an `x-now-route-matcher` header that contains the full URL. And Nitro vercel entry uses this header value to restore the original URL, but when `passQuery` is set, this header won't exist anymore, and the path is invalid (ISR function name) (example deploy). We cannot always assume `url` query param is for ISR functions (it can be an actual query in normal routes!)

This PR is a proposed fix to only use `url` param as ISR url if route starts with `/__fallback` (default function name), but still it can overlap with a real `__fallback` route and break websites if for any reason they are using it.