### PR TITLE
chore: enable pnpm trust policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,4 @@ peerDependencyRules:
     - "@algolia/client-search"
 
 shellEmulator: true
+trustPolicy: no-downgrade


### PR DESCRIPTION
since we're using pnpm 10.21, it has a very good option for security feature for enabling trust policy. maybe we can use it. (https://pnpm.io/settings#trustpolicy)