### PR TITLE
fix(dev): respect `opts.json` when `false` for error handler

### DIFF
--- a/src/runtime/internal/error/dev.ts
+++ b/src/runtime/internal/error/dev.ts
@@ -67,7 +67,7 @@ export async function defaultHandler(
 
   // Use HTML response only when user-agent expects it (browsers)
   const useJSON =
-    opts?.json || !event.req.headers.get("accept")?.includes("text/html");
+    opts?.json ?? !event.req.headers.get("accept")?.includes("text/html");
 
   // Prepare headers
   const headers: HeadersInit = {


### PR DESCRIPTION

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/33748#issuecomment-3693982472

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

previously it was impossible to _force_ an html response (`json: false`) if there were certain headers set.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
