### PR TITLE
fix(vite): use `configEnv.command` to determine dev mode

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -342,7 +342,7 @@ async function setupNitroContext(
 ) {
   // Nitro config overrides
   const nitroConfig = {
-    dev: configEnv.mode === "development",
+    dev: configEnv.command === "serve",
     rootDir: userConfig.root,
     ...defu(ctx.pluginConfig.config, userConfig.nitro),
   };


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️

-->

### 🔗 Linked issue

<!-- If no issue exists, you may need to create one first, or mention "N/A" if this is a minor fix -->

N/A - This is a bug fix for incorrect dev mode detection when using custom Vite modes.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

- [ ] 👌 Enhancement (improving an existing functionality like performance)

- [ ] ✨ New feature (a non-breaking change that adds functionality)

- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Problem:**

When running `vite dev --mode abc` (or any custom mode), the Nitro plugin incorrectly sets `dev: false` because it checks `configEnv.mode === "development"`. This breaks dev server functionality when using custom modes, as the mode can be any custom value (e.g., `abc`, `staging`, `test`) and doesn't necessarily equal `"development"`.

**Solution:**

Change the dev mode detection from `configEnv.mode === "development"` to `configEnv.command === "serve"`. This aligns with Vite's design where:
- `command` indicates the command type (`serve` for dev server or `build` for production build)
- `mode` indicates the environment mode (can be `development`, `production`, or any custom value)

This fix ensures that `dev: true` is correctly set whenever the dev server is running, regardless of the custom mode specified.

**Testing:**

This fix correctly handles:
- ✅ `vite dev` → `dev: true`
- ✅ `vite dev --mode abc` → `dev: true` (previously broken)
- ✅ `vite dev --mode production` → `dev: true` (previously broken)
- ✅ `vite build` → `dev: false`
- ✅ `vite build --mode production` → `dev: false`

**Note:**

This follows the same pattern already used in the `configResolved` hook (line 169) which checks `config.command === "build"` to determine build mode.

### 📝 Checklist

- [x] I have linked an issue or discussion. (N/A - minor bug fix)

- [ ] I have updated the documentation accordingly. (N/A - no documentation change needed)