### PR TITLE
refactor(zeabur): update preset

### DIFF
--- a/src/presets/zeabur/preset.ts
+++ b/src/presets/zeabur/preset.ts
@@ -1,54 +1,8 @@
-import fsp from "node:fs/promises";
-import { writeFile } from "../_utils/fs.ts";
 import { defineNitroPreset } from "../_utils/preset.ts";
-import type { Nitro } from "nitro/types";
-import { dirname, relative, resolve } from "pathe";
-
-// https://zeabur.com/docs/advanced/serverless-output-format
 
 const zeabur = defineNitroPreset(
   {
-    entry: "./zeabur/runtime/zeabur",
-    output: {
-      dir: "{{ rootDir }}/.zeabur/output",
-      serverDir: "{{ output.dir }}/functions/__nitro.func",
-      publicDir: "{{ output.dir }}/static",
-    },
-    hooks: {
-      async compiled(nitro: Nitro) {
-        const buildConfigPath = resolve(
-          nitro.options.output.dir,
-          "config.json"
-        );
-        const cfg = {
-          containerized: false,
-          routes: [{ src: ".*", dest: "/__nitro" }],
-        };
-        await writeFile(buildConfigPath, JSON.stringify(cfg, null, 2));
-
-        // Write ISR functions
-        for (const [key, value] of Object.entries(nitro.options.routeRules)) {
-          if (!value.isr) {
-            continue;
-          }
-          const funcPrefix = resolve(
-            nitro.options.output.serverDir,
-            ".." + key
-          );
-          await fsp.mkdir(dirname(funcPrefix), { recursive: true });
-          await fsp.symlink(
-            "./" +
-              relative(dirname(funcPrefix), nitro.options.output.serverDir),
-            funcPrefix + ".func",
-            "junction"
-          );
-          await writeFile(
-            funcPrefix + ".prerender-config.json",
-            JSON.stringify({ type: "Prerender" })
-          );
-        }
-      },
-    },
+    extends: "node-server",
   },
   {
     name: "zeabur" as const,
@@ -59,17 +13,9 @@ const zeabur = defineNitroPreset(
 const zeaburStatic = defineNitroPreset(
   {
     extends: "static",
-    output: {
-      dir: "{{ rootDir }}/.zeabur/output",
-      publicDir: "{{ output.dir }}/static",
-    },
-    commands: {
-      preview: "npx serve ./static",
-    },
   },
   {
     name: "zeabur-static" as const,
-
     static: true,
   }
 );

--- a/test/presets/zeabur.test.ts
+++ b/test/presets/zeabur.test.ts
@@ -1,0 +1,35 @@
+import { existsSync } from "node:fs";
+import fsp from "node:fs/promises";
+import { resolve } from "pathe";
+import { describe, expect, it } from "vitest";
+import { setupTest } from "../tests.ts";
+
+describe("nitro:preset:zeabur-static", async () => {
+  const ctx = await setupTest("zeabur-static");
+
+  it("should not generate a server folder", async () => {
+    const contents = await fsp.readdir(resolve(ctx.outDir));
+    expect(contents).toMatchInlineSnapshot(`
+      [
+        "nitro.json",
+        "public",
+      ]
+    `);
+  });
+
+  it("output has public directory", async () => {
+    // make output directory aligned with `nuxt generate`'s
+    // output directory, which is ".output/public"
+    expect(existsSync(resolve(ctx.outDir, "public", "favicon.ico"))).toBe(true);
+  });
+});
+
+describe("nitro:preset:zeabur", async () => {
+  const ctx = await setupTest("zeabur");
+
+  it("output directory is .output/server and has index.mjs", async () => {
+    // Zeabur sets ".output/server/index.mjs" as the entry point
+    // https://github.com/zeabur/zbpack/blob/b8d76b5758fed32203cbdbf0456a9bc5c948dfc0/internal/nodejs/plan.go#L883
+    expect(existsSync(resolve(ctx.outDir, "server", "index.mjs"))).toBe(true);
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

A better implementation of #3122.

Fix ZEA-7651

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Zeabur now uses the general "node-server" to build the Dockerfile. Therefore, we simply extend "node-server" and "static".

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

Checks:

- [x] Complete the tests of `zeabur` and `zeabur-static`.
- [x] "nuxt build" selects the "zeabur" provider and generates the same output as "node".
      ```
      $ ZEABUR=1 pnpm build
      ●  Nitro preset: zeabur
      [success] [nitro] You can preview this build using `node .output/server/index.mjs`
      ```
- [x] "nuxt generate" selects the ~~"zeabur-static"~~ "zeabur" provider and generates the same output as "static" (?)
      ```
      $ ZEABUR=1 pnpm generate
      ●  Nitro preset: zeabur
	  [success] [nitro] Generated public .output/public
      [success] [nitro] You can preview this build using `node .output/server/index.mjs`
      ```
