### PR TITLE
build: update node engine to `^20.19.0 || >=22.12.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
   },
   "packageManager": "pnpm@10.3.0",
   "engines": {
-    "node": "^16.11.0 || >=17.0.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
Node.js 16, 17 and 18 are EOL (18 last updated on Mar 27, 2025)

https://nodejs.org/en/eol

This PR makes engine to warn about old, and probably partially working runtimes.