### PR TITLE
feat(cloudflare-durable): add durable.bindingName config

### DIFF
--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -6,7 +6,7 @@ import { useNitroApp } from "nitropack/runtime";
 import { isPublicAssetURL } from "#nitro-internal-virtual/public-assets";
 import { createHandler, fetchHandler } from "./_module-handler";
 
-const DURABLE_BINDING = "$DurableObject";
+const DURABLE_BINDING = import.meta._durableBindingName || "$DurableObject";
 const DURABLE_INSTANCE = "server";
 
 interface Env {

--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -92,6 +92,18 @@ export interface CloudflareOptions {
      */
     defaultRoutes?: boolean;
   };
+
+  /**
+   * Options for the `cloudflare-durable` preset.
+   */
+  durable?: {
+    /**
+     * The binding name for the Durable Object used by `defineWebSocketHandler`.
+     *
+     * @default "$DurableObject"
+     */
+    bindingName?: string;
+  };
 }
 
 type DurableObjectState = ConstructorParameters<typeof DurableObject>[0];

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -364,6 +364,23 @@ export async function writeWranglerConfig(
   }
   wranglerConfig.compatibility_flags = [...compatFlags];
 
+  // Durable Objects config for cloudflare-durable preset
+  if (nitro.options.preset === "cloudflare-durable") {
+    const bindingName =
+      nitro.options.cloudflare?.durable?.bindingName || "$DurableObject";
+    wranglerConfig.durable_objects ??= { bindings: [] };
+    wranglerConfig.durable_objects.bindings ??= [];
+    const hasBinding = wranglerConfig.durable_objects.bindings.some(
+      (b) => b.name === bindingName && b.class_name === "$DurableObject"
+    );
+    if (!hasBinding) {
+      wranglerConfig.durable_objects.bindings.push({
+        name: bindingName,
+        class_name: "$DurableObject",
+      });
+    }
+  }
+
   // Write wrangler.json
   await writeFile(
     wranglerConfigPath,

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -237,6 +237,8 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     _asyncContext: nitro.options.experimental.asyncContext,
     _websocket: nitro.options.experimental.websocket,
     _tasks: nitro.options.experimental.tasks,
+    _durableBindingName:
+      nitro.options.cloudflare?.durable?.bindingName || "$DurableObject",
   };
 
   // Universal import.meta

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -5,6 +5,7 @@ export interface NitroStaticBuildFlags {
   _asyncContext?: boolean;
   _websocket?: boolean;
   _tasks?: boolean;
+  _durableBindingName?: string;
   dev?: boolean;
   client?: boolean;
   nitro?: boolean;


### PR DESCRIPTION
## Summary

Backport of #3875 for v2 branch.

Adds `cloudflare.durable.bindingName` config option to customize the Durable Object binding name used by `defineWebSocketHandler`.

- Default: `$DurableObject` (backwards compatible)
- Custom name is injected via `import.meta._durableBindingName`
- Auto-generates `durable_objects.bindings` in wrangler.json when `deployConfig: true`

## Usage

```ts
export default defineNuxtConfig({
  nitro: {
    preset: 'cloudflare-durable',
    cloudflare: {
      deployConfig: true,
      durable: { bindingName: 'MyDO' }
    }
  }
})
```

## Repro

https://github.com/onmax/repros/tree/repro/nitro-3378/nitro-3378

Related: #3378