### PR TITLE
feat: support `server` entry

### DIFF
--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -2,4 +2,7 @@ import { defineNitroConfig } from "nitro/config";
 
 export default defineNitroConfig({
   compatibilityDate: "latest",
+  routeRules: {
+    "/**": { headers: { "X-Powered-By": "Nitro" } },
+  },
 });

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -1,5 +1,18 @@
 export default {
-  async fetch(req: Request): Promise<Response> {
-    return new Response(`Hello world! (${req.url})`);
+  async fetch(req: Request) {
+    const url = new URL(req.url);
+    if (url.pathname === "/") {
+      return new Response(
+        /* html */ `
+        <h1>Hello world!</h1>
+        <ul>
+          <li><a href="/test">/test</a></li>
+        </ul>
+      `,
+        {
+          headers: { "Content-Type": "text/html" },
+        }
+      );
+    }
   },
 };

--- a/src/build/plugins/routing.ts
+++ b/src/build/plugins/routing.ts
@@ -22,7 +22,8 @@ export function routing(nitro: Nitro) {
         );
 
         return /* js */ `
-import * as __routeRules__ from 'nitro/runtime/internal/route-rules';
+import * as __routeRules__ from "nitro/runtime/internal/route-rules";
+${nitro.options.serverEntry ? `import __serverEntry__ from ${JSON.stringify(nitro.options.serverEntry)};` : ""}
 ${allHandlers.some((h) => h.lazy) ? `import { lazyEventHandler } from "h3";` : ""}
 
 export const findRouteRules = ${nitro.routing.routeRules.compileToString({ serialize: serializeRouteRule, matchAll: true })}
@@ -42,7 +43,10 @@ ${allHandlers
 
 export const findRoute = ${nitro.routing.routes.compileToString({ serialize: serializeHandler })}
 
-export const middleware = [${nitro.routing.middleware.map((h) => serializeHandler(h)).join(",")}];
+export const middleware = [
+  ${nitro.routing.middleware.map((h) => serializeHandler(h)).join(",")},
+  ${nitro.options.serverEntry ? "{handler:function serverEntry(event,next){return Promise.resolve(__serverEntry__?.fetch?.(event.req)).then(r =>!r||r.status===404?next():r)}}," : ""}
+];
   `;
       },
       // --- routing-meta ---

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -1,7 +1,7 @@
 import type { PluginOption as VitePlugin } from "vite";
 import type { Plugin as RollupPlugin } from "rollup";
 import type { NitroPluginConfig, NitroPluginContext } from "./types";
-import { join, resolve, relative } from "pathe";
+import { resolve, relative } from "pathe";
 import { createNitro, prepare } from "../..";
 import { getViteRollupConfig } from "./rollup";
 import { buildEnvironments, prodEntry } from "./prod";
@@ -12,7 +12,6 @@ import { runtimeDependencies, runtimeDir } from "nitro/runtime/meta";
 import * as rou3 from "rou3";
 import * as rou3Compiler from "rou3/compiler";
 import { resolveModulePath } from "exsolve";
-import { prettyPath } from "../../utils/fs";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html
@@ -63,27 +62,17 @@ function mainPlugin(ctx: NitroPluginContext): VitePlugin[] {
         if (!ctx.pluginConfig.services?.ssr) {
           ctx.pluginConfig.services ??= {};
           if (userConfig.environments?.ssr === undefined) {
-            const serverEntry = resolveModulePath("./server", {
-              from: [
-                join(ctx.nitro.options.srcDir, "/"),
-                join(ctx.nitro.options.rootDir, "src/"),
-              ],
-              extensions: [".ts", ".js", ".mts", ".mjs", ".tsx", ".jsx"],
-              try: true,
-            });
-            if (serverEntry) {
-              ctx.nitro!.logger.info(
-                `Using \`${prettyPath(serverEntry)}\` as the server entry.`
-              );
-              ctx.pluginConfig.services.ssr = { entry: serverEntry };
+            console.log(">>", ctx.nitro!.options.serverEntry);
+            if (ctx.nitro!.options.serverEntry) {
+              ctx.pluginConfig.services.ssr = {
+                entry: ctx.nitro!.options.serverEntry,
+              };
             }
           } else {
             const input =
               userConfig.environments.ssr.build?.rollupOptions?.input;
             if (typeof input === "string") {
-              ctx.pluginConfig.services.ssr = {
-                entry: input,
-              };
+              ctx.pluginConfig.services.ssr = { entry: input };
             } else {
               this.error(
                 `Invalid input type for SSR entry point. Expected a string.`

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -154,18 +154,19 @@ function createH3App(captureError: CaptureError) {
     let route = findRoute(method, pathname);
     const { routeRules, routeRuleMiddleware } = getRouteRules(method, pathname);
     event.context.routeRules = routeRules;
+    const hasMiddleware = routeRuleMiddleware || globalMiddleware.length > 0;
     if (!route) {
-      if (routeRuleMiddleware) {
+      if (hasMiddleware) {
         route = { data: { handler: () => Symbol.for("h3.notFound") } };
       } else {
         return;
       }
     }
-    if (routeRuleMiddleware) {
+    if (hasMiddleware) {
       route.data = {
         ...route.data,
         middleware: [
-          ...routeRuleMiddleware,
+          ...(routeRuleMiddleware || []),
           ...globalMiddleware,
           ...(route.data.middleware || []),
         ],

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -168,6 +168,7 @@ export interface NitroOptions extends PresetOptions {
   // Routing
   baseURL: string;
   apiBaseURL: string;
+  serverEntry: string;
   handlers: NitroEventHandler[];
   routeRules: { [path: string]: NitroRouteRules };
   devHandlers: NitroDevEventHandler[];

--- a/src/types/virtual/routing.d.ts
+++ b/src/types/virtual/routing.d.ts
@@ -1,5 +1,6 @@
 import type {
   H3EventHandler,
+  Middleware,
   H3Route,
   LazyEventHandler,
   RouterMethod,
@@ -22,3 +23,5 @@ export const middleware: {
   method?: string;
   handler: Middleware;
 }[];
+
+export const serverHandler = undefined | Middleware;


### PR DESCRIPTION
This PR adds support for the standard `server.ts` entry (initially introduced for the vite plugin)

Server entry runs before any lazy-loaded route chunk and can have global server logic (top-level async support is subject to runtime compat), also has a default fetchable export to support an external framework integration like h3, elysia or hono.

``js
// Server global init logic....
console.log("Server init!");

// Export a fetch-compatible handler...

// import { H3 } from "h3";
// export default new H3().get("/", () => "Hello from server entry!");

export default {
  async fetch(req: Request) {
    const url = new URL(req.url);
    if (url.pathname === "/") {
      return new Response("Hello from server entry!");
    }
  },
};
```
