### PR TITLE
fix(vite): skip early dev handler for special prefixes

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -242,19 +242,18 @@ export async function configureViteDevServer(
     }
   };
 
-  // Handle as first middleware for direct requests
-  // To avoid overlap with static assets served by Vite from root
+  // Handle server routes first to avoid conflicts with static assets served by Vite from the root
   // https://github.com/vitejs/vite/pull/20866
   server.middlewares.use(function nitroDevMiddlewarePre(req, res, next) {
     const fetchDest = req.headers["sec-fetch-dest"];
     res.setHeader("vary", "sec-fetch-dest");
     if (
-      // Originating from browser tab or no fetch dest (curl, fetch, etc) and not script, style, image etc
+      // Originating from browser tab or no fetch dest (curl, fetch, etc) and (not script, style, image, etc)
       (!fetchDest || /^(document|iframe|frame|empty)$/.test(fetchDest)) &&
-      // No file extension (/src/index.ts)
+      // No file extension (not /src/index.ts)
       !req.url!.match(/\.([a-z0-9]+)(?:[?#]|$)/i)?.[1] &&
       // Special prefixes (/__vue-router/auto-routes, /@vite-plugin-layouts/, etc)
-      !/^\/(?:__|@).*/.test(req.url!)
+      !/^\/(?:__|@)/.test(req.url!)
     ) {
       nitroDevMiddleware(req, res, next);
     } else {


### PR DESCRIPTION
(from pair programming with @atinux on [chat-vue](https://github.com/nuxt-ui-templates/chat-vue/) template)

Nitro vite plugin adds an early vite dev middleware to handle SSR/API requests before overlapping with vite's root-level static asset serving.

We skip the early handler for requests with an extension but it is not enough as some plugins such as [unplugin-vue-router](https://github.com/posva/unplugin-vue-router/blob/2f10b86f74e3b0a0c233a575f9834d00e21f7571/src/core/moduleConstants.ts#L22) use `/__` virtual prefix and [vite-plugin-layouts](https://github.com/stacksjs/vite-plugin-layouts/blob/5c495b39d4776e7e5ddbe2ad327b7b9240a3dd62/src/index.ts#L17) uses `/@` prefix.

This PR skips for these special patterns too.

**Note:** API routes still work with routes starting with `/__` or `/@` only if there is a file named like `/_test` or `@foo` in root of project, it will be wrongly served.