### PR TITLE
fix: wait on dev worker init

### DIFF
--- a/src/dev/worker.ts
+++ b/src/dev/worker.ts
@@ -61,7 +61,10 @@ export class NodeDevWorker implements DevWorker {
     input: string | URL | Request,
     init?: RequestInit
   ): Promise<Response> {
-    if (!this.#address || !this.#proxy) {
+    for (let i = 0; i < 5 && !(this.#address && this.#proxy); i++) {
+      await new Promise((r) => setTimeout(r, 100 * Math.pow(2, i)));
+    }
+    if (!(this.#address && this.#proxy)) {
       return new Response("Dev worker is unavailable", { status: 503 });
     }
     return fetchAddress(this.#address, input, init);

--- a/src/runtime/internal/vite/worker.mjs
+++ b/src/runtime/internal/vite/worker.mjs
@@ -57,8 +57,17 @@ class EnvRunner {
     if (this.entryError) {
       return renderError(req, this.entryError);
     }
+    for (let i = 0; i < 5 && !(this.entry || this.entryError); i++) {
+      await new Promise((r) => setTimeout(r, 100 * Math.pow(2, i)));
+    }
+    if (this.entryError) {
+      return renderError(req, this.entryError);
+    }
+    if (!this.entry) {
+      throw httpError(503, `Vite environment "${this.name}" is unavailable`);
+    }
     try {
-      const entryFetch = this.entry?.fetch || this.entry?.default?.fetch;
+      const entryFetch = this.entry.fetch || this.entry.default?.fetch;
       if (!entryFetch) {
         throw httpError(
           500,


### PR DESCRIPTION
(extracted from #3600)

Wait on dev worker (exponential intervals) init before responding `Dev worker is unavailable` or `Vite environment is unavailable` 

