### PR TITLE
feat(vite): basic `vite preview` support

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "preview": "vite preview",
     "dev": "vite dev"
   },
   "devDependencies": {

--- a/src/build/info.ts
+++ b/src/build/info.ts
@@ -1,0 +1,40 @@
+import type { Nitro, NitroBuildInfo } from "nitro/types";
+import { resolve } from "pathe";
+import { version as nitroVersion } from "nitro/meta";
+import { presetsWithConfig } from "../presets/_types.gen";
+import { writeFile } from "../utils/fs";
+import { mkdir, unlink, symlink } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export async function writeBuildInfo(nitro: Nitro): Promise<NitroBuildInfo> {
+  const buildInfoPath = resolve(nitro.options.output.dir, "nitro.json");
+  const buildInfo: NitroBuildInfo = {
+    date: new Date().toJSON(),
+    preset: nitro.options.preset,
+    framework: nitro.options.framework,
+    versions: {
+      nitro: nitroVersion,
+    },
+    commands: {
+      preview: nitro.options.commands.preview,
+      deploy: nitro.options.commands.deploy,
+    },
+    config: {
+      ...Object.fromEntries(
+        presetsWithConfig.map((key) => [key, nitro.options[key]])
+      ),
+    },
+  };
+
+  await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2), true);
+
+  const lastBuild = resolve(
+    nitro.options.rootDir,
+    "node_modules/.nitro/last-build"
+  );
+  await mkdir(dirname(lastBuild), { recursive: true });
+  await unlink(lastBuild).catch(() => {});
+  await symlink(nitro.options.output.dir, lastBuild).catch(console.warn);
+
+  return buildInfo;
+}

--- a/src/build/rolldown/prod.ts
+++ b/src/build/rolldown/prod.ts
@@ -1,15 +1,14 @@
 import type { Nitro, NitroBuildInfo } from "nitro/types";
 import type { OutputOptions, RolldownOptions } from "rolldown";
 import { formatCompatibilityDate } from "compatx";
-import { writeFile } from "../../utils/fs";
-import { version as nitroVersion } from "nitro/meta";
+
 import { relative, resolve } from "pathe";
-import { presetsWithConfig } from "../../presets/_types.gen";
 import { scanHandlers } from "../../scan";
 import { generateFSTree } from "../../utils/fs-tree";
 import { nitroServerName } from "../../utils/nitro";
 import { writeTypes } from "../types";
 import { snapshot } from "../snapshot";
