### PR TITLE
fix(vercel): add preview command

### DIFF
--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -26,7 +26,8 @@ const vercel = defineNitroPreset(
       publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
-      preview: "",
+      preview:
+        "npx srvx --static ../../static ./functions/__server.func/index.mjs",
       deploy: "npx vercel deploy --prebuilt",
     },
     hooks: {


### PR DESCRIPTION
This PR adds a `preview` command for vercel preset.

(hot) fixes #3905 as tanstack start now having hard requirment of vite preview server for prerendering. 

