### PR TITLE
docs(websocket): provide async await

### DIFF
--- a/docs/1.guide/3.websocket.md
+++ b/docs/1.guide/3.websocket.md
@@ -82,8 +82,8 @@ Use a client to connect to server. Example: (`server/routes/websocket.ts`)
 <!-- automd-disabled:file code src="../../examples/websocket/routes/index.ts" -->
 
 ```ts [index.ts]
-export default defineEventHandler(() => {
-  return $fetch(
+export default defineEventHandler(async () => {
+  return await $fetch(
     "https://raw.githubusercontent.com/h3js/crossws/main/examples/h3/public/index.html"
   );
 });


### PR DESCRIPTION
I think here we need to provide async await in the defineEventHandler function. 
Also in the doc, for the chat demo Nitro Websocket API this example is given (https://nuxt-chat.pi0.io/), which does not work now. 
Also the fetch example link (https://raw.githubusercontent.com/unjs/crossws/main/examples/h3/public/index.html) shows `404: Not Found`. 