### PR TITLE
docs(routing): update error handling description

### DIFF
--- a/docs/1.guide/2.routing.md
+++ b/docs/1.guide/2.routing.md
@@ -271,7 +271,7 @@ export default defineEventHandler((event) => {
 
 You can use the [utilities available in H3](https://h3.dev/guide/basics/error) to handle errors in both routes and middlewares.
 
-The way errors are sent back to the client depends on the route's path. For most routes `Content-Type` is set to `text/html` by default and a simple html error page is delivered. If the route starts with `/api/` (either because it is placed in `api/` or `routes/api/`) the default will change to `application/json` and a JSON object will be sent.
+The way errors are sent back to the client depends on the environment. In development, requests with an `Accept` header of `text/html` (such as browsers) will receive a HTML error page. In production, errors are always sent in JSON.  
 
 This behaviour can be overridden by some request properties (e.g.: `Accept` or `User-Agent` headers).
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

> If the route starts with `/api/` (either because it is placed in `api/` or `routes/api/`) the default will change to `application/json` and a JSON object will be sent.

I believe the above excerpt is no longer applicable due to the changes from #3002. 

It was true when the response still uses a util function called `isJsonRequest` and it has a specific check for `event.path.startsWith("/api/")` to make sure routes in that path will return JSON:

https://github.com/nitrojs/nitro/blob/e8d609908e9758094d3639b83fe2956ddf872fa8/src/runtime/internal/error/utils.ts#L11-L24

but as it was removed and #3002 specifically split the error handler into dev and prod handlers, I've opted to update the docs based on the new error handling changes.

That being said, should the following existing sentence: 

> This behaviour can be overridden by some request properties (e.g.: `Accept` or `User-Agent` headers).

be removed since it might be redundant now? or at least the `User-Agent` part might not really work, assuming if I didn't misunderstand the new error handling logic of course.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
