### PR TITLE
fix(cloudflare-durable): expose env bindings in durable handler

### DIFF
--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -71,6 +71,7 @@ export class $DurableObject extends DurableObject {
   }
 
   override fetch(request: Request) {
+    (globalThis as any).__env__ = this.env;
     if (
       import.meta._websocket &&
       request.headers.get("upgrade") === "websocket"
@@ -101,6 +102,7 @@ export class $DurableObject extends DurableObject {
     client: WebSocket,
     message: ArrayBuffer | string
   ) {
+    (globalThis as any).__env__ = this.env;
     if (import.meta._websocket) {
       return ws!.handleDurableMessage(this, client, message);
     }
@@ -112,6 +114,7 @@ export class $DurableObject extends DurableObject {
     reason: string,
     wasClean: boolean
   ) {
+    (globalThis as any).__env__ = this.env;
     if (import.meta._websocket) {
       return ws!.handleDurableClose(this, client, code, reason, wasClean);
     }


### PR DESCRIPTION
## Summary

This PR fixes a bug where Cloudflare bindings (D1, KV, R2, etc.) are not accessible in WebSocket handlers when using the `cloudflare_durable` preset.

## Problem

When using WebSocket with `cloudflare_durable` preset, any code that relies on lazy binding access via `globalThis.__env__` fails with errors like:

```
DB binding not found
```

This affects libraries like NuxtHub that use this pattern for database access:

```typescript
// NuxtHub's generated db.mjs
const binding = process.env.DB || globalThis.__env__?.DB || globalThis.DB
if (!binding) throw new Error('DB binding not found')
```

## Root Cause

In `cloudflare-durable.ts`, the `$DurableObject` class methods `fetch()`, `webSocketMessage()`, and `webSocketClose()` were not setting `globalThis.__env__` before invoking handlers.

This is inconsistent with how other Cloudflare handlers work in `_module-handler.ts`, where `(globalThis as any).__env__ = env` is called at the start of:
- `fetchHandler()` (line 122)
- `scheduled()` (line 37)
- `email()` (line 61)
- `queue()` (line 73)
- `tail()` (line 85)
- `trace()` (line 96)

## Solution

Add `(globalThis as any).__env__ = this.env` at the start of:
- `$DurableObject.fetch()` - for WebSocket upgrade requests
- `$DurableObject.webSocketMessage()` - for incoming WebSocket messages
- `$DurableObject.webSocketClose()` - for WebSocket close events

## Reproduction

1. Create a Nuxt app with NuxtHub and `cloudflare_durable` preset
2. Create a WebSocket handler in `server/routes/ws/chat.ts` that uses `db` (auto-imported from NuxtHub)
3. Deploy to Cloudflare Workers
4. Connect to the WebSocket endpoint
5. **Expected**: WebSocket works with database access
6. **Actual**: Error `DB binding not found` on any database operation

## Testing

Tested with:
- NuxtHub v0.10.4
- Nitro v2.12.9 (with this patch applied via pnpm)
- Cloudflare Workers with D1 database
- WebSocket chat functionality using database queries

After applying this fix, all WebSocket handlers can successfully access D1, KV, R2, and other Cloudflare bindings.