### PR TITLE
refactor!: disable unenv npm shims by default

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -101,7 +101,6 @@ export function baseBuildConfig(nitro: Nitro) {
 
   const { env } = defineEnv({
     nodeCompat: isNodeless,
-    npmShims: true,
     resolve: true,
     presets: nitro.options.unenv,
     overrides: {


### PR DESCRIPTION
Nitro uses unenv pakcage shims for `whatwg-url`, `cross-fetch`, `debug`, `fsevents`, `inherits` and `node-fetch` npm packages (source: https://github.com/unjs/unenv/tree/main/src/runtime/npm)

Main issue with shimming is that CommonJS plugin might import them wrongly.

This PR disables shims. Leaving it up to users to add them back case-by-case.