### PR TITLE
fix(vite): remove `noExternal: true` from service environment build

### DIFF
--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -73,7 +73,6 @@ export function createServiceEnvironment(
       emptyOutDir: true,
     },
     resolve: {
-      noExternal: ctx.nitro!.options.dev ? undefined : true,
       conditions: ctx.nitro!.options.exportConditions,
       externalConditions: ctx.nitro!.options.exportConditions,
     },


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

I think this can be removed from each service build since final `nitro` environment has `noExternal: true`, which can take care bundling up dependencies. Currently it's causing a large intermediate build for each service, for example in Vue Router SSR demo https://github.com/nitrojs/vite-examples/pull/5, the build log shows a following:

```sh
◐ Building [Client]                                                                                                                                                                                                      ...
...
✓ built in 416ms

◐ Building [SSR]                                                                                                                                                                                                         
...
...
.nitro/vite/services/ssr/assets/parser-DCdUCwrd.js                        15.00 kB
.nitro/vite/services/ssr/entry-server.js                               1,438.92 kB  👈👈 all dependencies are bundled at this stage
✓ built in 992ms 👈👈

◐ Building [Nitro] (preset: node-server, compatibility: 2025-10-18)                                                                                                                                                      ...
...
.output/server/index.mjs                                               75.11 kB
.output/server/chunks/build/entry-server.mjs                        1,407.94 kB 👈👈 then mostly copied to here
✓ built in 1.89s 👈👈
```

After removing `noExternal: true` from each service (by locally patching), the build becomes:

```sh
◐ Building [Client]                                                                                                                                                                                                      ...
...
✓ built in 414ms

◐ Building [SSR]                                                                                                                                                                                                         ...
...
.nitro/vite/services/ssr/assets/app-Bm8psYAt.js                        1.86 kB
.nitro/vite/services/ssr/entry-server.js                               3.23 kB 👈👈
✓ built in 44ms 👈👈

◐ Building [Nitro] (preset: node-server, compatibility: 2025-10-18)                                                                                                                                                      ...
...
.output/server/chunks/build/entry-server.mjs                         5.46 kB
.output/server/index.mjs                                            75.11 kB 👈👈
✓ built in 1.05s 👈👈
```

With this, the build got faster and external tracing of `nitro` environment properly isolated runtime dependencies `.output/server/node_modules`, so `.output` becomes standalone output.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
