### PR TITLE
fix: remove internal `nitro/deps/*` aliases

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -101,9 +101,6 @@ export function baseBuildConfig(nitro: Nitro) {
     "#internal/nitro": runtimeDir,
     "nitro/runtime": runtimeDir,
     "nitropack/runtime": runtimeDir, // Backwards compatibility
-    "nitro/deps/h3": "h3",
-    "nitro/deps/ofetch": "ofetch",
-    "nitro/h3": "h3",
     ...env.alias,
   });
 


### PR DESCRIPTION
reverting 2890a45f4984de2e1d2476fd722deb1fba482467