### PR TITLE
fix(azure): preserve query string in adapter handler

### DIFF
--- a/src/presets/azure/runtime/azure-functions.ts
+++ b/src/presets/azure/runtime/azure-functions.ts
@@ -10,7 +10,11 @@ import type { HttpRequest, HttpResponse } from "@azure/functions";
 const nitroApp = useNitroApp();
 
 export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
-  const url = "/" + (req.params.url || "");
+  let url = "/" + (req.params.url || "");
+
+  if (req.url && req.url.includes("?")) {
+    url += req.url.slice(req.url.indexOf("?"));
+  }
 
   const { body, status, statusText, headers } = await nitroApp.localCall({
     url,


### PR DESCRIPTION
### 🔗 Linked issue
- Resolves #3588 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `azure_functions` preset discards query parameters when constructing the
URL passed to `nitroApp.localCall`. Currently it only uses:

```js
const url = "/" + (req.params.url || "");
```

As a result, any query string is lost (`getQuery(event)` always returned `{}`).

This PR updates the handler to preserve the query portion from `req.url`
(if present):

```js
let path = "/" + (req.params.url || "");
if (req.url && req.url.includes("?")) {
  path += req.url.slice(req.url.indexOf("?"));
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
