### PR TITLE
chore: use `node:lts` image in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "nitro-devcontainer",
   "forwardPorts": [3000],
-  "image": "node:22",
+  "image": "node:lts",
   "features": {},
   "customizations": {
     "vscode": {


### PR DESCRIPTION
i think in devcontainer we can use `node:lts` image, since node:lts has some support like typescript.