### PR TITLE
ci: use hash instead of version

### DIFF
--- a/.github/workflows-disabled/codeql.yml
+++ b/.github/workflows-disabled/codeql.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,9 +13,9 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - run: npm i -g --force corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm i -g --force corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with: { node-version: lts/*, cache: pnpm }
       - run: pnpm install
       - run: pnpm stub && pnpm lint
@@ -26,14 +26,14 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm i -g --force corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with: { node-version: lts/*, cache: pnpm }
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         if: ${{ matrix.os != 'windows-latest' }}
         with: { bun-version: latest }
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         if: ${{ matrix.os != 'windows-latest' }}
         with: { deno-version: v2.x }
       - run: pnpm install
@@ -51,14 +51,14 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm i -g --force corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with: { node-version: lts/*, cache: pnpm }
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         if: ${{ matrix.os != 'windows-latest' }}
         with: { bun-version: latest }
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         if: ${{ matrix.os != 'windows-latest' }}
         with: { deno-version: v2.x }
       - run: pnpm install
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests-checks, tests-rollup, tests-rolldown]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with: { fetch-depth: 0 }
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm build
@@ -83,10 +83,10 @@ jobs:
     needs: [tests-checks, tests-rollup, tests-rolldown]
     if: contains('refs/heads/main', github.ref) && github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with: { fetch-depth: 0 }
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm build


### PR DESCRIPTION
I think i've read it using hash is always better practice for security reason in ci. That is why I have changed the actions to hash instead of versions. I thought maybe it might be better here. 