### PR TITLE
build!: remove `nitro/deps/*`

### DIFF
--- a/lib/deps/ofetch.mjs
+++ b/lib/deps/ofetch.mjs
@@ -1,1 +1,0 @@
-export { $fetch } from "ofetch";

--- a/lib/deps/ofetch.mts
+++ b/lib/deps/ofetch.mts
@@ -1,1 +1,0 @@
-export { $fetch } from "ofetch";

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "./config": "./dist/runtime/config.mjs",
     "./context": "./dist/runtime/context.mjs",
     "./database": "./dist/runtime/database.mjs",
-    "./deps/h3": "./lib/deps/h3.mjs",
-    "./deps/ofetch": "./lib/deps/ofetch.mjs",
     "./h3": "./lib/deps/h3.mjs",
     "./meta": "./dist/runtime/meta.mjs",
     "./package.json": "./package.json",

--- a/src/build/plugins/resolve.ts
+++ b/src/build/plugins/resolve.ts
@@ -3,8 +3,6 @@ import type { Plugin } from "rollup";
 
 const subpathMap = {
   "nitro/h3": "h3",
-  "nitro/deps/h3": "h3",
-  "nitro/deps/ofetch": "ofetch",
 };
 
 export function nitroResolveIds(): Plugin {


### PR DESCRIPTION
`nitro/deps/h3` and `nitro/h3` introduced in first alpha however having both confuses IDE and makes inconsistent usage. 

This PR removes `nitro/deps/h3|ofetch` and only keeps `nitro/h3`