### PR TITLE
chore: update url

### DIFF
--- a/lib/vite.types.d.mts
+++ b/lib/vite.types.d.mts
@@ -1,4 +1,4 @@
-// Based on https://github.com/hi-ogawa/vite-plugins/blob/main/packages/fullstack/types/query.d.ts
+// Based on https://github.com/hi-ogawa/vite-plugin-fullstack/blob/main/types/query.d.ts
 
 type ImportAssetsResult = ImportAssetsResultRaw & {
   merge(...args: ImportAssetsResultRaw[]): ImportAssetsResult;


### PR DESCRIPTION
I think the code is now moved from (https://github.com/hi-ogawa/vite-plugins/tree/main/packages/fullstack to https://github.com/hi-ogawa/vite-plugin-fullstack/blob/main/types/query.d.ts )