### PR TITLE
fix(vite): skip pre nitro middleware if path has extension

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -230,7 +230,11 @@ export async function configureViteDevServer(
     if (fetchDest) {
       res.setHeader("vary", "sec-fetch-dest");
     }
-    if (!fetchDest || /^(document|iframe|frame|empty)$/.test(fetchDest)) {
+    const ext = (req.url || "").match(/\.([a-z0-9]+)(?:[?#]|$)/i)?.[1] || "";
+    if (
+      !ext &&
+      (!fetchDest || /^(document|iframe|frame|empty)$/.test(fetchDest))
+    ) {
       nitroDevMiddleware(req, res, next);
     } else {
       next();


### PR DESCRIPTION
In order to bypass vite dev middleware limitation, nitro ssr handler checks `sec-fetch-dest` and runs as first if it doesnt exist or request coming from browser document origin 

But it can fail when header does not exist (stackblitz has this issue)

