### PR TITLE
feat(cloudflare): enable nodeCompat and deployConfig by default

### DIFF
--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -144,9 +144,6 @@ const cloudflareModule = defineNitroPreset(
     hooks: {
       "build:before": async (nitro) => {
         await enableNodeCompat(nitro);
-        if (nitro.options.builder?.includes("rolldown")) {
-          nitro.options.minify = false;
-        }
       },
       async compiled(nitro: Nitro) {
         await writeWranglerConfig(nitro, "module");

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -7,7 +7,6 @@ import { writeFile } from "../_utils/fs.ts";
 import { parseTOML, parseJSONC } from "confbox";
 import { readGitConfig, readPackageJSON, findNearestFile } from "pkg-types";
 import { defu } from "defu";
-import { provider } from "std-env";
 import { glob } from "tinyglobby";
 import { join, resolve } from "pathe";
 import {
@@ -190,36 +189,11 @@ export async function writeCFPagesRedirects(nitro: Nitro) {
 export async function enableNodeCompat(nitro: Nitro) {
   nitro.options.cloudflare ??= {};
 
-  // Enable deploy config for workers CI by default
-  // TODO: enable this by default once API could assert no config overrides will happen
-  if (
-    nitro.options.cloudflare.deployConfig === undefined &&
-    provider === "cloudflare_workers"
-  ) {
-    nitro.options.cloudflare.deployConfig = true;
+  nitro.options.cloudflare.deployConfig ??= true;
+  nitro.options.cloudflare.nodeCompat ??= true;
+  if (nitro.options.cloudflare.nodeCompat) {
+    nitro.options.unenv.push(unencCfNodeCompat);
   }
-
-  // Infer nodeCompat from user config
-  if (nitro.options.cloudflare.nodeCompat === undefined) {
-    const { config } = await readWranglerConfig(nitro);
-    const userCompatibilityFlags = new Set(config?.compatibility_flags || []);
-    if (
-      userCompatibilityFlags.has("nodejs_compat") ||
-      userCompatibilityFlags.has("nodejs_compat_v2") ||
-      nitro.options.cloudflare.deployConfig
-    ) {
-      nitro.options.cloudflare.nodeCompat = true;
-    }
-  }
-
-  if (!nitro.options.cloudflare.nodeCompat) {
-    if (nitro.options.cloudflare.nodeCompat === undefined) {
-      nitro.logger.warn("[cloudflare] Node.js compatibility is not enabled.");
-    }
-    return;
-  }
-
-  nitro.options.unenv.push(unencCfNodeCompat);
 }
 
 const extensionParsers = {

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -128,8 +128,6 @@ export default defineConfig({
     "* * * * *": "test",
   },
   cloudflare: {
-    nodeCompat: true,
-    deployConfig: true,
     pages: {
       routes: {
         include: ["/*"],


### PR DESCRIPTION
wrangler (cloudflare) supported deployConfig which makes deployment control much easier however we didn't opt-in as it could imply changing project settings. 

With nitro v3 we can opt-in + also leverage native node compatibility by default.