### PR TITLE
feat: add defineCachedHandler as alias

### DIFF
--- a/src/config/resolvers/imports.ts
+++ b/src/config/resolvers/imports.ts
@@ -74,6 +74,7 @@ function getNitroImportsPreset(): Preset[] {
       imports: [
         "defineCachedFunction",
         "defineCachedEventHandler",
+        "defineCachedHandler",
         "cachedFunction",
         "cachedEventHandler",
       ],

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -18,6 +18,7 @@ export { defineRenderHandler } from "./internal/renderer";
 export {
   defineCachedFunction,
   defineCachedEventHandler,
+  defineCachedHandler,
   cachedFunction,
   cachedEventHandler,
 } from "./internal/cache";

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -343,3 +343,4 @@ export function defineCachedEventHandler(
 }
 
 export const cachedEventHandler = defineCachedEventHandler;
+export const defineCachedHandler = defineCachedEventHandler;


### PR DESCRIPTION
To be consistant with the new `defineHandler`, I believe it would be nice to also have `defineCachedHandler` as alias now.