### PR TITLE
fix(vite): skip nitro middleware on mounted paths

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -208,12 +208,12 @@ export async function configureViteDevServer(
   ) => {
     // Skip for vite internal requests or if already handled
     if (
-      /^\/@(?:vite|fs|id)\//.test(nodeReq.url!) ||
+      !nodeReq.url ||
+      /^\/@(?:vite|fs|id)\//.test(nodeReq.url) ||
       nodeReq._nitroHandled ||
       server.middlewares.stack
         .map((mw) => mw.route)
-        .filter(Boolean)
-        .some((base) => nodeReq.url?.startsWith(base))
+        .some((base) => base && nodeReq.url!.startsWith(base))
     ) {
       return next();
     }


### PR DESCRIPTION
Some vite plugin and integrations might register their routes in the dev server. (Example:  '/.devtools-vite', '/.devtools', '/__open-in-editor')

This change skips Nitro dev middleware on mounted server paths.  (nice idea by @antfu  in https://github.com/nitrojs/nitro/pull/3775#discussion_r2512578545 ❤️)

