### PR TITLE
feat(vite): add cache-control to immutable client assets

### DIFF
--- a/playground/client.ts
+++ b/playground/client.ts
@@ -1,0 +1,1 @@
+console.log("client");

--- a/playground/vite.config.mjs
+++ b/playground/vite.config.mjs
@@ -1,6 +1,0 @@
-import { defineConfig } from "vite";
-import { nitro } from "nitro/vite";
-
-export default defineConfig({
-  plugins: [nitro()],
-});

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
+
+export default defineConfig({
+  plugins: [nitro()],
+  environments: {
+    client: {
+      build: {
+        rollupOptions: {
+          input: './client.ts',
+        }
+      }
+    }
+  },
+});

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -153,8 +153,8 @@ function mainPlugin(ctx: NitroPluginContext): VitePlugin[] {
           // add cache-control to immutable client assets
           const { outDir, assetsDir } = config.environments.client.build;
           ctx.nitro!.options.publicAssets.push({
-            dir: `${outDir}/${assetsDir}`,
-            baseURL: `/${assetsDir}`,
+            dir: `${outDir}/${assetsDir}/`,
+            baseURL: `/${assetsDir}/`,
             maxAge: 31_536_000, 
           });
         }

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -148,6 +148,18 @@ function mainPlugin(ctx: NitroPluginContext): VitePlugin[] {
         };
       },
 
+      configResolved(config) {
+        if (config.command === 'build') { 
+          // add cache-control to immutable client assets
+          const { outDir, assetsDir } = config.environments.client.build;
+          ctx.nitro!.options.publicAssets.push({
+            dir: `${outDir}/${assetsDir}`,
+            baseURL: `/${assetsDir}`,
+            maxAge: 31536000, 
+          });
+        }
+      },
+
       buildApp: {
         order: "post",
         handler(builder) {

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -155,7 +155,7 @@ function mainPlugin(ctx: NitroPluginContext): VitePlugin[] {
           ctx.nitro!.options.publicAssets.push({
             dir: `${outDir}/${assetsDir}`,
             baseURL: `/${assetsDir}`,
-            maxAge: 31536000, 
+            maxAge: 31_536_000, 
           });
         }
       },


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

- Closes https://github.com/nitrojs/nitro/issues/3585

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR updated vite plugin to automatically configure `maxAge` for static assets under `build.assetsDir` https://vite.dev/config/build-options.html#build-assetsdir.

To verify, I add client environment build to `playground`. But I'm actually failed to verify, so there might be something wrong.

```sh
cd playground
pnpm build
node .output/server/index.mjs
curl -v http://[::]:3000/assets/client-BXVNzxyk.js  # no cache-control header
```

Oddly, with Vercel preset `NITRO_PRESET=vercel pnpm build`, I can see `cache-control` is added in `.vercel/output/config.json`.

```json
{
  "version": 3,
  "overrides": {},
  "routes": [
    {
      "src": "/assets/(.*)",
      "headers": {
        "cache-control": "public,max-age=31536000,immutable"
      },
      "continue": true
    },
...
```

I'm digging in further, but let me open this as a draft to share the current state as I might be missing something obvious. I would appreciate any help!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
