### PR TITLE
refactor: better `serverDir` config dx

### DIFF
--- a/examples/api-routes/nitro.config.ts
+++ b/examples/api-routes/nitro.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "nitro";
 
 export default defineConfig({
-  serverDir: ".",
+  serverDir: "./",
 });

--- a/examples/auto-imports/nitro.config.ts
+++ b/examples/auto-imports/nitro.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "nitro";
 
 export default defineConfig({
-  serverDir: "./server",
+  serverDir: true,
   imports: {},
 });

--- a/examples/middleware/nitro.config.ts
+++ b/examples/middleware/nitro.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "nitro";
 
 export default defineConfig({
-  serverDir: "./server",
+  serverDir: true,
 });

--- a/examples/plugins/nitro.config.ts
+++ b/examples/plugins/nitro.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "nitro";
 
 export default defineConfig({
-  serverDir: "./server",
+  serverDir: true,
 });

--- a/examples/server-fetch/nitro.config.ts
+++ b/examples/server-fetch/nitro.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, serverFetch } from "nitro";
 
 export default defineConfig({
-  serverDir: "./",
+  serverDir: true,
   hooks: {
     "dev:start": async () => {
       const res = await serverFetch("/hello");

--- a/src/config/resolvers/paths.ts
+++ b/src/config/resolvers/paths.ts
@@ -26,6 +26,9 @@ export async function resolvePathOptions(options: NitroOptions) {
   }
 
   if (options.serverDir !== false) {
+    if ((options as any).serverDir === true) {
+      options.serverDir = "server";
+    }
     options.serverDir =
       resolve(options.rootDir, options.serverDir || ".") + "/";
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -294,6 +294,7 @@ export interface NitroConfig
         | "preset"
         | "compatibilityDate"
         | "unenv"
+        | "serverDir"
         | "_config"
         | "_c12"
       >
@@ -305,6 +306,7 @@ export interface NitroConfig
   rollupConfig?: Partial<RollupConfig>;
   compatibilityDate?: CompatibilityDateSpec;
   unenv?: UnenvPreset | UnenvPreset[];
+  serverDir?: boolean | "./" | "./server" | (string & {});
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
Adds `serverDir: true` shortcut instead of `serverDir: "./server"` + auto complete for two common values:

<img width="579" height="122" alt="image" src="https://github.com/user-attachments/assets/00e536fe-15f6-4bb2-8b6e-d09b97e120ab" />
