### PR TITLE
refactor!: remove `rollup-plugin-visualizer` (for now)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "ofetch": "^1.4.1",
     "ohash": "^2.0.11",
     "rollup": "^4.52.4",
-    "rollup-plugin-visualizer": "^6.0.4",
     "rou3": "^0.7.7",
     "scule": "^1.3.0",
     "source-map": "^0.7.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       rollup:
         specifier: ^4.52.4
         version: 4.52.4
-      rollup-plugin-visualizer:
-        specifier: ^6.0.4
-        version: 6.0.4(rolldown@1.0.0-beta.42)(rollup@4.52.4)
       rou3:
         specifier: ^0.7.7
         version: 0.7.7

--- a/src/build/rollup/config.ts
+++ b/src/build/rollup/config.ts
@@ -10,7 +10,6 @@ import commonjs from "@rollup/plugin-commonjs";
 import inject from "@rollup/plugin-inject";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
-import { visualizer } from "rollup-plugin-visualizer";
 import { replace } from "../plugins/replace";
 import { esbuild } from "../plugins/esbuild";
 import { sourcemapMininify } from "../plugins/sourcemap-min";
@@ -179,21 +178,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     nitro.options.experimental.sourcemapMinify !== false
   ) {
     config.plugins.push(sourcemapMininify());
-  }
-
-  // Bundle analyzer
-  if (nitro.options.analyze) {
-    config.plugins.push(
-      // https://github.com/btd/rollup-plugin-visualizer
-      visualizer({
-        ...nitro.options.analyze,
-        filename: (nitro.options.analyze.filename || "stats.html").replace(
-          "{name}",
-          "nitro"
-        ),
-        title: "Nitro Server bundle stats",
-      })
-    );
   }
 
   return config;

--- a/src/build/vite/rollup.ts
+++ b/src/build/vite/rollup.ts
@@ -5,7 +5,6 @@ import { normalize, resolve, dirname } from "pathe";
 import { runtimeDir } from "nitro/runtime/meta";
 import alias from "@rollup/plugin-alias";
 import inject from "@rollup/plugin-inject";
-import { visualizer } from "rollup-plugin-visualizer";
 import { replace } from "../plugins/replace";
 import { baseBuildConfig, type BaseBuildConfig } from "../config";
 import { baseBuildPlugins } from "../plugins";
@@ -23,7 +22,6 @@ import type { NitroPluginContext } from "./types";
  * TODO: Reuse with rollup:
  * - chunkFileNames
  * - moduleSideEffects
- * - visualizer
  */
 
 export const getViteRollupConfig = (
@@ -139,21 +137,6 @@ export const getViteRollupConfig = (
   if (config.output.inlineDynamicImports) {
     // @ts-ignore
     delete config.output.manualChunks;
-  }
-
-  // Bundle analyzer
-  if (nitro.options.analyze) {
-    config.plugins.push(
-      // https://github.com/btd/rollup-plugin-visualizer
-      visualizer({
-        ...nitro.options.analyze,
-        filename: (nitro.options.analyze.filename || "stats.html").replace(
-          "{name}",
-          "nitro"
-        ),
-        title: "Nitro Server bundle stats",
-      })
-    );
   }
 
   return { config, base };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -67,7 +67,6 @@ export const NitroDefaults: NitroConfig = {
 
   // Rollup
   builder: undefined,
-  analyze: false,
   moduleSideEffects: ["unenv/polyfill/", resolve(runtimeDir, "polyfill/")],
   replace: {},
   node: true,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -14,7 +14,6 @@ import type { NestedHooks } from "hookable";
 import type { ProxyServerOptions } from "httpxy";
 import type { PresetName, PresetNameInput, PresetOptions } from "nitro/presets";
 import type { TSConfig } from "pkg-types";
-// import type { PluginVisualizerOptions } from "rollup-plugin-visualizer";
 import type { Preset as UnenvPreset } from "unenv";
 import type { UnimportPluginOptions } from "unimport/unplugin";
 import type { BuiltinDriverName } from "unstorage";
@@ -219,7 +218,6 @@ export interface NitroOptions extends PresetOptions {
   };
   noExternals: boolean;
   externals: NodeExternalsOptions;
-  analyze: false | Record<string, any>;
   replace: Record<string, string | ((id: string) => string)>;
   commonJS?: RollupCommonJSOptions;
   exportConditions?: string[];


### PR DESCRIPTION
rollup-plugin-visualizer has a really big [dependency graph](https://npmgraph.js.org/?q=rollup-plugin-visualizer) and is incompatible with both vite and traced node modules. /cc @43081j

This PR for now removes `analyze` feature from nitro v3 but it can be fairly easily added back by users. 

---

Ideally i want to adopot [vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) which  as rollup/rolldown/vite support and zero dep 🚀 but couldn't work it with rollup/rolldown (does nothing) and with vite, env api seems not supported (ssr and nitro envs are not displayed) -- once fixed we might add this as official integration. /cc @nonzzz @kricsleo