### PR TITLE
fix(vite): enable virtualBundlePlugin as opt-in

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -236,8 +236,10 @@ function mainPlugin(ctx: NitroPluginContext): VitePlugin[] {
         if (serviceNames.includes(name)) {
           // we don't write to the file system
           // instead, the generateBundle hook will capture the output and write it to the virtual file system to be used by the nitro build later
-          config.build ??= {};
-          config.build.write = config.build.write ?? false;
+          if (ctx.pluginConfig.experimental?.virtualBundle) {
+            config.build ??= {};
+            config.build.write = config.build.write ?? false;
+          }
         }
       },
 

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -1,7 +1,7 @@
 import type { ViteBuilder } from "vite";
 import type { NitroPluginContext } from "./types";
 
-import { relative } from "pathe";
+import { relative, resolve } from "pathe";
 import { formatCompatibilityDate } from "compatx";
 import { copyPublicAssets, prerender } from "../..";
 import { nitroServerName } from "../../utils/nitro";
@@ -87,7 +87,15 @@ export function prodEntry(ctx: NitroPluginContext): string {
   const serviceNames = Object.keys(services);
   const result = [
     // Fetchable services
-    `const services = { ${serviceNames.map((name) => `[${JSON.stringify(name)}]: () => import("${ctx._entryPoints[name]}")`)}};`,
+    `const services = { ${serviceNames.map((name) => {
+      let entry: string;
+      if (ctx.pluginConfig.experimental?.virtualBundle) {
+        entry = ctx._entryPoints[name];
+      } else {
+        entry = resolve(ctx.nitro!.options.buildDir, "vite/services", name, ctx._entryPoints[name])
+      }
+      return `[${JSON.stringify(name)}]: () => import("${entry}")`;
+    })}};`,
     /* js */ `
               const serviceHandlers = {};
               const originalFetch = globalThis.fetch;

--- a/src/build/vite/rollup.ts
+++ b/src/build/vite/rollup.ts
@@ -52,7 +52,7 @@ export const getViteRollupConfig = (
     input: nitro.options.entry,
     external: [...base.env.external],
     plugins: [
-      virtualBundlePlugin(ctx._serviceBundles),
+      ctx.pluginConfig.experimental?.virtualBundle && virtualBundlePlugin(ctx._serviceBundles),
       ...baseBuildPlugins(nitro, base),
       alias({ entries: base.aliases }),
       replace({ preventAssignment: true, values: base.replacements }),

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -17,6 +17,14 @@ export interface NitroPluginConfig {
    * @internal Pre-initialized Nitro instance.
    */
   _nitro?: Nitro;
+
+  experimental?: {
+    /**
+     * Experimental: optimization to enable virtualized intermediate build output.
+     * this is unsafe when server framework relies on filesystem output structure.
+     */
+    virtualBundle?: boolean;
+  }
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

- Closes https://github.com/nitrojs/nitro/issues/3577

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds `experimental.virtualBundle` flag to make `virtualBundlePlugin` opt-in. See https://github.com/nitrojs/nitro/issues/3577#issuecomment-3359076907 for more context.

In terms of optimization, I don't think file read/write would be a bottleneck. It's nothing but a speculation, but I would imagine actual bundler logic where processing modules would cost more in general.

The flag is tested in `playground`:

- default

```sh
$ pnpm build

> nitro-playground@1.0.0 build /home/hiroshi/code/others/nitro/playground
> vite build

ℹ Using server.ts as the server entry.                                                   nitro 2:15:01 PM
ℹ Using app/server.tsx as SSR entry.                                                     nitro 2:15:01 PM
◐ Building Client...                                                                      nitro 2:15:01 PM
vite v7.1.7 building for production...
✓ 28 modules transformed.
.output/public/assets/nitro-DF0LpONz.png   54.51 kB
.output/public/assets/App-rqxwfrMX.js       1.82 kB │ gzip:  0.94 kB
.output/public/assets/index-LGjrhyKI.js     8.59 kB │ gzip:  3.22 kB
.output/public/assets/client-1KOwG8Aa.js  179.11 kB │ gzip: 56.64 kB
✓ built in 464ms
◐ Building SSR...                                                                         nitro 2:15:02 PM
vite v7.1.7 building SSR bundle for production...
✓ 39 modules transformed.
.nitro/vite/services/ssr/server.js  1,198.70 kB
✓ built in 566ms
◐ Building Nitro Server (preset: node-server, compatibility date: 2025-10-02)             nitro 2:15:02 PM
✔ Generated public .output/public                                                        nitro 2:15:02 PM
vite v7.1.7 building SSR bundle for production...
✓ 74 modules transformed.
.output/server/chunks/routes/route.get.mjs    0.13 kB
.output/server/index.mjs                    118.32 kB
.output/server/chunks/build/server.mjs      463.44 kB
✓ built in 1.07s
✔ You can preview this build using node .output/server/index.mjs                         nitro 2:15:03 PM
```

- with `experimental.virtualBundle`

```sh
$ pnpm build

> nitro-playground@1.0.0 build /home/hiroshi/code/others/nitro/playground
> vite build

ℹ Using server.ts as the server entry.                                                   nitro 2:15:35 PM
ℹ Using app/server.tsx as SSR entry.                                                     nitro 2:15:35 PM
◐ Building Client...                                                                      nitro 2:15:35 PM
vite v7.1.7 building for production...
✓ 28 modules transformed.
.output/public/assets/nitro-DF0LpONz.png   54.51 kB
.output/public/assets/App-rqxwfrMX.js       1.82 kB │ gzip:  0.94 kB
.output/public/assets/index-LGjrhyKI.js     8.59 kB │ gzip:  3.22 kB
.output/public/assets/client-1KOwG8Aa.js  179.11 kB │ gzip: 56.64 kB
✓ built in 469ms
◐ Building SSR...                                                                         nitro 2:15:35 PM
vite v7.1.7 building SSR bundle for production...
✓ 39 modules transformed.
✓ built in 550ms
◐ Building Nitro Server (preset: node-server, compatibility date: 2025-10-02)             nitro 2:15:36 PM
✔ Generated public .output/public                                                        nitro 2:15:36 PM
vite v7.1.7 building SSR bundle for production...
✓ 74 modules transformed.
.output/server/chunks/routes/route.get.mjs    0.13 kB
.output/server/index.mjs                    118.31 kB
.output/server/chunks/_/server.mjs          463.44 kB
✓ built in 1.00s
✔ You can preview this build using node .output/server/index.mjs                         nitro 2:15:37 PM
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
