### PR TITLE
refactor!: remove `#build` alias

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -91,18 +91,7 @@ export function baseBuildConfig(nitro: Nitro) {
     },
   });
 
-  let buildDir = nitro.options.buildDir;
-  // Windows (native) dynamic imports should be file:// urls
-  if (
-    isWindows &&
-    nitro.options.externals?.trace === false &&
-    nitro.options.dev
-  ) {
-    buildDir = pathToFileURL(buildDir).href;
-  }
-
   const aliases = resolveAliases({
-    "#build": buildDir,
     "#internal/nitro": runtimeDir,
     "nitro/runtime": runtimeDir,
     "nitropack/runtime": runtimeDir, // Backwards compatibility
@@ -110,7 +99,6 @@ export function baseBuildConfig(nitro: Nitro) {
   });
 
   return {
-    buildDir,
     buildServerDir,
     presetsDir,
     extensions,


### PR DESCRIPTION
This PR removes legacy `#build` alias which was pointing to build dir. 

This is mainly to avoid conflicting with user defined `#build` alias but also this feature should really not be used by end-users to depend on intermediate build dirs (unless they explicitly need to!)