### PR TITLE
refactor!: remove default auto imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "ultrahtml": "^1.6.0",
     "uncrypto": "^0.1.3",
     "unctx": "^2.4.1",
+    "unimport": "^5.5.0",
     "untyped": "^2.0.0",
     "unwasm": "^0.4.2",
     "vitest": "^4.0.8",


### PR DESCRIPTION
With auto imports, some globals like `definePlugin` can easily conflict between h3 and nitro.

This PR simplifies feature to scan `utils/` import scan by default and anything else can be added by modules or user config.