### PR TITLE
fix(vercel): always add `url` to src regex for `isr` routes

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -207,7 +207,7 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
     ...rules
       .filter(([key, value]) => value.isr !== undefined && key !== "/")
       .map(([key, value]) => {
-        const src = key.replace(/^(.*)\/\*\*/, "(?<url>$1/.*)");
+        const src = `(?<url>${normalizeRouteSrc(key)})`;
         if (value.isr === false) {
           // We need to write a rule to avoid route being shadowed by another cache rule elsewhere
           return {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -115,39 +115,39 @@ describe("nitro:preset:vercel", async () => {
               },
               {
                 "dest": "/rules/_/noncached/cached-isr?url=$url",
-                "src": "/rules/_/noncached/cached",
+                "src": "(?<url>/rules/_/noncached/cached)",
               },
               {
                 "dest": "/__fallback",
-                "src": "/rules/_/cached/noncached",
+                "src": "(?<url>/rules/_/cached/noncached)",
               },
               {
                 "dest": "/__fallback",
-                "src": "(?<url>/rules/_/noncached/.*)",
+                "src": "(?<url>/rules/_/noncached/(?:.*))",
               },
               {
                 "dest": "/rules/_/cached/[...]-isr?url=$url",
-                "src": "(?<url>/rules/_/cached/.*)",
+                "src": "(?<url>/rules/_/cached/(?:.*))",
               },
               {
                 "dest": "/__fallback",
-                "src": "/rules/dynamic",
+                "src": "(?<url>/rules/dynamic)",
               },
               {
                 "dest": "/rules/isr/[...]-isr?url=$url",
-                "src": "(?<url>/rules/isr/.*)",
+                "src": "(?<url>/rules/isr/(?:.*))",
               },
               {
                 "dest": "/rules/isr-ttl/[...]-isr?url=$url",
-                "src": "(?<url>/rules/isr-ttl/.*)",
+                "src": "(?<url>/rules/isr-ttl/(?:.*))",
               },
               {
                 "dest": "/rules/swr/[...]-isr?url=$url",
-                "src": "(?<url>/rules/swr/.*)",
+                "src": "(?<url>/rules/swr/(?:.*))",
               },
               {
                 "dest": "/rules/swr-ttl/[...]-isr?url=$url",
-                "src": "(?<url>/rules/swr-ttl/.*)",
+                "src": "(?<url>/rules/swr-ttl/(?:.*))",
               },
               {
                 "dest": "/wasm/static-import",


### PR DESCRIPTION
Resolves https://github.com/nuxt/nuxt/issues/33316

In nitro [2.12.6](https://github.com/nitrojs/nitro/releases/tag/v2.12.6), we have introduced fixes for overlapping route rule functions + better names.

This revealed an undicovered issue where in past ISR route for `/path` would generate a function called `/path.func` and even without ISR path rewrites (`$url` param) it was working as name of function and path were same.

This PR fixes issue by 1) always normalizing rou3 patterns to PCRE and 2) Always wrapping regex with `$url` matcher.