### PR TITLE
chore(node, bun, deno): validate port range

### DIFF
--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -9,7 +9,7 @@ const host = process.env.NITRO_HOST || process.env.HOST;
 const cert = process.env.NITRO_SSL_CERT;
 const key = process.env.NITRO_SSL_KEY;
 
-if (port < 0 || port > 65535) {
+if (port < 0 || port > 65_535) {
   throw new Error("Port number range is between 0 to 65535");
 }
 

--- a/src/presets/deno/runtime/deno-server.ts
+++ b/src/presets/deno/runtime/deno-server.ts
@@ -10,7 +10,7 @@ const host = process.env.NITRO_HOST || process.env.HOST;
 const cert = process.env.NITRO_SSL_CERT;
 const key = process.env.NITRO_SSL_KEY;
 
-if (port < 0 || port > 65535) {
+if (port < 0 || port > 65_535) {
   throw new Error("Port number range is between 0 to 65535");
 }
 

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -11,7 +11,7 @@ const host = process.env.NITRO_HOST || process.env.HOST;
 const cert = process.env.NITRO_SSL_CERT;
 const key = process.env.NITRO_SSL_KEY;
 
-if (port < 0 || port > 65535) {
+if (port < 0 || port > 65_535) {
   throw new Error("Port number range is between 0 to 65535");
 }
 


### PR DESCRIPTION
Actually the port number range is between 0 to 65535. That is why I've tried to give a validation range for port. I dont know how it would be though. 