### PR TITLE
refactor(vite): remove `__VITE_MANIFEST__`

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -199,7 +199,6 @@ function nitroMain(ctx: NitroPluginContext): VitePlugin {
           "[main] Generating manifest and entry points for environment:",
           environment.name
         );
-        const { root } = environment.config;
         const services = ctx.pluginConfig.services || {};
         const serviceNames = Object.keys(services);
         const isRegisteredService = serviceNames.includes(environment.name);
@@ -207,22 +206,13 @@ function nitroMain(ctx: NitroPluginContext): VitePlugin {
         // Find entry point of this service
         let entryFile: string | undefined;
         for (const [_name, file] of Object.entries(bundle)) {
-          if (file.type === "chunk") {
-            if (isRegisteredService && file.isEntry) {
-              if (entryFile === undefined) {
-                entryFile = file.fileName;
-              } else {
-                this.warn(
-                  `Multiple entry points found for service "${environment.name}"`
-                );
-              }
-            }
-            const filteredModuleIds = file.moduleIds.filter((id) =>
-              id.startsWith(root)
-            );
-            for (const id of filteredModuleIds) {
-              const originalFile = relative(root, id);
-              ctx._manifest[originalFile] = { file: file.fileName };
+          if (file.type === "chunk" && isRegisteredService && file.isEntry) {
+            if (entryFile === undefined) {
+              entryFile = file.fileName;
+            } else {
+              this.warn(
+                `Multiple entry points found for service "${environment.name}"`
+              );
             }
           }
         }
@@ -332,7 +322,6 @@ function createContext(pluginConfig: NitroPluginConfig): NitroPluginContext {
   return {
     pluginConfig,
     _entryPoints: {},
-    _manifest: {},
     _serviceBundles: {},
   };
 }

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -157,8 +157,6 @@ export function prodSetup(ctx: NitroPluginContext): string {
   return /* js */ `
 import { setupVite } from "${resolve(runtimeDir, "internal/vite/prod-setup.mjs")}";
 
-const manifest = ${JSON.stringify(ctx._manifest || {})};
-
 function lazyService(loader) {
   let promise, mod
   return {
@@ -181,6 +179,6 @@ ${serviceEntries
   .join(",\n")}
 };
 
-setupVite({ manifest, services });
+setupVite({ services });
   `;
 }

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -95,7 +95,6 @@ export interface NitroPluginContext {
   devApp?: NitroDevApp;
 
   _initialized?: boolean;
-  _manifest: Record<string, { file: string }>;
   _publicDistDir?: string;
   _entryPoints: Record<string, string>;
   _serviceBundles: Record<string, OutputBundle>;

--- a/src/runtime/internal/vite/prod-setup.mjs
+++ b/src/runtime/internal/vite/prod-setup.mjs
@@ -1,6 +1,4 @@
-export function setupVite({ manifest, services }) {
-  globalThis.__VITE_MANIFEST__ = manifest;
-
+export function setupVite({ services }) {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = function nitroViteFetch(input, init) {
     // Only override if viteEnvName is specified


### PR DESCRIPTION
We had initially supported `__VITE_MANIFEST__` from vite plugin to allow accessing build meta from SSR and map assets.

With new full stasck mode by @hi-ogawa ❤️  we don't need it anymore.