### PR TITLE
refactor: use `node_modules/.nitro` for `buildDir` and rely less on it

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -6,7 +6,6 @@ import { runtimeDir } from "nitro/runtime/meta";
 export type BaseBuildConfig = ReturnType<typeof baseBuildConfig>;
 
 export function baseBuildConfig(nitro: Nitro) {
-  const buildServerDir = join(nitro.options.buildDir, "dist/server");
   const presetsDir = resolve(runtimeDir, "../presets");
 
   // prettier-ignore
@@ -97,7 +96,6 @@ export function baseBuildConfig(nitro: Nitro) {
   });
 
   return {
-    buildServerDir,
     presetsDir,
     extensions,
     isNodeless,

--- a/src/build/info.ts
+++ b/src/build/info.ts
@@ -1,10 +1,12 @@
 import type { Nitro, NitroBuildInfo, WorkerAddress } from "nitro/types";
-import { relative, resolve } from "pathe";
+import { join, relative, resolve } from "pathe";
 import { version as nitroVersion } from "nitro/meta";
 import { presetsWithConfig } from "../presets/_types.gen.ts";
 import { writeFile } from "../utils/fs.ts";
 import { mkdir, readFile, stat } from "node:fs/promises";
 import { dirname } from "node:path";
+
+const NITRO_WELLKNOWN_DIR = "node_modules/.nitro";
 
 export async function getBuildInfo(
   root: string
@@ -32,7 +34,7 @@ export async function getBuildInfo(
 }
 
 export async function findLastBuildDir(root: string): Promise<string> {
-  const lastBuildLink = resolve(root, "node_modules/.nitro/last-build.json");
+  const lastBuildLink = join(root, NITRO_WELLKNOWN_DIR, "last-build.json");
   const outputDir = await readFile(lastBuildLink, "utf8")
     .then(JSON.parse)
     .then((data) =>
@@ -64,9 +66,10 @@ export async function writeBuildInfo(nitro: Nitro): Promise<NitroBuildInfo> {
 
   await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2), true);
 
-  const lastBuild = resolve(
+  const lastBuild = join(
     nitro.options.rootDir,
-    "node_modules/.nitro/last-build.json"
+    NITRO_WELLKNOWN_DIR,
+    "last-build.json"
   );
   await mkdir(dirname(lastBuild), { recursive: true });
   await writeFile(
@@ -82,7 +85,11 @@ export async function writeDevBuildInfo(
   nitro: Nitro,
   addr?: WorkerAddress
 ): Promise<void> {
-  const buildInfoPath = resolve(nitro.options.buildDir, "nitro.json");
+  const buildInfoPath = join(
+    nitro.options.rootDir,
+    NITRO_WELLKNOWN_DIR,
+    "nitro.dev.json"
+  );
   const buildInfo: NitroBuildInfo = {
     date: new Date().toJSON(),
     preset: nitro.options.preset,

--- a/src/build/plugins.ts
+++ b/src/build/plugins.ts
@@ -115,10 +115,7 @@ export function baseBuildPlugins(nitro: Nitro, base: BaseBuildConfig) {
         defu(nitro.options.externals, {
           outDir: nitro.options.output.serverDir,
           moduleDirectories: nitro.options.nodeModulesDirs,
-          external: [
-            ...(nitro.options.dev ? [nitro.options.buildDir] : []),
-            ...nitro.options.nodeModulesDirs,
-          ],
+          external: nitro.options.nodeModulesDirs,
           inline: [
             "#",
             "~",

--- a/src/build/rolldown/config.ts
+++ b/src/build/rolldown/config.ts
@@ -14,8 +14,6 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
   const base = baseBuildConfig(nitro);
 
   const chunkNamePrefixes = [
-    [nitro.options.buildDir, "build"],
-    [base.buildServerDir, "app"],
     [runtimeDir, "nitro"],
     [base.presetsDir, "nitro"],
     ["\0raw:", "raw"],

--- a/src/build/rollup/config.ts
+++ b/src/build/rollup/config.ts
@@ -20,8 +20,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
   const base = baseBuildConfig(nitro);
 
   const chunkNamePrefixes = [
-    [nitro.options.buildDir, "build"],
-    [base.buildServerDir, "app"],
     [runtimeDir, "nitro"],
     [base.presetsDir, "nitro"],
     ["\0raw:", "raw"],

--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -18,7 +18,10 @@ export async function writeTypes(nitro: Nitro) {
     routes: {},
   };
 
-  const typesDir = resolve(nitro.options.buildDir, "types");
+  const generatedTypesDir = resolve(
+    nitro.options.rootDir,
+    nitro.options.typescript.generatedTypesDir || "node_modules/.nitro/types"
+  );
 
   const middleware = [...nitro.scannedHandlers, ...nitro.options.handlers];
 
@@ -27,7 +30,7 @@ export async function writeTypes(nitro: Nitro) {
       continue;
     }
     const relativePath = relative(
-      typesDir,
+      generatedTypesDir,
       resolveNitroPath(mw.handler, nitro.options)
     ).replace(/\.(js|mjs|cjs|ts|mts|cts|tsx|jsx)$/, "");
 
@@ -52,7 +55,7 @@ export async function writeTypes(nitro: Nitro) {
 
     autoImportExports = toExports(allImports).replace(
       /#internal\/nitro/g,
-      relative(typesDir, runtimeDir)
+      relative(generatedTypesDir, runtimeDir)
     );
 
     const resolvedImportPathMap = new Map<string, string>();
@@ -85,7 +88,7 @@ export async function writeTypes(nitro: Nitro) {
         path = path.replace(/\.[a-z]+$/, "");
       }
       if (isAbsolute(path)) {
-        path = relative(typesDir, path);
+        path = relative(generatedTypesDir, path);
       }
       resolvedImportPathMap.set(from, path);
     }
@@ -153,7 +156,7 @@ export async function writeTypes(nitro: Nitro) {
   ];
 
   const declarations = [
-    // local nitropack augmentations
+    // local nitro augmentations
     '/// <reference path="./nitro-routes.d.ts" />',
     '/// <reference path="./nitro-config.d.ts" />',
     // global server auto-imports
@@ -163,30 +166,30 @@ export async function writeTypes(nitro: Nitro) {
   const buildFiles: { path: string; contents: string | (() => string) }[] = [];
 
   buildFiles.push({
-    path: join(typesDir, "nitro-routes.d.ts"),
+    path: join(generatedTypesDir, "nitro-routes.d.ts"),
     contents: () => generateRoutes().join("\n"),
   });
 
   buildFiles.push({
-    path: join(typesDir, "nitro-config.d.ts"),
+    path: join(generatedTypesDir, "nitro-config.d.ts"),
     contents: config.join("\n"),
   });
 
   buildFiles.push({
-    path: join(typesDir, "nitro-imports.d.ts"),
+    path: join(generatedTypesDir, "nitro-imports.d.ts"),
     contents: [...autoImportedTypes, autoImportExports || "export {}"].join(
       "\n"
     ),
   });
 
   buildFiles.push({
-    path: join(typesDir, "nitro.d.ts"),
+    path: join(generatedTypesDir, "nitro.d.ts"),
     contents: declarations.join("\n"),
   });
 
   if (nitro.options.typescript.generateTsConfig) {
     const tsConfigPath = resolve(
-      nitro.options.buildDir,
+      generatedTypesDir,
       nitro.options.typescript.tsconfigPath
     );
     const tsconfigDir = dirname(tsConfigPath);
@@ -215,7 +218,10 @@ export async function writeTypes(nitro: Nitro) {
         jsxFragmentFactory: "Fragment",
         paths: {
           "#imports": [
-            relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports")),
+            relativeWithDot(
+              tsconfigDir,
+              join(generatedTypesDir, "nitro-imports")
+            ),
           ],
           ...(nitro.options.typescript.internalPaths
             ? {
@@ -236,10 +242,10 @@ export async function writeTypes(nitro: Nitro) {
         },
       },
       include: [
-        relativeWithDot(tsconfigDir, join(typesDir, "nitro.d.ts")).replace(
-          /^(?=[^.])/,
-          "./"
-        ),
+        relativeWithDot(
+          tsconfigDir,
+          join(generatedTypesDir, "nitro.d.ts")
+        ).replace(/^(?=[^.])/, "./"),
         join(relativeWithDot(tsconfigDir, nitro.options.rootDir), "**/*"),
         ...(!nitro.options.serverDir ||
         nitro.options.serverDir === nitro.options.rootDir
@@ -303,7 +309,7 @@ export async function writeTypes(nitro: Nitro) {
   await Promise.all(
     buildFiles.map(async (file) => {
       await writeFile(
-        resolve(nitro.options.buildDir, file.path),
+        resolve(generatedTypesDir, file.path),
         typeof file.contents === "string" ? file.contents : file.contents()
       );
     })

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -68,7 +68,7 @@ export function createServiceEnvironment(
     build: {
       rollupOptions: { input: serviceConfig.entry },
       minify: ctx.nitro!.options.minify,
-      outDir: join(ctx.nitro!.options.buildDir, "vite", "services", name),
+      outDir: join(ctx.nitro!.options.buildDir, "vite/services", name),
       emptyOutDir: true,
     },
     resolve: {

--- a/src/build/vite/rollup.ts
+++ b/src/build/vite/rollup.ts
@@ -32,8 +32,6 @@ export const getViteRollupConfig = (
   const base = baseBuildConfig(nitro);
 
   const chunkNamePrefixes = [
-    [nitro.options.buildDir, "build"],
-    [base.buildServerDir, "app"],
     [runtimeDir, "nitro"],
     [base.presetsDir, "nitro"],
     ["\0nitro-wasm:", "wasm"],

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -13,7 +13,7 @@ export const NitroDefaults: NitroConfig = {
   // Dirs
   serverDir: false,
   scanDirs: [],
-  buildDir: ".nitro",
+  buildDir: `node_modules/.nitro`,
   output: {
     dir: "{{ rootDir }}/.output",
     serverDir: "{{ output.dir }}/server",
@@ -85,7 +85,7 @@ export const NitroDefaults: NitroConfig = {
     strict: true,
     generateRuntimeConfigTypes: false,
     generateTsConfig: false,
-    tsconfigPath: "types/tsconfig.json",
+    tsconfigPath: "tsconfig.json",
     internalPaths: false,
     tsConfig: {},
   },

--- a/src/task.ts
+++ b/src/task.ts
@@ -82,9 +82,9 @@ const _devHint = `(is dev server running?)`;
 
 async function _getTasksContext(opts?: TaskRunnerOptions) {
   const cwd = resolve(process.cwd(), opts?.cwd || ".");
-  const outDir = resolve(cwd, opts?.buildDir || ".nitro");
+  const buildDir = resolve(cwd, opts?.buildDir || "node_modules/.nitro");
 
-  const buildInfoPath = resolve(outDir, "nitro.json");
+  const buildInfoPath = resolve(buildDir, "nitro.dev.json");
   if (!existsSync(buildInfoPath)) {
     throw new Error(`Missing info file: \`${buildInfoPath}\` ${_devHint}`);
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -251,9 +251,21 @@ export interface NitroOptions extends PresetOptions {
     internalPaths?: boolean;
     generateRuntimeConfigTypes?: boolean;
     generateTsConfig?: boolean;
-    /** the path of the generated `tsconfig.json`, relative to buildDir */
-    tsconfigPath: string;
     tsConfig?: Partial<TSConfig>;
+
+    /**
+     * Path of the generated types directory.
+     *
+     * Default is `node_modules/.nitro/types`
+     */
+    generatedTypesDir?: string;
+
+    /**
+     * Path of the generated `tsconfig.json` relative to `typescript.generatedTypesDir`
+     *
+     * Default is `tsconfig.json` (`node_modules/.nitro/types/tsconfig.json`)
+     */
+    tsconfigPath: string;
   };
   hooks: NestedHooks<NitroHooks>;
   nodeModulesDirs: string[];


### PR DESCRIPTION
This PR moves default buildDir from `.nitro` to `node_modules/.nitro` to generate less user code.

Previously we were relyong on build dir to generate chunk names which was opinionated this had been removed.

Temporary (dev) `nito.json` will be standalone generated to `node_modules/.nitro/nitro.dev`

Typescript files will be generated to ``node_modules/.nitro/types` with a new standalone `typescript.generatedTypesDir` (/cc @danielroe)