### PR TITLE
chore(security): bump expressjs

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.5",
-    "express": "^5.1.0",
+    "express": "^5.2.0",
     "nitro": "latest"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,8 +368,8 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.0
+        version: 5.2.1
       nitro:
         specifier: link:../..
         version: link:../..
@@ -4417,8 +4417,8 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   exsolve@1.0.8:
@@ -11153,7 +11153,7 @@ snapshots:
 
   expect-type@1.2.2: {}
 
-  express@5.1.0:
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.1
@@ -11162,6 +11162,7 @@ snapshots:
       cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.3
+      depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1


### PR DESCRIPTION
@pi0 , there is a security issue in expressjs which published yesterday i guess. It needs to be updated. i have updated it and also deduped the lockfile.
https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6