### PR TITLE
refactor: only allow strict `raw:` imports

### DIFF
--- a/src/build/plugins.ts
+++ b/src/build/plugins.ts
@@ -19,6 +19,7 @@ import { rendererTemplate } from "./plugins/renderer-template.ts";
 import { featureFlags } from "./plugins/feature-flags.ts";
 import { nitroResolveIds } from "./plugins/resolve.ts";
 import { sourcemapMinify } from "./plugins/sourcemap-min.ts";
+import { raw } from "./plugins/raw.ts";
 
 export function baseBuildPlugins(nitro: Nitro, base: BaseBuildConfig) {
   const plugins: Plugin[] = [];
@@ -77,6 +78,9 @@ export function baseBuildPlugins(nitro: Nitro, base: BaseBuildConfig) {
 
   // Routing
   plugins.push(routing(nitro));
+
+  // Raw Imports
+  plugins.push(raw());
 
   // Route meta
   if (nitro.options.experimental.openAPI) {

--- a/src/build/rolldown/config.ts
+++ b/src/build/rolldown/config.ts
@@ -8,7 +8,6 @@ import { baseBuildPlugins } from "../plugins.ts";
 import { replace } from "../plugins/replace.ts";
 import { builtinModules } from "node:module";
 import { defu } from "defu";
-import { raw } from "../plugins/raw.ts";
 
 export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
   const base = baseBuildConfig(nitro);
@@ -38,7 +37,6 @@ export const getRolldownConfig = (nitro: Nitro): RolldownOptions => {
         preventAssignment: true,
         values: base.replacements,
       }) as RolldownPlugin,
-      raw() as RolldownPlugin,
     ],
     resolve: {
       alias: base.aliases,

--- a/src/build/rollup/config.ts
+++ b/src/build/rollup/config.ts
@@ -12,7 +12,6 @@ import { replace } from "../plugins/replace.ts";
 import { oxc } from "../plugins/oxc.ts";
 import { baseBuildConfig } from "../config.ts";
 import { baseBuildPlugins } from "../plugins.ts";
-import { raw } from "../plugins/raw.ts";
 
 export const getRollupConfig = (nitro: Nitro): RollupConfig => {
   const base = baseBuildConfig(nitro);
@@ -74,7 +73,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       }),
       (json as unknown as typeof json.default)(),
       (inject as unknown as typeof inject.default)(base.env.inject),
-      raw(),
     ],
     onwarn(warning, rollupWarn) {
       if (

--- a/src/types/rollup.ts
+++ b/src/types/rollup.ts
@@ -31,7 +31,3 @@ export interface ServerAssetOptions {
     };
   };
 }
-
-export interface RawOptions {
-  extensions?: string[];
-}

--- a/test/fixture/server/routes/assets/md.ts
+++ b/test/fixture/server/routes/assets/md.ts
@@ -1,5 +1,5 @@
 export default async () => {
-  const md = await import("../../assets/test.md" as string).then(
+  const md = await import("raw:../../assets/test.md" as string).then(
     (r) => r.default
   );
   return md;

--- a/test/fixture/server/routes/raw.ts
+++ b/test/fixture/server/routes/raw.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import sql from "../files/sql.sql";
+import sql from "raw:../files/sql.sql";
 
 // https://github.com/nitrojs/nitro/issues/2836
 // @ts-ignore


### PR DESCRIPTION
Nitro allows importing assets as raw (content). This feature is usable standalone and also for using with server assets feature.

Nitro were also allowing implicit raw imports for known extensions such as `.sql` which can cause issues with user logic or other custom plugins (also somehow breaking in vite).

This change make it to strictly require `raw:` when importing raw specifiers (later might support `?raw` too)