### PR TITLE
perf: process static assets in parallel

### DIFF
--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -32,7 +32,7 @@ export default function publicAssets(nitro: Nitro) {
           dot: true,
         });
 
-        await runParallel(
+        const { errors } = await runParallel(
           new Set(files),
           async (id) => {
             let mimeType =
@@ -75,6 +75,13 @@ export default function publicAssets(nitro: Nitro) {
           },
           { concurrency: 25 }
         );
+
+        if (errors.length > 0) {
+          throw new Error(
+            `Failed to process public assets:\n${errors.join("\n")}`,
+            { cause: errors }
+          );
+        }
 
         return `export default ${JSON.stringify(assets, null, 2)};`;
       },

--- a/src/utils/parallel.ts
+++ b/src/utils/parallel.ts
@@ -2,7 +2,8 @@ export async function runParallel<T>(
   inputs: Set<T>,
   cb: (input: T) => unknown | Promise<unknown>,
   opts: { concurrency: number; interval?: number }
-) {
+): Promise<{ errors: unknown[] }> {
+  const errors: unknown[] = [];
   const tasks = new Set<Promise<unknown>>();
 
   function queueNext(): undefined | Promise<unknown> {
@@ -37,4 +38,6 @@ export async function runParallel<T>(
   }
 
   await refillQueue();
+
+  return { errors };
 }


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue
#3909 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
Process static assets in parallel
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
