### PR TITLE
forward `duplex` `RequestInit` option in `dispatcher`

### DIFF
--- a/src/runtime/internal/vite/dispatcher.mjs
+++ b/src/runtime/internal/vite/dispatcher.mjs
@@ -20,5 +20,6 @@ export default defineHandler(async (event) => {
     referrerPolicy: event.req.referrerPolicy,
     integrity: event.req.integrity,
     mode: event.req.mode,
+    duplex: event.req.duplex,
   });
 });


### PR DESCRIPTION
fix: forward `duplex` `RequestInit` option in `dispatcher`

<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

No issue found.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I encountered this when returning an `AsyncIterable` instance as the body of a `Response` in a TanStack Start api route handler using the `nitro/vite` plugin from `nitro-nightly@3.0.0-20250902-103829-4daac97b`.

That resulted in an unhandled error:

```
TypeError: RequestInit: duplex option is required when sending a body.
    at new Request (node:internal/deps/undici/undici:9813:19)
    ... 8 lines matching cause stack trace ...
    at next (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1740:18) {
  cause: TypeError: RequestInit: duplex option is required when sending a body.
      at new Request (node:internal/deps/undici/undici:9813:19)
      at globalThis.fetch (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:19:15)
      at globalThis.fetch (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/chunks/_/server.mjs:18205:16)
      at Object.handler (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:4975:10)
      at file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1871:35
      at callMiddleware (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1733:43)
      at next (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1740:18)
      at file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1711:50
      at callMiddleware (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1743:15)
      at next (file:///Users/tronic/tmp/apollo-next/integration-test/tanstack-start/.output/server/index.mjs:1740:18),
  status: 500,
  statusText: undefined,
  headers: undefined,
  data: undefined,
  body: undefined,
  unhandled: true
}
```

It seems that when the `body` of a `fetch` request is a `ReadableStream`, the `duplex` option must be set.

I tested this locally by making the same change manually to the `.output/server/chunks/_/server.mjs` file, and that resolved the issue.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion. (no existing issue)
- [ ] I have updated the documentation accordingly. (no docs changes needed)
