### PR TITLE
fix(vercel): skip o11y routes matching `isr` route rule

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -90,6 +90,11 @@ export async function generateFunctionFiles(nitro: Nitro) {
   const _getRouteRules = (path: string) =>
     defu({}, ..._routeRulesMatcher.matchAll(path).reverse()) as NitroRouteRules;
   for (const route of o11Routes) {
+    const routeRules = _getRouteRules(route.src);
+    // TODO: address issue with 404s with /index.func + ISR
+    if (routeRules.isr && route.dest.endsWith("/index")) {
+      continue;
+    }
     const funcPrefix = resolve(
       nitro.options.output.serverDir,
       "..",
@@ -101,7 +106,6 @@ export async function generateFunctionFiles(nitro: Nitro) {
       funcPrefix + ".func",
       "junction"
     );
-    const routeRules = _getRouteRules(route.src);
     if (routeRules.isr) {
       await writePrerenderConfig(
         funcPrefix + ".prerender-config.json",

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -92,7 +92,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
   for (const route of o11Routes) {
     const routeRules = _getRouteRules(route.src);
     // TODO: address issue with 404s with /index.func + ISR
-    if (routeRules.isr && route.dest.endsWith("/index")) {
+    if (routeRules.isr) {
       continue;
     }
     const funcPrefix = resolve(
@@ -106,13 +106,6 @@ export async function generateFunctionFiles(nitro: Nitro) {
       funcPrefix + ".func",
       "junction"
     );
-    if (routeRules.isr) {
-      await writePrerenderConfig(
-        funcPrefix + ".prerender-config.json",
-        routeRules.isr,
-        nitro.options.vercel?.config?.bypassToken
-      );
-    }
   }
 }
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a hotfix to address an unintended regression from https://github.com/nitrojs/nitro/pull/3562 - when re-enabling observability on a route ending in `/index.func`, we get 404s - this needs further investigation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
