### PR TITLE
feat(vercel): add support for skew protection

### DIFF
--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -16,6 +16,9 @@ const vercel = defineNitroPreset(
   {
     extends: "node",
     entry: "./runtime/vercel",
+    vercel: {
+      skewProtection: !!process.env.VERCEL_SKEW_PROTECTION_ENABLED,
+    },
     output: {
       dir: "{{ rootDir }}/.vercel/output",
       serverDir: "{{ output.dir }}/functions/__fallback.func",
@@ -93,6 +96,9 @@ const vercelEdge = defineNitroPreset(
 const vercelStatic = defineNitroPreset(
   {
     extends: "static",
+    vercel: {
+      skewProtection: !!process.env.VERCEL_SKEW_PROTECTION_ENABLED,
+    },
     output: {
       dir: "{{ rootDir }}/.vercel/output",
       publicDir: "{{ output.dir }}/static/{{ baseURL }}",

--- a/src/presets/vercel/types.ts
+++ b/src/presets/vercel/types.ts
@@ -113,6 +113,14 @@ export interface VercelOptions {
   config: VercelBuildConfigV3;
 
   /**
+   * If you have enabled skew protection in the Vercel dashboard, it will
+   * be enabled by default.
+   *
+   * You can disable the Nitro integration by setting this option to `false`.
+   */
+  skewProtection?: boolean;
+
+  /**
    * If you are using `vercel-edge`, you can specify the region(s) for your edge function.
    * @see https://vercel.com/docs/concepts/functions/edge-functions#edge-function-regions
    */

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -187,6 +187,26 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
           }
           return route;
         }),
+      // Skew protection
+      ...(nitro.options.vercel?.skewProtection &&
+      process.env.VERCEL_DEPLOYMENT_ID
+        ? [
+            {
+              src: "/.*",
+              has: [
+                {
+                  type: "header",
+                  key: "Sec-Fetch-Dest",
+                  value: "document",
+                },
+              ],
+              headers: {
+                "Set-Cookie": `__vdpl=${process.env.VERCEL_DEPLOYMENT_ID}; Path=${nitro.options.baseURL}; SameSite=Strict; Secure; HttpOnly`,
+              },
+              continue: true,
+            },
+          ]
+        : []),
       // Public asset rules
       ...nitro.options.publicAssets
         .filter((asset) => !asset.fallthrough)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro/pull/3802

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this cherry-picks the support for skew protection from https://github.com/nitrojs/nitro/pull/3787 (see https://github.com/nitrojs/nitro/issues/2311), but without `manifest.deploymentId` (as [requested](https://github.com/nitrojs/nitro/pull/3802#issuecomment-3633958772) ❤️).