### PR TITLE
refactor(types): avoid `DeepPartial`

### DIFF
--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -190,7 +190,7 @@ export async function writeTypes(nitro: Nitro) {
   if (nitro.options.typescript.generateTsConfig) {
     const tsConfigPath = resolve(
       generatedTypesDir,
-      nitro.options.typescript.tsconfigPath
+      nitro.options.typescript.tsconfigPath || "tsconfig.json"
     );
     const tsconfigDir = dirname(tsConfigPath);
     const tsConfig: TSConfig = defu(nitro.options.typescript.tsConfig, {

--- a/src/config/resolvers/database.ts
+++ b/src/config/resolvers/database.ts
@@ -2,6 +2,7 @@ import type { NitroOptions } from "nitro/types";
 
 export async function resolveDatabaseOptions(options: NitroOptions) {
   if (options.experimental.database && options.imports) {
+    options.imports.presets ??= [];
     options.imports.presets.push({
       from: "nitro/database",
       imports: ["useDatabase"],

--- a/src/config/resolvers/runtime-config.ts
+++ b/src/config/resolvers/runtime-config.ts
@@ -24,6 +24,7 @@ export function normalizeRuntimeConfig(config: NitroConfig) {
       },
     } as NitroRuntimeConfig
   );
+  runtimeConfig.nitro ??= {};
   runtimeConfig.nitro.routeRules = config.routeRules;
   checkSerializableRuntimeConfig(runtimeConfig);
   return runtimeConfig as NitroRuntimeConfig;

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -91,12 +91,10 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
       }
     });
 
-    if (nitro.options.devServer.watch.length > 0) {
+    const devWatch = nitro.options.devServer.watch;
+    if (devWatch && devWatch.length > 0) {
       const debouncedReload = debounce(() => this.reload());
-      this.#watcher = watch(
-        nitro.options.devServer.watch,
-        nitro.options.watchOptions
-      );
+      this.#watcher = watch(devWatch, nitro.options.watchOptions);
       this.#watcher.on("add", debouncedReload).on("change", debouncedReload);
     }
   }

--- a/src/prerender/prerender.ts
+++ b/src/prerender/prerender.ts
@@ -147,9 +147,11 @@ export async function prerender(nitro: Nitro) {
     }
 
     // Check for explicitly ignored routes
-    for (const pattern of nitro.options.prerender.ignore) {
-      if (matchesIgnorePattern(route, pattern)) {
-        return false;
+    if (nitro.options.prerender.ignore) {
+      for (const pattern of nitro.options.prerender.ignore) {
+        if (matchesIgnorePattern(route, pattern)) {
+          return false;
+        }
       }
     }
 
@@ -322,7 +324,7 @@ export async function prerender(nitro: Nitro) {
         dataBuff!.toString("utf8"),
         route,
         res,
-        nitro.options.prerender.crawlLinks
+        nitro.options.prerender.crawlLinks ?? false
       );
       for (const _link of extractedLinks) {
         if (canPrerender(_link)) {
@@ -345,7 +347,7 @@ export async function prerender(nitro: Nitro) {
   );
 
   await runParallel(routes, generateRoute, {
-    concurrency: nitro.options.prerender.concurrency,
+    concurrency: nitro.options.prerender.concurrency || 1,
     interval: nitro.options.prerender.interval,
   });
 

--- a/src/presets/vercel/types.ts
+++ b/src/presets/vercel/types.ts
@@ -110,7 +110,7 @@ export interface VercelServerlessFunctionConfig {
 }
 
 export interface VercelOptions {
-  config: VercelBuildConfigV3;
+  config?: VercelBuildConfigV3;
 
   /**
    * If you have enabled skew protection in the Vercel dashboard, it will

--- a/src/runtime/internal/routes/scalar.ts
+++ b/src/runtime/internal/routes/scalar.ts
@@ -5,13 +5,13 @@ import { useRuntimeConfig } from "../runtime-config.ts";
 // Served as /_scalar
 export default defineHandler((event) => {
   const runtimeConfig = useRuntimeConfig();
-  const title = runtimeConfig.nitro.openAPI?.meta?.title || "API Reference";
-  const description = runtimeConfig.nitro.openAPI?.meta?.description || "";
+  const title = runtimeConfig.nitro?.openAPI?.meta?.title || "API Reference";
+  const description = runtimeConfig.nitro?.openAPI?.meta?.description || "";
   const openAPIEndpoint =
-    runtimeConfig.nitro.openAPI?.route || "./_openapi.json";
+    runtimeConfig.nitro?.openAPI?.route || "./_openapi.json";
 
   // https://github.com/scalar/scalar
-  const _config = runtimeConfig.nitro.openAPI?.ui
+  const _config = runtimeConfig.nitro?.openAPI?.ui
     ?.scalar as ApiReferenceConfiguration;
   const scalarConfig: ApiReferenceConfiguration = {
     ..._config,

--- a/src/runtime/internal/routes/swagger.ts
+++ b/src/runtime/internal/routes/swagger.ts
@@ -6,10 +6,10 @@ import { useRuntimeConfig } from "../runtime-config.ts";
 
 export default defineHandler((event) => {
   const runtimeConfig = useRuntimeConfig();
-  const title = runtimeConfig.nitro.openAPI?.meta?.title || "API Reference";
-  const description = runtimeConfig.nitro.openAPI?.meta?.description || "";
+  const title = runtimeConfig.nitro?.openAPI?.meta?.title || "API Reference";
+  const description = runtimeConfig.nitro?.openAPI?.meta?.description || "";
   const openAPIEndpoint =
-    runtimeConfig.nitro.openAPI?.route || "./_openapi.json";
+    runtimeConfig.nitro?.openAPI?.route || "./_openapi.json";
 
   const CDN_BASE = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@^5";
   event.res.headers.set("Content-Type", "text/html");

--- a/src/types/_utils.ts
+++ b/src/types/_utils.ts
@@ -16,12 +16,6 @@ export type ExcludeFunctions<G extends Record<string, any>> = Pick<
   { [P in keyof G]: NonNullable<G[P]> extends Function ? never : P }[keyof G]
 >;
 
-export type DeepPartial<T> = T extends (...args: never) => any
-  ? T
-  : T extends Record<string, any>
-    ? { [P in keyof T]?: DeepPartial<T[P]> }
-    : T;
-
 export type KebabCase<
   T extends string,
   A extends string = "",

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -22,7 +22,6 @@ import type { Preset as UnenvPreset } from "unenv";
 import type { UnimportPluginOptions } from "unimport/unplugin";
 import type { BuiltinDriverName } from "unstorage";
 import type { UnwasmPluginOptions } from "unwasm/plugin";
-import type { DeepPartial } from "./_utils.ts";
 import type {
   EventHandlerFormat,
   NitroDevEventHandler,
@@ -95,12 +94,12 @@ export interface NitroOptions extends PresetOptions {
      *
      * By default this feature will be enabled if there is at least one nitro plugin.
      */
-    runtimeHooks: boolean;
+    runtimeHooks?: boolean;
 
     /**
      * Enable WebSocket support
      */
-    websocket: boolean;
+    websocket?: boolean;
   };
 
   /**
@@ -157,15 +156,15 @@ export interface NitroOptions extends PresetOptions {
     tsconfigPaths?: boolean;
   };
   future: {
-    nativeSWR: boolean;
+    nativeSWR?: boolean;
   };
   serverAssets: ServerAssetDir[];
   publicAssets: PublicAssetDir[];
 
-  imports: UnimportPluginOptions | false;
+  imports: Partial<UnimportPluginOptions> | false;
   modules?: NitroModuleInput[];
   plugins: string[];
-  tasks: { [name: string]: { handler: string; description: string } };
+  tasks: { [name: string]: { handler?: string; description?: string } };
   scheduledTasks: { [cron: string]: string | string[] };
   virtual: Record<string, string | (() => string | Promise<string>)>;
   compressPublicAssets: boolean | CompressOptions;
@@ -174,17 +173,17 @@ export interface NitroOptions extends PresetOptions {
   // Dev
   dev: boolean;
   devServer: {
-    port: number;
-    hostname: string;
-    watch: string[];
+    port?: number;
+    hostname?: string;
+    watch?: string[];
   };
   watchOptions: ChokidarOptions;
   devProxy: Record<string, string | ProxyServerOptions>;
 
   // Logging
   logging: {
-    compressedSizes: boolean;
-    buildSuccess: boolean;
+    compressedSizes?: boolean;
+    buildSuccess?: boolean;
   };
 
   // Routing
@@ -207,26 +206,26 @@ export interface NitroOptions extends PresetOptions {
     /**
      * Prerender HTML routes within subfolders (`/test` would produce `/test/index.html`)
      */
-    autoSubfolderIndex: boolean;
-    concurrency: number;
-    interval: number;
-    crawlLinks: boolean;
-    failOnError: boolean;
-    ignore: Array<
+    autoSubfolderIndex?: boolean;
+    concurrency?: number;
+    interval?: number;
+    crawlLinks?: boolean;
+    failOnError?: boolean;
+    ignore?: Array<
       string | RegExp | ((path: string) => undefined | null | boolean)
     >;
-    ignoreUnprefixedPublicAssets: boolean;
-    routes: string[];
+    ignoreUnprefixedPublicAssets?: boolean;
+    routes?: string[];
     /**
      * Amount of retries. Pass Infinity to retry indefinitely.
      * @default 3
      */
-    retry: number;
+    retry?: number;
     /**
      * Delay between each retry in ms.
      * @default 500
      */
-    retryDelay: number;
+    retryDelay?: number;
   };
 
   // Rollup
@@ -266,12 +265,12 @@ export interface NitroOptions extends PresetOptions {
      *
      * Default is `tsconfig.json` (`node_modules/.nitro/types/tsconfig.json`)
      */
-    tsconfigPath: string;
+    tsconfigPath?: string;
   };
   hooks: NestedHooks<NitroHooks>;
   commands: {
-    preview: string;
-    deploy: string;
+    preview?: string;
+    deploy?: string;
   };
 
   // Framework
@@ -289,7 +288,7 @@ export interface NitroOptions extends PresetOptions {
  */
 export interface NitroConfig
   extends
-    DeepPartial<
+    Partial<
       Omit<
         NitroOptions,
         | "routeRules"
@@ -302,6 +301,7 @@ export interface NitroConfig
         | "_c12"
         | "serverEntry"
         | "renderer"
+        | "output"
       >
     >,
     C12InputConfig<NitroConfig> {
@@ -314,6 +314,7 @@ export interface NitroConfig
   serverDir?: boolean | "./" | "./server" | (string & {});
   serverEntry?: string | NitroOptions["serverEntry"];
   renderer?: false | NitroOptions["renderer"];
+  output?: Partial<NitroOptions["output"]>;
 }
 
 // ------------------------------------------------------------
@@ -388,8 +389,7 @@ export interface NitroRuntimeConfigApp {
 }
 
 export interface NitroRuntimeConfig {
-  app: NitroRuntimeConfigApp;
-  nitro: {
+  nitro?: {
     envPrefix?: string;
     envExpansion?: boolean;
     routeRules?: {


### PR DESCRIPTION
Nitro input config was marked as DeepPartial<NitroOptions> while it makes impl little eaiser makes type complexity higher (now failing for rollup config in #3887) but also it introduces implicit types.