### PR TITLE
chore: correct `WebSocket` spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -775,7 +775,7 @@ Check [release notes](https://github.com/nitrojs/nitro/releases/tag/v2.11.0)
 
 ### 📖 Documentation
 
-- Add websocket chat demo to websocket api page ([#2189](https://github.com/nitrojs/nitro/pull/2189))
+- Add WebSocket chat demo to WebSocket api page ([#2189](https://github.com/nitrojs/nitro/pull/2189))
 - Fix typo ([#2190](https://github.com/nitrojs/nitro/pull/2190))
 - Fix typo ([#2194](https://github.com/nitrojs/nitro/pull/2194))
 
@@ -807,7 +807,7 @@ Check [release notes](https://github.com/nitrojs/nitro/releases/tag/v2.11.0)
 - **zeabur:** Support `zeaburStatic` and auto detect preset ([#2014](https://github.com/nitrojs/nitro/pull/2014))
 - **runtime-config:** Experimental env expansion support ([#2043](https://github.com/nitrojs/nitro/pull/2043))
 - Support binary server assets ([#2107](https://github.com/nitrojs/nitro/pull/2107))
-- Experimental websocket support ([#2170](https://github.com/nitrojs/nitro/pull/2170))
+- Experimental WebSocket support ([#2170](https://github.com/nitrojs/nitro/pull/2170))
 - **dev:** Expose upgrade handler ([5374429f](https://github.com/nitrojs/nitro/commit/5374429f))
 - Experimental database layer ([#1351](https://github.com/nitrojs/nitro/pull/1351))
 - Experimental scheduled tasks ([#2179](https://github.com/nitrojs/nitro/pull/2179))

--- a/docs/1.guide/3.websocket.md
+++ b/docs/1.guide/3.websocket.md
@@ -15,9 +15,9 @@ Nitro natively supports runtime agnostic [WebSocket](https://developer.mozilla.o
 ## Opt-in to the experimental feature
 
 > [!IMPORTANT]
-> WebSockets support is currently experimental. See [nitrojs/nitro#2171](https://github.com/nitrojs/nitro/issues/2171) for platform support status.
+> WebSocket support is currently experimental. See [nitrojs/nitro#2171](https://github.com/nitrojs/nitro/issues/2171) for platform support status.
 
-In order to enable websocket support you need to enable the experimental `websocket` feature flag.
+In order to enable WebSocket support you need to enable the experimental `websocket` feature flag.
 
 ::code-group
 ```ts [nitro.config.ts]
@@ -41,7 +41,7 @@ export default defineNuxtConfig({
 
 ## Usage
 
-Create a websocket handler in `server/routes/_ws.ts`.
+Create a WebSocket handler in `server/routes/_ws.ts`.
 
 > [!TIP]
 > You can use any route like `server/routes/chatroom.ts` to register upgrade handler on `/chatroom`.
@@ -75,7 +75,7 @@ export default defineWebSocketHandler({
 <!-- /automd -->
 
 > [!NOTE]
-> Nitro allows you defining multiple websocket handlers using same routing of event handlers.
+> Nitro allows you defining multiple WebSocket handlers using same routing of event handlers.
 
 Use a client to connect to server. Example: (`server/routes/websocket.ts`)
 
@@ -95,11 +95,11 @@ export default defineEventHandler(() => {
 Now you can try it on `/websocket` route!
 
 > [!TIP]
-> Check out our [chat demo](https://nuxt-chat.pi0.io/) using Nitro Websocket API.
+> Check out our [chat demo](https://nuxt-chat.pi0.io/) using Nitro WebSocket API.
 
 ## Server-Sent Events (SSE)
 
-As an alternative to WebSockets, you can use [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+As an alternative to WebSocket, you can use [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
 
 ### Example
 

--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -46,7 +46,7 @@ export default createHandler<Env>({
     // Expose stub fetch to the context
     ctxExt.durableFetch = (req = request) => getDurableStub(env).fetch(req);
 
-    // Websocket upgrade
+    // WebSocket upgrade
     // https://crossws.unjs.io/adapters/cloudflare#durable-objects
     if (
       import.meta._websocket &&

--- a/src/presets/cloudflare/runtime/cloudflare-module.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-module.ts
@@ -23,7 +23,7 @@ export default createHandler<Env>({
       return env.ASSETS.fetch(request);
     }
 
-    // Websocket upgrade
+    // WebSocket upgrade
     // https://crossws.unjs.io/adapters/cloudflare
     if (
       import.meta._websocket &&

--- a/src/presets/cloudflare/runtime/cloudflare-pages.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-pages.ts
@@ -43,7 +43,7 @@ export default {
     req.runtime.cloudflare ??= { context, env } as any;
     req.waitUntil = context.waitUntil.bind(context);
 
-    // Websocket upgrade
+    // WebSocket upgrade
     // https://crossws.unjs.io/adapters/cloudflare
     if (
       import.meta._websocket &&

--- a/src/presets/deno/runtime/deno-server.ts
+++ b/src/presets/deno/runtime/deno-server.ts
@@ -52,7 +52,7 @@ if (!serveOptions.key || !serveOptions.cert) {
 
 Deno.serve(serveOptions, handler);
 
-// Websocket support
+// WebSocket support
 const ws = import.meta._websocket
   ? // @ts-expect-error
     wsAdapter(nitroApp.h3App.websocket)

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -56,7 +56,7 @@ trapUnhandledNodeErrors();
 // Graceful shutdown
 setupGracefulShutdown(listener, nitroApp);
 
-// Websocket support
+// WebSocket support
 // https://crossws.unjs.io/adapters/node
 if (import.meta._websocket) {
   // @ts-expect-error


### PR DESCRIPTION
`WebSocket` is the correct spelling. 
https://developer.mozilla.org/en-US/docs/Web/API/WebSocket