### PR TITLE
perf: reduce type instantiations on route matching

### DIFF
--- a/src/types/fetch/_match.ts
+++ b/src/types/fetch/_match.ts
@@ -67,11 +67,7 @@ type _MatchedRoutes<
         ? Route extends `${Root}/${string}`
           ? MatchResult<MatchedKeys, false, [], true>
           : never // catchAll match
-        : MatchResult<
-            MatchedKeys,
-            false,
-            CalcMatchScore<Root, Route, [], true>
-          > // glob match
+        : MatchResult<MatchedKeys, false, CalcMatchScore<Root, Route, [], true>> // glob match
       : MatchResult<
           MatchedKeys,
           false,

--- a/src/types/fetch/_match.ts
+++ b/src/types/fetch/_match.ts
@@ -91,8 +91,8 @@ export type MatchedRoutes<
 > = Route extends "/"
   ? keyof InternalApi // root middleware
   : Extract<Matches, { exact: true }> extends never
-    ? // @ts-ignore
-      | Extract<
+    ?
+        | Extract<
             Exclude<Matches, { score: never }>,
             { score: MaxTuple<Matches["score"]> }
           >["key"]


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

fix nuxt/nuxt#33735

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Here are the tsc diagnostic results with 200 API routes:

| before | after |
| --- | --- |
| <img width="334" height="464" alt="PixPin_2025-11-20_23-52-43" src="https://github.com/user-attachments/assets/e3364a9e-b1e5-4934-912a-7e1cd4f5cd9f" /> | <img width="340" height="462" alt="PixPin_2025-11-20_23-52-13" src="https://github.com/user-attachments/assets/91c7bc96-0fa6-421d-8998-ca5503b78522" /> |

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
