### PR TITLE
chore: mention `strictRequires` to `true`

### DIFF
--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -17,7 +17,7 @@ export function createNitroEnvironment(
       rollupOptions: ctx.rollupConfig!.config,
       minify: ctx.nitro!.options.minify,
       commonjsOptions: {
-        strictRequires: "auto", // TODO: set to true (default) in v3
+        strictRequires: true, // TODO: set to true (default) in v3
         esmExternals: (id) => !id.startsWith("unenv/"),
         requireReturnsDefault: "auto",
         ...(ctx.nitro!.options.commonJS as any),


### PR DESCRIPTION
Actually in the comment it is said to make it as `true` in v3. Since we are now on v3 beta, that's why I thought may be we can change it now. 