### PR TITLE
chore(playground): add `"type": "module"` to `package.json`

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nitro-playground",
+  "type": "module",
   "version": "1.0.0",
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
though it is in playground, i had read `"type": "module"` has some performance related issue if we do not explicitly mention it. that is why I've thought we can add it here. (https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default)