### PR TITLE
refactor: remove specific `delimiters`

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -46,12 +46,6 @@ export function baseBuildConfig(nitro: Nitro) {
     _tasks: nitro.options.experimental.tasks,
   };
 
-  // https://github.com/rollup/plugins/tree/master/packages/replace#delimiters
-  const replaceDelimiters: [string, string] = [
-    String.raw`\b`,
-    String.raw`(?![\w.$])`,
-  ];
-
   const replacements = {
     "typeof window": '"undefined"',
     _import_meta_url_: "import.meta.url",
@@ -109,7 +103,6 @@ export function baseBuildConfig(nitro: Nitro) {
     isNodeless,
     buildEnvVars,
     staticFlags,
-    replaceDelimiters,
     replacements,
     env,
     aliases,

--- a/src/build/rolldown/config.ts
+++ b/src/build/rolldown/config.ts
@@ -35,7 +35,6 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
       ...(baseBuildPlugins(nitro, base) as RolldownPlugin[]),
       // https://github.com/rolldown/rolldown/issues/4257
       replace({
-        delimiters: base.replaceDelimiters,
         preventAssignment: true,
         values: base.replacements,
       }) as RolldownPlugin,

--- a/src/build/rollup/config.ts
+++ b/src/build/rollup/config.ts
@@ -48,7 +48,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       }),
       alias({ entries: base.aliases }),
       replace({
-        delimiters: base.replaceDelimiters,
         preventAssignment: true,
         values: base.replacements,
       }),

--- a/src/build/vite/rollup.ts
+++ b/src/build/vite/rollup.ts
@@ -55,7 +55,6 @@ export const getViteRollupConfig = (
       ...baseBuildPlugins(nitro, base),
       alias({ entries: base.aliases }),
       replace({
-        delimiters: base.replaceDelimiters,
         preventAssignment: true,
         values: base.replacements,
       }),


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi! I've noted that @danielroe has updated the default delimiters in `rollup-plugin-replace`(https://github.com/rollup/plugins/pull/1938), which has been released in [v6.0.3](https://github.com/rollup/plugins/blob/master/packages/replace/CHANGELOG.md#v603).

Since [we've already upgraded to this version](https://github.com/nitrojs/nitro/blob/737f4e6e84a3d5213cb0016c4851b53de7d6132f/package.json#L84), and the default delimiters are now more comprehensive and should address the issue we originally planned to fix in Nitro, I believe we can safely remove the custom delimiters we specified.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
