### PR TITLE
feat(vite): support top level `nitro` config in `vite.config`

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -13,11 +13,11 @@ import {
 import { configureViteDevServer } from "./dev";
 import { runtimeDependencies, runtimeDir } from "nitro/runtime/meta";
 import { resolveModulePath } from "exsolve";
+import { fileURLToPath } from "node:url";
+import { defu } from "defu";
 import { prettyPath } from "../../utils/fs";
 import { NitroDevApp } from "../../dev/app";
 import { nitroPreviewPlugin } from "./preview";
-import { fileURLToPath } from "node:url";
-import defu from "defu";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -17,6 +17,7 @@ import { prettyPath } from "../../utils/fs";
 import { NitroDevApp } from "../../dev/app";
 import { nitroPreviewPlugin } from "./preview";
 import { fileURLToPath } from "node:url";
+import defu from "defu";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html
@@ -58,7 +59,7 @@ function nitroPlugin(ctx: NitroPluginContext): VitePlugin[] {
           (await createNitro({
             dev: configEnv.mode === "development",
             rootDir: userConfig.root,
-            ...ctx.pluginConfig.config,
+            ...defu(ctx.pluginConfig.config, userConfig.nitro),
           }));
 
         // Config ssr env as a fetchable ssr service

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -3,6 +3,15 @@ import type { getViteRollupConfig } from "./rollup";
 import type { DevWorker, Nitro, NitroConfig } from "nitro/types";
 import type { NitroDevApp } from "../../dev/app";
 
+declare module "vite" {
+  interface UserConfig {
+    /**
+     * Nitro Vite Plugin options.
+     */
+    nitro?: NitroConfig;
+  }
+}
+
 export interface NitroPluginConfig {
   /** Custom Nitro config */
   config?: NitroConfig;


### PR DESCRIPTION
Makes passing nitro config easier also allows other vite plugins to (pre) inject some nitro init config if they want to.

```js
import { defineConfig } from "vite";
import { nitro } from "nitro/vite";

import tailwindcss from "@tailwindcss/vite";

export default defineConfig({
  plugins: [nitro(), tailwindcss()],
  nitro: {
    renderer: {
      entry: "app.html",
    },
  },
});
```