### PR TITLE
docs(v2): add versions select on header

### DIFF
--- a/docs/.config/docs.yaml
+++ b/docs/.config/docs.yaml
@@ -9,6 +9,11 @@ socials:
   bluesky: "https://bsky.app/profile/nitro.build"
   discord: https://discord.nitro.build
 themeColor: "red"
+versions:
+  - label: "v2"
+    active: true
+  - label: "v3 (alpha)"
+    to: "https://v3.nitro.build"
 automd: true
 redirects:
   /deploy/node: /deploy/runtimes/node

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,6 @@
     "build": "undocs build"
   },
   "devDependencies": {
-    "undocs": "^0.4.3"
+    "undocs": "^0.4.11"
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       undocs:
-        specifier: ^0.4.3
-        version: 0.4.3(@babel/parser@7.28.4)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(rollup@4.50.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)(zod@3.25.76)
+        specifier: ^0.4.11
+        version: 0.4.11(@babel/parser@7.28.4)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.21)(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.9.2)))(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(rollup@4.50.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)(zod@3.25.76)
 
 packages:
 
@@ -4260,8 +4260,8 @@ packages:
   unctx@2.4.1:
     resolution: {integrity: sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg==}
 
-  undocs@0.4.3:
-    resolution: {integrity: sha512-nL7RQAWIA0EhwgYoQGKTtVWDNLJoXkZmpQzzHSLSZ5fs0V984Km0jcgySANYgR1UkhVgT/aZ8C5oi+oPLhCJZw==}
+  undocs@0.4.11:
+    resolution: {integrity: sha512-S5V1sGz5sBCG3JNgCBR0WEvSIK/vgEMTwGG8a1+KepWunzvEpHWCoOOvCLAp3PZndj1xNQpC3hj2PPVFU/LK7Q==}
     hasBin: true
 
   unenv@2.0.0-rc.21:
@@ -9879,7 +9879,7 @@ snapshots:
       magic-string: 0.30.19
       unplugin: 2.3.10
 
-  undocs@0.4.3(@babel/parser@7.28.4)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(rollup@4.50.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)(zod@3.25.76):
+  undocs@0.4.11(@babel/parser@7.28.4)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.21)(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.9.2)))(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(rollup@4.50.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)(zod@3.25.76):
     dependencies:
       '@headlessui/vue': 1.7.23(vue@3.5.21(typescript@5.9.2))
       '@iconify-json/logos': 1.2.9
@@ -9897,6 +9897,7 @@ snapshots:
       is-buffer: 2.0.5
       md4w: 0.2.7
       mermaid: 11.12.0
+      motion-v: 1.7.1(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.9.2)))(vue@3.5.21(typescript@5.9.2))
       nitropack: 2.12.6
       nuxi: 3.28.0
       nuxt: 4.1.2(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(rollup@4.50.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
@@ -9936,6 +9937,7 @@ snapshots:
       - '@vercel/kv'
       - '@vue/compiler-sfc'
       - '@vue/composition-api'
+      - '@vueuse/core'
       - async-validator
       - aws4fetch
       - axios


### PR DESCRIPTION
In order to give visibility + quick access from nitro.build to Nitro v3

<img width="452" height="272" alt="CleanShot 2025-12-11 at 01 06 37@2x" src="https://github.com/user-attachments/assets/ef12dd24-0eeb-4692-bae2-90e4d5b3ad08" />

Related to #3856 