### PR TITLE
feat(vercel): switch to `node` compat if one handler format is `node`

### DIFF
--- a/examples/express/nitro.config.ts
+++ b/examples/express/nitro.config.ts
@@ -4,4 +4,9 @@ export default defineConfig({
   routes: {
     "/**": { handler: "./server.ts", format: "node" },
   },
+  vercel: {
+    functions: {
+      runtime: "bun1.x",
+    },
+  },
 });

--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -20,11 +20,13 @@ const vercel = defineNitroPreset(
       publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
-      deploy: "",
       preview: "",
+      deploy: "npx vercel deploy --prebuilt",
     },
     hooks: {
       "build:before": async (nitro: Nitro) => {
+        const logger = nitro.logger.withTag("vercel");
+
         // Runtime
         const runtime = await resolveVercelRuntime(nitro);
         if (
@@ -33,6 +35,7 @@ const vercel = defineNitroPreset(
         ) {
           nitro.options.exportConditions!.push("bun");
         }
+        logger.info(`Using \`${runtime}\` runtime.`);
 
         // Entry handler format
         let serverFormat = nitro.options.vercel?.entryFormat;
@@ -42,7 +45,7 @@ const vercel = defineNitroPreset(
             .some((h) => h.format === "node");
           serverFormat = hasNodeHandler ? "node" : "web";
         }
-        nitro.logger.info(`[vercel] Using \`${serverFormat}\` entry format.`);
+        logger.info(`Using \`${serverFormat}\` entry format.`);
         nitro.options.entry = nitro.options.entry.replace(
           "{format}",
           serverFormat


### PR DESCRIPTION
Vercel preset supports both `node` and `web` handler compatibility format.

When at least one handler needs node compatibility (like Express), it is safer at runtime to switch to node handler format and use srvx compatibility layer as this way we can directly call express middleware with node `IncominMessage`/`ServerResponse` instead of doing web=>node conversion.