### PR TITLE
fix(cloudflare): hotfix for rolldown minifier issue

### DIFF
--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -49,6 +49,9 @@ const cloudflarePages = defineNitroPreset(
     hooks: {
       "build:before": async (nitro) => {
         await enableNodeCompat(nitro);
+        if (nitro.options.builder?.includes("rolldown")) {
+          nitro.options.minify = false;
+        }
       },
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "pages");
@@ -142,6 +145,9 @@ const cloudflareModule = defineNitroPreset(
     hooks: {
       "build:before": async (nitro) => {
         await enableNodeCompat(nitro);
+        if (nitro.options.builder?.includes("rolldown")) {
+          nitro.options.minify = false;
+        }
       },
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "module");


### PR DESCRIPTION
Discovered from #3747

It seems rolldown minifier has an issue that generates invalid chunks when minifier enabled (not sure why yet have to investigate but only happens in certain condition reproducable in fixtures)

This PR is a hotfix to disable minifier on rolldown variants to pass CI for all presets x rolldown

/cc @sapphi-red (only FYI!)