### PR TITLE
refactor(rollup, vite): remove commonjs option overrides

### DIFF
--- a/src/build/rollup/config.ts
+++ b/src/build/rollup/config.ts
@@ -71,9 +71,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
         exportConditions: nitro.options.exportConditions,
       }),
       (commonjs as unknown as typeof commonjs.default)({
-        strictRequires: "auto", // TODO: set to true (default) in v3
-        esmExternals: (id) => !id.startsWith("unenv/"),
-        requireReturnsDefault: "auto",
         ...nitro.options.commonJS,
       }),
       (json as unknown as typeof json.default)(),

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -32,9 +32,6 @@ export function createNitroEnvironment(
       minify: ctx.nitro!.options.minify,
       emptyOutDir: false,
       commonjsOptions: {
-        strictRequires: "auto", // TODO: set to true (default) in v3
-        esmExternals: (id) => !id.startsWith("unenv/"),
-        requireReturnsDefault: "auto",
         ...(ctx.nitro!.options.commonJS as any),
       },
     },


### PR DESCRIPTION
leaving default behavior to bundler defauls.