### PR TITLE
fix(bun): fix hostname handling

### DIFF
--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -15,7 +15,7 @@ const ws = import.meta._websocket
 // @ts-expect-error
 const server = Bun.serve({
   port: process.env.NITRO_PORT || process.env.PORT || 3000,
-  host: process.env.NITRO_HOST || process.env.HOST,
+  hostname: process.env.NITRO_HOST || process.env.HOST,
   websocket: import.meta._websocket ? ws!.websocket : (undefined as any),
   async fetch(bunReq: Request, server: any) {
     // srvx compatibility


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked "issue"

https://github.com/nitrojs/nitro/pull/3547#issuecomment-3334713786

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed to use `hostname` argument instead of `host` per Bun documentation, otherwise it doesn't respect `HOST` and `NITRO_HOST` (per #3547).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion (it was a discussion in the previous PR).
- [ ] I have updated the documentation accordingly.
