### PR TITLE
build: bundle preset definitions

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -70,6 +70,9 @@ export default defineBuildConfig({
         if (id.includes("/src/cli/")) {
           return "cli/[name].mjs";
         }
+        if (id.includes("/src/presets")) {
+          return "presets.mjs";
+        }
         return "_chunks/[name].mjs";
       },
     },

--- a/build.config.ts
+++ b/build.config.ts
@@ -35,7 +35,12 @@ export default defineBuildConfig({
     { input: "src/vite.ts" },
     { input: "src/types/index.ts" },
     { input: "src/runtime/", outDir: "dist/runtime", format: "esm" },
-    { input: "src/presets/", outDir: "dist/presets", format: "esm" },
+    {
+      input: "src/presets/",
+      outDir: "dist/presets",
+      format: "esm",
+      pattern: "**/runtime/**",
+    },
   ],
   hooks: {
     async "build:done"(ctx) {

--- a/lib/runtime-meta.d.mts
+++ b/lib/runtime-meta.d.mts
@@ -1,4 +1,5 @@
 export declare const pkgDir: string;
 export declare const runtimeDir: string;
+export declare const presetsDir: string;
 export declare const subpaths: string[];
 export declare const runtimeDependencies: string[];

--- a/lib/runtime-meta.mjs
+++ b/lib/runtime-meta.mjs
@@ -6,6 +6,10 @@ export const runtimeDir = fileURLToPath(
   new URL("../dist/runtime/", import.meta.url)
 );
 
+export const presetsDir = fileURLToPath(
+  new URL("../dist/presets/", import.meta.url)
+);
+
 export const runtimeDependencies = [
   "h3",
   "cookie-es",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "./config": "./lib/config.mjs",
     "./types": "./dist/types/index.d.mts",
     "./meta": "./lib/meta.mjs",
-    "./presets": "./dist/presets/index.mjs",
     "./runtime": "./dist/runtime/index.mjs",
     "./runtime/internal": "./dist/runtime/internal/index.mjs",
     "./runtime/meta": "./lib/runtime-meta.mjs",

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -76,9 +76,7 @@ async function _loadUserConfig(
       process.env.COMPATIBILITY_DATE) as CompatibilityDateSpec);
 
   // Preset resolver
-  const { resolvePreset } = (await import(
-    "nitro/" + "presets"
-  )) as typeof import("nitro/presets");
+  const { resolvePreset } = await import("../presets");
 
   // prettier-ignore
   let preset: string | undefined = (configOverrides.preset as string) || process.env.NITRO_PRESET || process.env.SERVER_PRESET

--- a/src/presets/_nitro/base-worker.ts
+++ b/src/presets/_nitro/base-worker.ts
@@ -18,7 +18,6 @@ const baseWorker = defineNitroPreset(
   },
   {
     name: "base-worker" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/_nitro/nitro-dev.ts
+++ b/src/presets/_nitro/nitro-dev.ts
@@ -4,7 +4,7 @@ import { join } from "pathe";
 
 const nitroDev = defineNitroPreset(
   {
-    entry: "./runtime/nitro-dev",
+    entry: "./_nitro/runtime/nitro-dev",
     output: {
       dir: "{{ buildDir }}/dev",
       serverDir: "{{ buildDir }}/dev",
@@ -25,7 +25,6 @@ const nitroDev = defineNitroPreset(
   {
     name: "nitro-dev" as const,
     dev: true,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/_nitro/nitro-prerender.ts
+++ b/src/presets/_nitro/nitro-prerender.ts
@@ -2,7 +2,7 @@ import { defineNitroPreset } from "../_utils/preset";
 
 const nitroPrerender = defineNitroPreset(
   {
-    entry: "./runtime/nitro-prerenderer",
+    entry: "./_nitro/runtime/nitro-prerenderer",
     serveStatic: true,
     output: {
       serverDir: "{{ buildDir }}/prerender",
@@ -11,7 +11,6 @@ const nitroPrerender = defineNitroPreset(
   },
   {
     name: "nitro-prerender" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/_static/preset.ts
+++ b/src/presets/_static/preset.ts
@@ -19,7 +19,6 @@ const _static = defineNitroPreset(
   {
     name: "static" as const,
     static: true,
-    url: import.meta.url,
   }
 );
 
@@ -48,7 +47,6 @@ const githubPages = defineNitroPreset(
   {
     name: "github-pages" as const,
     static: true,
-    url: import.meta.url,
   }
 );
 
@@ -66,7 +64,6 @@ const gitlabPages = defineNitroPreset(
   {
     name: "gitlab-pages" as const,
     static: true,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/_utils/preset.ts
+++ b/src/presets/_utils/preset.ts
@@ -1,17 +1,18 @@
-import { fileURLToPath } from "node:url";
 import type { NitroPreset, NitroPresetMeta } from "nitro/types";
+
+import { presetsDir } from "nitro/runtime/meta";
+import { resolve } from "node:path";
 
 export function defineNitroPreset<
   P extends NitroPreset,
   M extends NitroPresetMeta,
 >(preset: P, meta?: M): P & { _meta: NitroPresetMeta } {
   if (
-    meta?.url &&
     typeof preset !== "function" &&
     preset.entry &&
     preset.entry.startsWith(".")
   ) {
-    preset.entry = fileURLToPath(new URL(preset.entry, meta.url));
+    preset.entry = resolve(presetsDir, preset.entry);
   }
   return { ...preset, _meta: meta } as P & { _meta: M };
 }

--- a/src/presets/alwaysdata/preset.ts
+++ b/src/presets/alwaysdata/preset.ts
@@ -11,7 +11,6 @@ const alwaysdata = defineNitroPreset(
   },
   {
     name: "alwaysdata" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/aws-amplify/preset.ts
+++ b/src/presets/aws-amplify/preset.ts
@@ -5,7 +5,7 @@ export type { AWSAmplifyOptions as PresetOptions } from "./types";
 
 const awsAmplify = defineNitroPreset(
   {
-    entry: "./runtime/aws-amplify",
+    entry: "./aws-amplify/runtime/aws-amplify",
     serveStatic: true,
     output: {
       dir: "{{ rootDir }}/.amplify-hosting",
@@ -24,7 +24,6 @@ const awsAmplify = defineNitroPreset(
   {
     name: "aws-amplify" as const,
     stdName: "aws_amplify",
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/aws-lambda/preset.ts
+++ b/src/presets/aws-lambda/preset.ts
@@ -3,7 +3,7 @@ export type { AwsLambdaOptions as PresetOptions } from "./types";
 
 const awsLambda = defineNitroPreset(
   {
-    entry: "./runtime/aws-lambda",
+    entry: "./aws-lambda/runtime/aws-lambda",
     awsLambda: {
       streaming: false,
     },
@@ -17,7 +17,6 @@ const awsLambda = defineNitroPreset(
   },
   {
     name: "aws-lambda" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/azure/preset.ts
+++ b/src/presets/azure/preset.ts
@@ -6,7 +6,7 @@ export type { AzureOptions as PresetOptions } from "./types";
 
 const azureSWA = defineNitroPreset(
   {
-    entry: "./runtime/azure-swa",
+    entry: "./azure/runtime/azure-swa",
     output: {
       serverDir: "{{ output.dir }}/server/functions",
       publicDir: "{{ output.dir }}/public/{{ baseURL }}",
@@ -24,7 +24,6 @@ const azureSWA = defineNitroPreset(
   {
     name: "azure-swa" as const,
     stdName: "azure_static",
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/bun/preset.ts
+++ b/src/presets/bun/preset.ts
@@ -2,7 +2,7 @@ import { defineNitroPreset } from "../_utils/preset";
 
 const bun = defineNitroPreset(
   {
-    entry: "./runtime/bun",
+    entry: "./bun/runtime/bun",
     serveStatic: true,
     // https://bun.sh/docs/runtime/modules#resolution
     exportConditions: ["bun", "node", "import", "default"],
@@ -12,7 +12,6 @@ const bun = defineNitroPreset(
   },
   {
     name: "bun" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/cleavr/preset.ts
+++ b/src/presets/cleavr/preset.ts
@@ -8,7 +8,6 @@ const cleavr = defineNitroPreset(
   {
     name: "cleavr" as const,
     stdName: "cleavr",
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/cloudflare/dev.ts
+++ b/src/presets/cloudflare/dev.ts
@@ -5,7 +5,7 @@ import type { Nitro } from "nitro/types";
 import { findFile } from "pkg-types";
 import { resolveModulePath } from "exsolve";
 
-export async function cloudflareDev(nitro: Nitro) {
+export async function cloudflareDevModule(nitro: Nitro) {
   if (!nitro.options.dev) {
     return; // Production doesn't need this
   }

--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -10,13 +10,14 @@ import {
   writeCFHeaders,
   writeCFPagesRedirects,
 } from "./utils";
+import { cloudflareDevModule } from "./dev";
 
 export type { CloudflareOptions as PresetOptions } from "./types";
 
 const cloudflarePages = defineNitroPreset(
   {
     extends: "base-worker",
-    entry: "./runtime/cloudflare-pages",
+    entry: "./cloudflare/runtime/cloudflare-pages",
     exportConditions: ["workerd"],
     commands: {
       preview: "npx wrangler --cwd ./ pages dev",
@@ -59,7 +60,6 @@ const cloudflarePages = defineNitroPreset(
   {
     name: "cloudflare-pages" as const,
     stdName: "cloudflare_pages",
-    url: import.meta.url,
   }
 );
 
@@ -84,7 +84,7 @@ const cloudflarePagesStatic = defineNitroPreset(
   {
     name: "cloudflare-pages-static" as const,
     stdName: "cloudflare_pages",
-    url: import.meta.url,
+
     static: true,
   }
 );
@@ -92,16 +92,13 @@ const cloudflarePagesStatic = defineNitroPreset(
 export const cloudflareDev = defineNitroPreset(
   {
     extends: "nitro-dev",
-    modules: [
-      async (nitro) =>
-        await import("./dev").then((m) => m.cloudflareDev(nitro)),
-    ],
+    modules: [cloudflareDevModule],
   },
   {
     name: "cloudflare-dev" as const,
     aliases: ["cloudflare-module", "cloudflare-durable", "cloudflare-pages"],
     compatibilityDate: "2025-07-13",
-    url: import.meta.url,
+
     dev: true,
   }
 );
@@ -109,7 +106,7 @@ export const cloudflareDev = defineNitroPreset(
 const cloudflareModule = defineNitroPreset(
   {
     extends: "base-worker",
-    entry: "./runtime/cloudflare-module",
+    entry: "./cloudflare/runtime/cloudflare-module",
     output: {
       publicDir: "{{ output.dir }}/public/{{ baseURL }}",
     },
@@ -152,18 +149,16 @@ const cloudflareModule = defineNitroPreset(
   {
     name: "cloudflare-module" as const,
     stdName: "cloudflare_workers",
-    url: import.meta.url,
   }
 );
 
 const cloudflareDurable = defineNitroPreset(
   {
     extends: "cloudflare-module",
-    entry: "./runtime/cloudflare-durable",
+    entry: "./cloudflare/runtime/cloudflare-durable",
   },
   {
     name: "cloudflare-durable" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/cloudflare/unenv/preset.ts
+++ b/src/presets/cloudflare/unenv/preset.ts
@@ -6,7 +6,6 @@ import * as workerdNodeCompat from "./node-compat";
 export const unencCfNodeCompat: Preset = {
   meta: {
     name: "nitro:cloudflare-node-compat",
-    url: import.meta.url,
   },
   external: workerdNodeCompat.builtnNodeModules,
   alias: {
@@ -29,7 +28,6 @@ export const unencCfNodeCompat: Preset = {
 export const unenvCfExternals: Preset = {
   meta: {
     name: "nitro:cloudflare-externals",
-    url: import.meta.url,
   },
   external: [
     "cloudflare:email",

--- a/src/presets/deno/preset.ts
+++ b/src/presets/deno/preset.ts
@@ -5,7 +5,7 @@ import { unenvDeno } from "./unenv/preset";
 
 const denoDeploy = defineNitroPreset(
   {
-    entry: "./runtime/deno-deploy",
+    entry: "./deno/runtime/deno-deploy",
     exportConditions: ["deno"],
     node: false,
     noExternals: true,
@@ -28,13 +28,12 @@ const denoDeploy = defineNitroPreset(
   },
   {
     name: "deno-deploy" as const,
-    url: import.meta.url,
   }
 );
 
 const denoServer = defineNitroPreset(
   {
-    entry: "./runtime/deno-server",
+    entry: "./deno/runtime/deno-server",
     serveStatic: true,
     exportConditions: ["deno"],
     commands: {
@@ -64,7 +63,6 @@ const denoServer = defineNitroPreset(
   },
   {
     name: "deno-server" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/deno/unenv/preset.ts
+++ b/src/presets/deno/unenv/preset.ts
@@ -7,7 +7,6 @@ import * as denoCompat from "./node-compat";
 export const unenvDeno: Preset = {
   meta: {
     name: "nitro:deno",
-    url: import.meta.url,
   },
   external: denoCompat.builtnNodeModules.map((m) => `node:${m}`),
   alias: {

--- a/src/presets/digitalocean/preset.ts
+++ b/src/presets/digitalocean/preset.ts
@@ -7,7 +7,6 @@ const digitalOcean = defineNitroPreset(
   },
   {
     name: "digital-ocean" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/firebase/preset.ts
+++ b/src/presets/firebase/preset.ts
@@ -44,7 +44,6 @@ const firebaseAppHosting = defineNitroPreset(
   {
     name: "firebase-app-hosting" as const,
     stdName: "firebase_app_hosting",
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/flightcontrol/preset.ts
+++ b/src/presets/flightcontrol/preset.ts
@@ -7,7 +7,6 @@ const flightControl = defineNitroPreset(
   },
   {
     name: "flight-control" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/genezio/preset.ts
+++ b/src/presets/genezio/preset.ts
@@ -6,7 +6,6 @@ const genezio = defineNitroPreset(
   },
   {
     name: "genezio" as const,
-    url: import.meta.url,
   }
 );
 export default [genezio] as const;

--- a/src/presets/heroku/preset.ts
+++ b/src/presets/heroku/preset.ts
@@ -7,7 +7,6 @@ const heroku = defineNitroPreset(
   },
   {
     name: "heroku" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/iis/preset.ts
+++ b/src/presets/iis/preset.ts
@@ -14,7 +14,6 @@ const iisHandler = defineNitroPreset(
   },
   {
     name: "iis-handler" as const,
-    url: import.meta.url,
   }
 );
 
@@ -30,7 +29,6 @@ const iisNode = defineNitroPreset(
   },
   {
     name: "iis-node" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/koyeb/preset.ts
+++ b/src/presets/koyeb/preset.ts
@@ -7,7 +7,6 @@ const koyeb = defineNitroPreset(
   },
   {
     name: "koyeb" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -17,7 +17,7 @@ export type { NetlifyOptions as PresetOptions } from "./types";
 // Netlify functions
 const netlify = defineNitroPreset(
   {
-    entry: "./runtime/netlify",
+    entry: "./netlify/runtime/netlify",
     output: {
       dir: "{{ rootDir }}/.netlify/functions-internal",
       publicDir: "{{ rootDir }}/dist/{{ baseURL }}",
@@ -61,7 +61,6 @@ const netlify = defineNitroPreset(
   {
     name: "netlify" as const,
     stdName: "netlify",
-    url: import.meta.url,
   }
 );
 
@@ -69,7 +68,7 @@ const netlify = defineNitroPreset(
 const netlifyEdge = defineNitroPreset(
   {
     extends: "base-worker",
-    entry: "./runtime/netlify-edge",
+    entry: "./netlify/runtime/netlify-edge",
     exportConditions: ["netlify"],
     output: {
       serverDir: "{{ rootDir }}/.netlify/edge-functions/server",
@@ -120,7 +119,6 @@ const netlifyEdge = defineNitroPreset(
   },
   {
     name: "netlify-edge" as const,
-    url: import.meta.url,
   }
 );
 
@@ -151,7 +149,6 @@ const netlifyStatic = defineNitroPreset(
     name: "netlify-static" as const,
     stdName: "netlify",
     static: true,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/node/preset.ts
+++ b/src/presets/node/preset.ts
@@ -4,7 +4,7 @@ import { resolveModulePath } from "exsolve";
 
 const nodeServer = defineNitroPreset(
   {
-    entry: "./runtime/node-server",
+    entry: "./node/runtime/node-server",
     serveStatic: true,
     commands: {
       preview: "node ./server/index.mjs",
@@ -12,17 +12,15 @@ const nodeServer = defineNitroPreset(
   },
   {
     name: "node-server" as const,
-    url: import.meta.url,
   }
 );
 
 const nodeMiddleware = defineNitroPreset(
   {
-    entry: "./runtime/node-middleware",
+    entry: "./node/runtime/node-middleware",
   },
   {
     name: "node-middleware" as const,
-    url: import.meta.url,
   }
 );
 
@@ -30,7 +28,7 @@ const nodeCluster = defineNitroPreset(
   {
     extends: "node-server",
     serveStatic: true,
-    entry: "./runtime/node-cluster",
+    entry: "./node/runtime/node-cluster",
     hooks: {
       "rollup:before"(_nitro, rollupConfig) {
         const manualChunks = rollupConfig.output?.manualChunks;
@@ -51,7 +49,6 @@ const nodeCluster = defineNitroPreset(
   },
   {
     name: "node-cluster" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/platform.sh/preset.ts
+++ b/src/presets/platform.sh/preset.ts
@@ -7,7 +7,6 @@ const platformSh = defineNitroPreset(
   },
   {
     name: "platform-sh" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/render.com/preset.ts
+++ b/src/presets/render.com/preset.ts
@@ -7,7 +7,6 @@ const renderCom = defineNitroPreset(
   },
   {
     name: "render-com" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/standard/preset.ts
+++ b/src/presets/standard/preset.ts
@@ -2,7 +2,7 @@ import { defineNitroPreset } from "../_utils/preset";
 
 const standard = defineNitroPreset(
   {
-    entry: "./runtime/server",
+    entry: "./standard/runtime/server",
     serveStatic: false,
     commands: {
       preview: "npx srvx --prod ./",
@@ -10,7 +10,6 @@ const standard = defineNitroPreset(
   },
   {
     name: "standard" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/stormkit/preset.ts
+++ b/src/presets/stormkit/preset.ts
@@ -2,7 +2,7 @@ import { defineNitroPreset } from "../_utils/preset";
 
 const stormkit = defineNitroPreset(
   {
-    entry: "./runtime/stormkit",
+    entry: "./stormkit/runtime/stormkit",
     output: {
       dir: "{{ rootDir }}/.stormkit",
       publicDir: "{{ rootDir }}/.stormkit/public/{{ baseURL }}",
@@ -11,7 +11,6 @@ const stormkit = defineNitroPreset(
   {
     name: "stormkit" as const,
     stdName: "stormkit",
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -12,7 +12,7 @@ export type { VercelOptions as PresetOptions } from "./types";
 
 const vercel = defineNitroPreset(
   {
-    entry: "./runtime/vercel",
+    entry: "./vercel/runtime/vercel",
     output: {
       dir: "{{ rootDir }}/.vercel/output",
       serverDir: "{{ output.dir }}/functions/__fallback.func",
@@ -34,7 +34,6 @@ const vercel = defineNitroPreset(
   {
     name: "vercel" as const,
     stdName: "vercel",
-    url: import.meta.url,
   }
 );
 
@@ -61,7 +60,6 @@ const vercelStatic = defineNitroPreset(
     name: "vercel-static" as const,
     stdName: "vercel",
     static: true,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/winterjs/preset.ts
+++ b/src/presets/winterjs/preset.ts
@@ -3,7 +3,7 @@ import { defineNitroPreset } from "../_utils/preset";
 const winterjs = defineNitroPreset(
   {
     extends: "base-worker",
-    entry: "./runtime/winterjs",
+    entry: "./winterjs/runtime/winterjs",
     minify: false,
     serveStatic: "inline",
     wasm: {
@@ -16,7 +16,6 @@ const winterjs = defineNitroPreset(
   },
   {
     name: "winterjs" as const,
-    url: import.meta.url,
   }
 );
 

--- a/src/presets/zeabur/preset.ts
+++ b/src/presets/zeabur/preset.ts
@@ -8,7 +8,7 @@ import { dirname, relative, resolve } from "pathe";
 
 const zeabur = defineNitroPreset(
   {
-    entry: "./runtime/zeabur",
+    entry: "./zeabur/runtime/zeabur",
     output: {
       dir: "{{ rootDir }}/.zeabur/output",
       serverDir: "{{ output.dir }}/functions/__nitro.func",
@@ -53,7 +53,6 @@ const zeabur = defineNitroPreset(
   {
     name: "zeabur" as const,
     stdName: "zeabur",
-    url: import.meta.url,
   }
 );
 
@@ -70,7 +69,7 @@ const zeaburStatic = defineNitroPreset(
   },
   {
     name: "zeabur-static" as const,
-    url: import.meta.url,
+
     static: true,
   }
 );

--- a/src/presets/zerops/preset.ts
+++ b/src/presets/zerops/preset.ts
@@ -7,7 +7,6 @@ const zerops = defineNitroPreset(
   },
   {
     name: "zerops" as const,
-    url: import.meta.url,
   }
 );
 
@@ -21,7 +20,7 @@ const zeropsStatic = defineNitroPreset(
   },
   {
     name: "zerops-static" as const,
-    url: import.meta.url,
+
     static: true,
   }
 );

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -5,7 +5,6 @@ import type { NitroConfig } from "./config";
 export type NitroPreset = NitroConfig | (() => NitroConfig);
 
 export interface NitroPresetMeta {
-  url: string;
   name: string;
   stdName?: ProviderName;
   aliases?: string[];


### PR DESCRIPTION
Instead of file-by-file copy, bundle presets into `dist/presets.mjs` for pkg. This allows prebundling preset build-time deps.