### PR TITLE
chore: remove `node_modules` from prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 *.md
 **/*.gen.ts
-node_modules
 pnpm-lock.yaml
 **/.docs
 **/dist/**


### PR DESCRIPTION
By default prettier ignores `node_modules`. That is why I thought may be we can remove it. I have seen in h3 that we have not mentioned node_modules in .prettierignore file.   
https://prettier.io/docs/ignore#ignoring-files-prettierignore
https://github.com/h3js/h3/blob/main/.prettierignore