+import { writeBuildInfo } from "../info";
 
 export async function buildProduction(nitro: Nitro, config: RolldownOptions) {
   const rolldown = await import("rolldown");
@@ -26,26 +25,7 @@ export async function buildProduction(nitro: Nitro, config: RolldownOptions) {
     await build.write(config.output as OutputOptions);
   }
 
-  // Write .output/nitro.json
-  const buildInfoPath = resolve(nitro.options.output.dir, "nitro.json");
-  const buildInfo: NitroBuildInfo = {
-    date: new Date().toJSON(),
-    preset: nitro.options.preset,
-    framework: nitro.options.framework,
-    versions: {
-      nitro: nitroVersion,
-    },
-    commands: {
-      preview: nitro.options.commands.preview,
-      deploy: nitro.options.commands.deploy,
-    },
-    config: {
-      ...Object.fromEntries(
-        presetsWithConfig.map((key) => [key, nitro.options[key]])
-      ),
-    },
-  };
-  await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2));
+  const buildInfo = await writeBuildInfo(nitro);
 
   if (!nitro.options.static) {
     if (nitro.options.logging.buildSuccess) {

--- a/src/build/rollup/prod.ts
+++ b/src/build/rollup/prod.ts
@@ -1,14 +1,12 @@
-import type { Nitro, NitroBuildInfo, RollupConfig } from "nitro/types";
+import type { Nitro, RollupConfig } from "nitro/types";
 import { formatCompatibilityDate } from "compatx";
-import { writeFile } from "../../utils/fs";
-import { version as nitroVersion } from "nitro/meta";
-import { relative, resolve } from "pathe";
-import { presetsWithConfig } from "../../presets/_types.gen";
+import { relative } from "pathe";
 import { scanHandlers } from "../../scan";
 import { generateFSTree } from "../../utils/fs-tree";
 import { nitroServerName } from "../../utils/nitro";
 import { writeTypes } from "../types";
 import { snapshot } from "../snapshot";
+import { writeBuildInfo } from "../info";
 import { formatRollupError } from "./error";
 
 export async function buildProduction(
@@ -33,26 +31,7 @@ export async function buildProduction(
     await build.write(rollupConfig.output);
   }
 
-  // Write .output/nitro.json
-  const buildInfoPath = resolve(nitro.options.output.dir, "nitro.json");
-  const buildInfo: NitroBuildInfo = {
-    date: new Date().toJSON(),
-    preset: nitro.options.preset,
-    framework: nitro.options.framework,
-    versions: {
-      nitro: nitroVersion,
-    },
-    commands: {
-      preview: nitro.options.commands.preview,
-      deploy: nitro.options.commands.deploy,
-    },
-    config: {
-      ...Object.fromEntries(
-        presetsWithConfig.map((key) => [key, nitro.options[key]])
-      ),
-    },
-  };
-  await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2));
+  const buildInfo = await writeBuildInfo(nitro);
 
   if (!nitro.options.static) {
     if (nitro.options.logging.buildSuccess) {

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -15,6 +15,7 @@ import { runtimeDependencies, runtimeDir } from "nitro/runtime/meta";
 import { resolveModulePath } from "exsolve";
 import { prettyPath } from "../../utils/fs";
 import { NitroDevApp } from "../../dev/app";
+import { nitroPreviewPlugin } from "./preview";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html
@@ -29,16 +30,19 @@ export function nitro(pluginConfig: NitroPluginConfig = {}): VitePlugin {
     _serviceBundles: {},
   };
 
-  return [mainPlugin(ctx), nitroServicePlugin(ctx)];
+  return [nitroPlugin(ctx), nitroServicePlugin(ctx), nitroPreviewPlugin(ctx)];
 }
 
-function mainPlugin(ctx: NitroPluginContext): VitePlugin[] {
+function nitroPlugin(ctx: NitroPluginContext): VitePlugin[] {
   return [
     {
       name: "nitro:main",
 
       // Opt-in this plugin into the shared plugins pipeline
       sharedDuringBuild: true,
+
+      // Only apply this plugin during build or dev
+      apply: (config, configEnv) => !configEnv.isPreview,
 
       // Extend vite config before it's resolved
       async config(userConfig, configEnv) {

--- a/src/build/vite/preview.ts
+++ b/src/build/vite/preview.ts
@@ -1,0 +1,111 @@
+import type { Plugin as VitePlugin } from "vite";
+import type { NitroBuildInfo } from "nitro/types";
+import type { NitroPluginContext } from "./types";
+
+import { resolve } from "pathe";
+import { existsSync } from "node:fs";
+import { readFile, readlink } from "node:fs/promises";
+import { getRandomPort } from "get-port-please";
+
+import consola from "consola";
+import { spawn } from "node:child_process";
+import { prettyPath } from "../../utils/fs";
+import { createProxyServer } from "httpxy";
+
+export function nitroPreviewPlugin(ctx: NitroPluginContext): VitePlugin {
+  return <VitePlugin>{
+    name: "nitro:preview",
+
+    apply: (_config, configEnv) => !!configEnv.isPreview,
+
+    config(config) {
+      return {
+        preview: {
+          port: config.preview?.port || 3000,
+        },
+      };
+    },
+
+    async configurePreviewServer(server) {
+      const buildInfoPath = resolve(
+        server.config.root,
+        "node_modules/.nitro/last-build",
+        "nitro.json"
+      );
+      if (!existsSync(buildInfoPath)) {
+        console.warn(
+          `[nitro] No build found. Please build your project before previewing.`
+        );
+        return;
+      }
+
+      const realBuildDir = await readlink("node_modules/.nitro/last-build");
+
+      const buildInfo = JSON.parse(
+        await readFile(buildInfoPath, "utf8")
+      ) as NitroBuildInfo;
+
+      const info = [
+        ["Build Directory:", prettyPath(realBuildDir)],
+        ["Date:", buildInfo.date && new Date(buildInfo.date).toLocaleString()],
+        ["Nitro Version:", buildInfo.versions.nitro],
+        ["Nitro Preset:", buildInfo.preset],
+        buildInfo.framework?.name !== "nitro" && [
+          "Framework:",
+          buildInfo.framework?.name +
+            (buildInfo.framework?.version
+              ? ` (v${buildInfo.framework.version})`
+              : ""),
+        ],
+      ].filter((i) => i && i[1]) as [string, string][];
+      consola.box({
+        title: " [Build Info] ",
+        message: info.map((i) => `- ${i[0]} ${i[1]}`).join("\n"),
+      });
+
+      if (!buildInfo.commands?.preview) {
+        consola.warn("[nitro] No preview command found for this preset..");
+        return;
+      }
+
+      const randomPort = await getRandomPort();
+      consola.info(`Spawning preview server...`);
+
+      const [command, ...args] = buildInfo.commands.preview.split(" ");
+
+      let child: ReturnType<typeof spawn> | undefined;
+
+      consola.info(buildInfo.commands?.preview);
+
+      child = spawn(command, args, {
+        stdio: "inherit",
+        cwd: realBuildDir,
+        env: {
+          ...process.env,
+          PORT: String(randomPort),
+        },
+      });
+      process.on("exit", () => {
+        child?.kill();
+        child = undefined;
+      });
+      child.on("exit", (code) => {
+        if (code && code !== 0) {
+          consola.error(`[nitro] Preview server exited with code ${code}`);
+        }
+      });
+
+      const proxy = createProxyServer({
+        target: `http://localhost:${randomPort}`,
+      });
+
+      server.middlewares.use((req, res, next) => {
+        if (child && !child.killed) {
+          proxy.web(req, res).catch(next);
+        } else {
+          res.end(`Nitro preview server is not running.`);
+        }
+      });
+    },
+  };
+}

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -7,6 +7,7 @@ import { colors as C } from "consola/utils";
 import { copyPublicAssets, prerender } from "../..";
 import { existsSync, mkdirSync, rename, renameSync } from "node:fs";
 import { runtimeDir } from "nitro/runtime/meta";
+import { writeBuildInfo } from "../info";
 
 const BuilderNames = {
   nitro: C.magenta("Nitro"),
@@ -101,6 +102,9 @@ export async function buildEnvironments(
 
   // Call compiled hook
   await nitro.hooks.callHook("compiled", nitro);
+
+  // Write build info
+  await writeBuildInfo(nitro);
 
   // Show deploy and preview commands
   const rOutput = relative(process.cwd(), nitro.options.output.dir);


### PR DESCRIPTION
This PR adds basic `vite preview` integration by spawning the preview command.

As another improvement, we symlink output dir to known path of `<root>/node_modules/.nitro/last-build` this helps to discover real path of build dir.