### PR TITLE
feat: automatically detect `deno` and `bun` as preset

### DIFF
--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "nitro";
 
 export default defineConfig({
-  preset: "standard",
+  // preset: "standard",
   // minify: true,
 });

--- a/src/presets/_resolve.ts
+++ b/src/presets/_resolve.ts
@@ -5,7 +5,7 @@ import {
 import type { CompatibilityDateSpec, PlatformName } from "compatx";
 import type { NitroPreset, NitroPresetMeta } from "nitro/types";
 import { kebabCase } from "scule";
-import { provider } from "std-env";
+import { provider, runtime } from "std-env";
 import type { ProviderName } from "std-env";
 import allPresets from "./_all.gen.ts";
 
@@ -85,9 +85,11 @@ export async function resolvePreset(
 
   // Auto-detect preset
   if (!name && !preset) {
-    return opts?.static
-      ? resolvePreset("static", opts)
-      : resolvePreset("node-server", opts);
+    if (opts?.static) {
+      return resolvePreset("static", opts);
+    }
+    const runtimeMap = { deno: "deno", bun: "bun" } as Record<string, string>;
+    return resolvePreset(runtimeMap[runtime] || "node", opts);
   }
 
   if (name && !preset) {

--- a/src/presets/standard/preset.ts
+++ b/src/presets/standard/preset.ts
@@ -13,8 +13,7 @@ const standard = defineNitroPreset(
     },
     alias: {
       srvx: "srvx/generic",
-      "srvx/node": "srvx/node",
-      "srvx/generic": "srvx/generic",
+      "srvx/": "srvx/",
     },
   },
   {


### PR DESCRIPTION
Nitro defaults to `node` preset output.

When running build command with deno (`deno run -A build`) or bun (`bun --bun run build`), we can detect it and generate and output corresponding builder (matching export conditions and handler format)

---

Manually tested and fixed one issue. CI tests to be added later for bun/deno.