### PR TITLE
build!: move `nitro` exports to `nitro/builder`

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -13,7 +13,7 @@ const pkg = await import("./package.json").then((r) => r.default || r);
 const srcDir = fileURLToPath(new URL("src", import.meta.url));
 const libDir = fileURLToPath(new URL("lib", import.meta.url));
 
-export const distSubpaths = ["presets", "runtime", "types", "vite"];
+export const distSubpaths = ["builder", "presets", "runtime", "types", "vite"];
 export const libSubpaths = [
   "config",
   "meta",
@@ -40,11 +40,14 @@ const tracePkgs = [
 ];
 
 export const stubAlias = {
-  nitro: resolve(srcDir, "index.ts"),
+  nitro: resolve(libDir, "index.mjs"),
   ...Object.fromEntries(
     distSubpaths.map((subpath) => [
       `nitro/${subpath}`,
-      resolve(srcDir, `${subpath}/index.ts`),
+      resolve(
+        srcDir,
+        subpath === "builder" ? "builder.ts" : `${subpath}/index.ts`
+      ),
     ])
   ),
   ...Object.fromEntries(
@@ -60,7 +63,7 @@ export default defineBuildConfig({
   name: "nitro",
   entries: [
     { input: "src/cli/index.ts" },
-    { input: "src/index.ts" },
+    { input: "src/builder.ts" },
     { input: "src/vite.ts" },
     { input: "src/types/index.ts" },
     { input: "src/runtime/", outDir: "dist/runtime", format: "esm" },

--- a/docs/1.docs/99.migration.md
+++ b/docs/1.docs/99.migration.md
@@ -107,16 +107,17 @@ Some (legacy) presets have been removed or renamed.
 | `service_worker`             | Removed due to instability |
 | `firebase`                   | Use new firebase app hosting |
 
-## Removed Subpath Exports
+## Changed nitro subpath imports
 
-Nitro v2 introduced multiple subpath exports, some of which have been removed:
+Nitro v2 introduced multiple subpath exports, some of which have been removed or updated:
 
-- `nitropack/core` (use `nitro`)
-- `nitropack/runtime/*`
-- `nitropack/dist/runtime/*`
-- `nitropack/presets/*`
-- `nitro/rollup`
-- `nitropack/kit`
+- `nitropack/core` (use `nitro/builder`)
+- `nitropack/runtime/*` (use `nitro/runtime`)
+- `nitropack/dist/runtime/*` (use `nitro/runtime`)
+- `nitro/rollup` (use `nitro/builder`)
+- `nitropack/kit` (removed)
+- `nitropack/presets` (removed)
+
 
 An experimental `nitropack/kit` was introduced but has now been removed. A standalone Nitro Kit package may be introduced in the future with clearer objectives.
 

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,0 +1,1 @@
+// reserved for "nitro" import

--- a/lib/indexd.mts
+++ b/lib/indexd.mts
@@ -1,0 +1,1 @@
+// reserved for "nitro" import

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "license": "MIT",
   "type": "module",
   "exports": {
+    ".": "./lib/index.mjs",
     "./package.json": "./package.json",
-    ".": "./dist/index.mjs",
+    "./builder": "./dist/builder.mjs",
     "./config": "./lib/config.mjs",
     "./types": "./dist/types/index.d.mts",
     "./meta": "./lib/meta.mjs",

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -7,7 +7,7 @@ import type {
 import type { InputOption } from "rollup";
 import type { NitroPluginConfig, NitroPluginContext } from "./types";
 import { resolve, relative, join } from "pathe";
-import { createNitro, prepare } from "../..";
+import { createNitro, prepare } from "../../builder";
 import { getViteRollupConfig } from "./rollup";
 import { buildEnvironments, prodSetup } from "./prod";
 import {

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -4,7 +4,7 @@ import type { NitroPluginContext } from "./types";
 import { basename, dirname, relative, resolve } from "pathe";
 import { formatCompatibilityDate } from "compatx";
 import { colors as C } from "consola/utils";
-import { copyPublicAssets } from "../..";
+import { copyPublicAssets } from "../../builder";
 import { existsSync } from "node:fs";
 import { runtimeDir } from "nitro/runtime/meta";
 import { writeBuildInfo } from "../info";

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,20 +1,20 @@
 // Core
 export { createNitro } from "./nitro";
 
-// Prerender
-export { prerender } from "./prerender/prerender";
-
-// Dev server
-export { createDevServer } from "./dev/server";
-
 // Config loader
 export { loadOptions } from "./config/loader";
-
-// Tasks API
-export { runTask, listTasks } from "./task";
 
 // Build
 export { build } from "./build/build";
 export { copyPublicAssets } from "./build/assets";
 export { prepare } from "./build/prepare";
 export { writeTypes } from "./build/types";
+
+// Dev server
+export { createDevServer } from "./dev/server";
+
+// Prerender
+export { prerender } from "./prerender/prerender";
+
+// Tasks API
+export { runTask, listTasks } from "./task";

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,4 +1,3 @@
-import nodeCrypto from "node:crypto";
 import { defineCommand } from "citty";
 import type { DateString } from "compatx";
 import {
@@ -7,14 +6,9 @@ import {
   createNitro,
   prepare,
   prerender,
-} from "nitro";
+} from "nitro/builder";
 import { resolve } from "pathe";
 import { commonArgs } from "../common";
-
-// globalThis.crypto support for Node.js 18
-if (!globalThis.crypto) {
-  globalThis.crypto = nodeCrypto as unknown as Crypto;
-}
 
 export default defineCommand({
   meta: {

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -1,7 +1,7 @@
 import type { Nitro } from "nitro/types";
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { build, createNitro, prepare } from "nitro";
+import { build, createNitro, prepare } from "nitro/builder";
 import { resolve } from "pathe";
 import { commonArgs } from "../common";
 import { NitroDevServer } from "../../dev/server";

--- a/src/cli/commands/prepare.ts
+++ b/src/cli/commands/prepare.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { createNitro, writeTypes } from "nitro";
+import { createNitro, writeTypes } from "nitro/builder";
 import { resolve } from "pathe";
 import { commonArgs } from "../common";
 

--- a/src/cli/commands/task/list.ts
+++ b/src/cli/commands/task/list.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { listTasks, loadOptions } from "nitro";
+import { listTasks, loadOptions } from "nitro/builder";
 import { resolve } from "pathe";
 
 export default defineCommand({

--- a/src/cli/commands/task/run.ts
+++ b/src/cli/commands/task/run.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
 import destr from "destr";
-import { createNitro, loadOptions, runTask } from "nitro";
+import { loadOptions, runTask } from "nitro/builder";
 import { resolve } from "pathe";
 
 export default defineCommand({

--- a/src/presets/_nitro/runtime/nitro-dev.ts
+++ b/src/presets/_nitro/runtime/nitro-dev.ts
@@ -4,17 +4,11 @@ import { useNitroApp, useNitroHooks } from "nitro/runtime";
 import { trapUnhandledNodeErrors } from "nitro/runtime/internal";
 import { startScheduleRunner } from "nitro/runtime/internal";
 import { Server } from "node:http";
-import nodeCrypto from "node:crypto";
 import { parentPort, threadId } from "node:worker_threads";
 
 import wsAdapter from "crossws/adapters/node";
 import { toNodeHandler } from "srvx/node";
 import { getSocketAddress, isSocketSupported } from "get-port-please";
-
-// globalThis.crypto support for Node.js 18
-if (!globalThis.crypto) {
-  globalThis.crypto = nodeCrypto as unknown as Crypto;
-}
 
 // Trap unhandled errors
 trapUnhandledNodeErrors();

--- a/src/types/virtual/app-config.d.ts
+++ b/src/types/virtual/app-config.d.ts
@@ -1,3 +1,3 @@
-import type { AppConfig } from "nitro";
+import type { AppConfig } from "nitro/types";
 
 export const appConfig: AppConfig;

--- a/test/minimal/minimal.test.ts
+++ b/test/minimal/minimal.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { createNitro, build, prepare } from "nitro";
+import { createNitro, build, prepare } from "nitro/builder";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mkdir, rm, stat } from "node:fs/promises";
 import { glob } from "tinyglobby";
-import { isCI, isWindows } from "std-env";
 
 const fixtureDir = fileURLToPath(new URL("./", import.meta.url));
 const tmpDir = fileURLToPath(new URL(".tmp", import.meta.url));

--- a/test/scripts/gen-fixture-types.ts
+++ b/test/scripts/gen-fixture-types.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "mlly";
-import { createNitro, writeTypes } from "nitro";
+import { createNitro, writeTypes } from "nitro/builder";
 import { resolve } from "pathe";
 import { scanHandlers } from "../../src/scan";
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -13,7 +13,7 @@ import {
   createNitro,
   prepare,
   prerender,
-} from "nitro";
+} from "nitro/builder";
 import type { Nitro, NitroConfig } from "nitro/types";
 import { fetch } from "ofetch";
 import type { FetchOptions } from "ofetch";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "lib": ["es2022", "webworker", "dom.iterable"],
     "types": ["node", "@cloudflare/workers-types"],
     "paths": {
-      "nitro": ["./src/index"],
+      "nitro": ["./lib/index"],
+      "nitro/builder": ["./src/builder"],
       "nitro/runtime": ["./src/runtime"],
       "nitro/runtime/internal": ["./src/runtime/internal"],
       "nitro/vite": ["./src/vite"],


### PR DESCRIPTION
Exports from `"nitro"` are mainly used by custom integrations and meta frameworks.

This PR moves them under `"nitro/builder"` so that we can use `"nitro"` for useful runtime imports.

/cc @danielroe 