### PR TITLE
refactor(prerender): show details for 5xx handled errors

### DIFF
--- a/src/presets/_nitro/runtime/nitro-prerenderer.ts
+++ b/src/presets/_nitro/runtime/nitro-prerenderer.ts
@@ -1,8 +1,27 @@
 import "#nitro-internal-pollyfills";
+import consola from "consola";
+import { getRequestHeader, getRequestURL, H3Error, isEvent } from "h3";
 import { useNitroApp } from "nitropack/runtime";
 import { trapUnhandledNodeErrors } from "nitropack/runtime/internal";
 
 const nitroApp = useNitroApp();
+
+nitroApp.hooks.hook("error", (error, context) => {
+  if (
+    isEvent(context.event) &&
+    !(error as H3Error).unhandled &&
+    (error as H3Error).statusCode >= 500 &&
+    getRequestHeader(context.event, "x-nitro-prerender")
+  ) {
+    const url = getRequestURL(context.event).href;
+    consola.error(
+      `[prerender error]`,
+      `[${context.event.method}]`,
+      `[${url}]`,
+      error
+    );
+  }
+});
 
 export const localFetch = nitroApp.localFetch;
 export const closePrerenderer = () => nitroApp.hooks.callHook("close");

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -85,6 +85,7 @@ export default defineNitroConfig({
   routeRules: {
     "/api/param/prerender4": { prerender: true },
     "/api/param/prerender2": { prerender: false },
+    "/prerender-error": { prerender: true },
     "/rules/headers": { headers: { "cache-control": "s-maxage=60" } },
     "/rules/cors": {
       cors: true,

--- a/test/fixture/routes/prerender-error.ts
+++ b/test/fixture/routes/prerender-error.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return new Error("Prerender error test");
+});

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -182,6 +182,10 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/raw",
               },
               {
+                "dest": "/prerender-error",
+                "src": "/prerender-error",
+              },
+              {
                 "dest": "/prerender-custom.html",
                 "src": "/prerender-custom.html",
               },
@@ -562,6 +566,7 @@ describe("nitro:preset:vercel", async () => {
             "functions/modules.func (symlink)",
             "functions/node-compat.func (symlink)",
             "functions/prerender-custom.html.func (symlink)",
+            "functions/prerender-error.func (symlink)",
             "functions/prerender.func (symlink)",
             "functions/raw.func (symlink)",
             "functions/replace.func (symlink)",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -21,6 +21,7 @@ import { isWindows, nodeMajorVersion } from "std-env";
 import { joinURL } from "ufo";
 import consola from "consola";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 
 export interface Context {
   preset: string;
@@ -37,7 +38,7 @@ export interface Context {
   env: Record<string, string>;
   lambdaV1?: boolean;
   // [key: string]: unknown;
-  consolaError: ReturnType<typeof vi.spyOn>;
+  consolaError: MockInstance<typeof consola.error>;
 }
 
 // https://github.com/nitrojs/nitro/pull/1240

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -19,7 +19,8 @@ import { type FetchOptions, fetch } from "ofetch";
 import { join, resolve } from "pathe";
 import { isWindows, nodeMajorVersion } from "std-env";
 import { joinURL } from "ufo";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import consola from "consola";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 export interface Context {
   preset: string;
@@ -36,6 +37,7 @@ export interface Context {
   env: Record<string, string>;
   lambdaV1?: boolean;
   // [key: string]: unknown;
+  consolaError: ReturnType<typeof vi.spyOn>;
 }
 
 // https://github.com/nitrojs/nitro/pull/1240
@@ -109,6 +111,7 @@ export async function setupTest(
         redirect: "manual",
         ...(opts as any),
       }),
+    consolaError: vi.spyOn(consola, "error").mockImplementation(() => {}),
   };
 
   // Set environment variables for process compatible presets
@@ -157,6 +160,7 @@ export async function setupTest(
   }
 
   afterAll(async () => {
+    ctx.consolaError.mockRestore();
     if (ctx.server) {
       await ctx.server.close();
     }
@@ -458,6 +462,12 @@ export function testNitro(
       });
       expect(data).toBe("prerender4");
       expect(headers["content-type"]).toBe("text/plain; charset=utf-16");
+    });
+
+    it("show details for 5xx handled errors", async () => {
+      expect(ctx.consolaError.mock.calls.flat().join(" ")).toContain(
+        "Prerender error test"
+      );
     });
   }
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

resolves https://github.com/nitrojs/nitro/issues/2992

Port https://github.com/nitrojs/nitro/pull/3348 back to `v2`. 🎉

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
