### PR TITLE
refactor(aws-amplify, azure, vercel): update node to 20, 22

### DIFF
--- a/src/presets/aws-amplify/types.ts
+++ b/src/presets/aws-amplify/types.ts
@@ -8,7 +8,7 @@ export interface AmplifyComputeConfig {
    * The runtime property dictates the runtime of the provisioned compute resource.
    * Values are subset of https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
    */
-  runtime: "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
+  runtime: "nodejs20.x" | "nodejs22.x";
 
   /**
    * Specifies the starting file from which code will run for the given compute resource.
@@ -158,5 +158,5 @@ export interface AWSAmplifyOptions {
     cacheControl?: string;
   };
   imageSettings?: AmplifyImageSettings;
-  runtime?: "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
+  runtime?: "nodejs20.x" | "nodejs22.x";
 }

--- a/src/presets/azure/utils.ts
+++ b/src/presets/azure/utils.ts
@@ -9,7 +9,7 @@ export async function writeSWARoutes(nitro: Nitro) {
   };
 
   // https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#supported-versions
-  const supportedNodeVersions = new Set(["18", "20", "22"]);
+  const supportedNodeVersions = new Set(["20", "22"]);
   let nodeVersion = "18";
   try {
     const currentNodeVersion = JSON.parse(

--- a/src/presets/azure/utils.ts
+++ b/src/presets/azure/utils.ts
@@ -1,4 +1,3 @@
-import { createWriteStream } from "node:fs";
 import fsp from "node:fs/promises";
 import { writeFile } from "../_utils/fs";
 import type { Nitro } from "nitro/types";
@@ -10,7 +9,7 @@ export async function writeSWARoutes(nitro: Nitro) {
   };
 
   // https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#supported-versions
-  const supportedNodeVersions = new Set(["16", "18", "20"]);
+  const supportedNodeVersions = new Set(["18", "20", "22"]);
   let nodeVersion = "18";
   try {
     const currentNodeVersion = JSON.parse(

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -14,7 +14,7 @@ import { isTest } from "std-env";
 // https://vercel.com/docs/build-output-api/configuration
 
 // https://vercel.com/docs/functions/runtimes/node-js/node-js-versions
-const SUPPORTED_NODE_VERSIONS = [18, 20, 22];
+const SUPPORTED_NODE_VERSIONS = [20, 22];
 
 function getSystemNodeVersion() {
   const systemNodeVersion = Number.parseInt(


### PR DESCRIPTION
Actually there are some runtime versions which are changed. For example, in aws-amplify now only supported node.js runtime is 20 and 22. (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported). 
In azure, 18, 20, 22 (https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#supported-versions). We can go below 18 but it requires specific file structure. 
In vercel, 20, 22. (https://vercel.com/docs/functions/runtimes/node-js/node-js-versions#default-and-available-versions)
That is why I thought may be we can update something in the codebase as well. 
