### PR TITLE
fix(cloudflare): filter inherited values from Cloudflare preset _headers file

### DIFF
--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -96,6 +96,13 @@ export interface CloudflareOptions {
 
 type DurableObjectState = ConstructorParameters<typeof DurableObject>[0];
 
+export type CloudflareHeaderTreeNode = {
+  path: string;
+  wildcardHeaders: Record<string, string> | undefined;
+  headers: Record<string, string> | undefined;
+  children: Record<string, CloudflareHeaderTreeNode>;
+};
+
 declare module "nitropack/types" {
   export interface NitroRuntimeHooks {
     // https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -6,7 +6,7 @@ import type {
   CloudflareHeaderTreeNode,
 } from "./types";
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, rename, rm } from "node:fs/promises";
 import { relative, dirname, extname } from "node:path";
 import { writeFile } from "nitropack/kit";
 import { parseTOML, parseJSONC } from "confbox";
@@ -223,10 +223,13 @@ export async function writeCFHeaders(
   nitro: Nitro,
   outdir: "public" | "output"
 ) {
-  const headersPath = join(
-    outdir === "public"
-      ? nitro.options.output.publicDir
-      : nitro.options.output.dir,
+  const publicRootPath = join(
+    nitro.options.output.dir,
+    outdir === "public" ? "public" : "",
+    "_headers"
+  );
+  const publicBasePath = join(
+    (outdir === "public" && nitro.options.baseURL !== "") ? nitro.options.output.publicDir : publicRootPath,
     "_headers"
   );
 
@@ -235,13 +238,19 @@ export async function writeCFHeaders(
     buildHeaderTree(nitro.options.routeRules)
   );
 
-  if (existsSync(headersPath)) {
-    const currentHeaders = await readFile(headersPath, "utf8");
+  if (existsSync(publicBasePath)) {
+    const currentHeaders = await readFile(publicBasePath, "utf8");
     if (/^\/\* /m.test(currentHeaders)) {
+      if (publicBasePath != publicRootPath) {
+        await rename(publicBasePath, publicRootPath);
+      }
       nitro.logger.info(
         "Not adding Nitro fallback to `_headers` (as an existing fallback was found)."
       );
       return;
+    }
+    if (publicBasePath != publicRootPath) {
+      await rm(publicBasePath);
     }
     nitro.logger.info(
       "Adding Nitro fallback to `_headers` to handle all unmatched routes."
@@ -249,7 +258,7 @@ export async function writeCFHeaders(
     contents.unshift(currentHeaders);
   }
 
-  await writeFile(headersPath, contents.join("\n"), true);
+  await writeFile(publicRootPath, contents.join("\n"), true);
 }
 
 export async function writeCFPagesRedirects(nitro: Nitro) {

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -1,6 +1,10 @@
-import type { Nitro } from "nitropack/types";
+import type { Nitro, NitroRouteRules } from "nitropack/types";
 import type { Plugin } from "rollup";
-import type { WranglerConfig, CloudflarePagesRoutes } from "./types";
+import type {
+  WranglerConfig,
+  CloudflarePagesRoutes,
+  CloudflareHeaderTreeNode,
+} from "./types";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { relative, dirname, extname } from "node:path";
@@ -105,6 +109,116 @@ function comparePaths(a: string, b: string) {
   return a.split("/").length - b.split("/").length || a.localeCompare(b);
 }
 
+function buildHeaderTree(rules: {
+  [p: string]: NitroRouteRules;
+}): CloudflareHeaderTreeNode {
+  const tree: CloudflareHeaderTreeNode = {
+    path: "/",
+    wildcardHeaders: undefined,
+    headers: undefined,
+    children: {},
+  };
+
+  for (const [path, routeRules] of Object.entries(rules).filter(
+    ([_, routeRules]) => routeRules.headers
+  )) {
+    const pathParts = path == "/" ? [] : path.slice(1).split("/");
+    let currentNode = tree;
+    for (const part of pathParts) {
+      if (part === "**") break;
+
+      currentNode.children[part] = currentNode.children[part] || {
+        path: (currentNode.path == "/" ? "" : currentNode.path) + "/" + part,
+        wildcardHeaders: undefined,
+        headers: undefined,
+        children: {},
+      };
+      currentNode = currentNode.children[part];
+    }
+    if (pathParts.at(-1) === "**") {
+      currentNode.wildcardHeaders = routeRules.headers;
+    } else {
+      currentNode.headers = routeRules.headers;
+    }
+  }
+
+  return tree;
+}
+function processHeaderValues(
+  parentHeaders: Record<string, string>,
+  headers: Record<string, string>
+) {
+  return Object.entries(headers)
+    .filter(
+      ([header, value]) =>
+        !parentHeaders[header.toLowerCase()] ||
+        parentHeaders[header.toLowerCase()] !== value
+    )
+    .map(([header, value]) => {
+      const values = [`  ${header}: ${value}`];
+      if (parentHeaders[header.toLowerCase()]) {
+        values.unshift(`  ! ${header}`);
+      }
+      return values.join("\n");
+    });
+}
+function processHeaderTree(
+  baseURL: string,
+  tree: CloudflareHeaderTreeNode,
+  parentHeaders?: Record<string, Record<string, string>>
+) {
+  parentHeaders = parentHeaders || { "/": {} };
+  let contents: string[] = [];
+
+  let closestWildcard = tree.path;
+  do {
+    closestWildcard = closestWildcard.split("/").slice(0, -1).join("/") || "/";
+  } while (closestWildcard !== "/" && !parentHeaders[closestWildcard]);
+
+  if (tree.wildcardHeaders) {
+    const path = joinURL(baseURL, (tree.path == "/" ? "" : tree.path) + "/*");
+    const headers = processHeaderValues(
+      parentHeaders[closestWildcard],
+      tree.wildcardHeaders
+    );
+
+    if (headers.length > 0) {
+      contents.push([path, ...headers].join("\n"));
+
+      parentHeaders[tree.path] = {
+        ...parentHeaders[closestWildcard],
+        ...Object.fromEntries(
+          Object.entries(tree.wildcardHeaders).map(([header, value]) => [
+            header.toLowerCase(),
+            value,
+          ])
+        ),
+      };
+    }
+  }
+
+  if (tree.headers) {
+    const headers = processHeaderValues(
+      parentHeaders[closestWildcard],
+      tree.headers
+    );
+    if (headers.length > 0) {
+      contents.push([joinURL(baseURL, tree.path), ...headers].join("\n"));
+    }
+  }
+
+  for (const [_, child] of Object.entries(tree.children).sort((a, b) =>
+    a[0].localeCompare(b[0])
+  )) {
+    contents = [
+      ...contents,
+      ...processHeaderTree(baseURL, child, parentHeaders),
+    ];
+  }
+
+  return contents;
+}
+
 export async function writeCFHeaders(
   nitro: Nitro,
   outdir: "public" | "output"
@@ -115,24 +229,11 @@ export async function writeCFHeaders(
       : nitro.options.output.dir,
     "_headers"
   );
-  const contents = [];
 
-  const rules = Object.entries(nitro.options.routeRules).sort(
-    (a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length
+  const contents = processHeaderTree(
+    nitro.options.baseURL,
+    buildHeaderTree(nitro.options.routeRules)
   );
-
-  for (const [path, routeRules] of rules.filter(
-    ([_, routeRules]) => routeRules.headers
-  )) {
-    const headers = [
-      joinURL(nitro.options.baseURL, path.replace("/**", "/*")),
-      ...Object.entries({ ...routeRules.headers }).map(
-        ([header, value]) => `  ${header}: ${value}`
-      ),
-    ].join("\n");
-
-    contents.push(headers);
-  }
 
   if (existsSync(headersPath)) {
     const currentHeaders = await readFile(headersPath, "utf8");

--- a/test/presets/cloudflare-module.test.ts
+++ b/test/presets/cloudflare-module.test.ts
@@ -1,12 +1,69 @@
 import { Miniflare } from "miniflare";
 import { resolve } from "pathe";
 import { Response as _Response } from "undici";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { setupTest, testNitro } from "../tests";
+import { promises as fsp } from "node:fs";
 
 describe("nitro:preset:cloudflare-module", async () => {
-  const ctx = await setupTest("cloudflare-module");
+  const ctx = await setupTest("cloudflare-module", {
+    config: {
+      routeRules: {
+        "/": {
+          headers: {
+            "x-test": "test",
+            "x-cf-test-root": "test",
+          },
+        },
+        "/cf/_header/**": {
+          headers: {
+            "x-cf-test": "0",
+          },
+        },
+        "/cf/_header/0": {
+          headers: {
+            "x-cf-test": "0",
+          },
+        },
+        "/cf/_header/a": {
+          headers: {
+            "x-cf-test": "a",
+          },
+        },
+        "/cf/_header/B": {
+          headers: {
+            "X-CF-Test": "0",
+          },
+        },
+        "/cf/_header/1/**": {
+          headers: {
+            "x-cf-test": "1",
+          },
+        },
+        "/cf/_header/1/2/**": {
+          headers: {
+            "x-cf-test": "2",
+          },
+        },
+        "/cf/_header/1/2/1": {
+          headers: {
+            "x-cf-test": "1",
+          },
+        },
+        "/cf/_header/1/2/2": {
+          headers: {
+            "x-cf-test": "2",
+          },
+        },
+        "/cf/_header/2/2/0": {
+          headers: {
+            "x-cf-test": "0",
+          },
+        },
+      },
+    },
+  });
 
   testNitro(ctx, () => {
     const mf = new Miniflare({
@@ -39,5 +96,45 @@ describe("nitro:preset:cloudflare-module", async () => {
       });
       return res as unknown as Response;
     };
+  });
+
+  it("should generate a _headers file", async () => {
+    const config = await fsp.readFile(
+      resolve(
+        ctx.nitro?.options.output.publicDir || ctx.outDir + "/public",
+        "_headers"
+      ),
+      "utf8"
+    );
+    expect(config).toMatchInlineSnapshot(`
+      "/*
+        x-test: test
+      /
+        x-cf-test-root: test
+      /build/*
+        cache-control: public, max-age=3600, immutable
+        x-build-header: works
+      /cf/_header/*
+        x-cf-test: 0
+      /cf/_header/1/*
+        ! x-cf-test
+        x-cf-test: 1
+      /cf/_header/1/2/*
+        ! x-cf-test
+        x-cf-test: 2
+      /cf/_header/1/2/1
+        ! x-cf-test
+        x-cf-test: 1
+      /cf/_header/a
+        ! x-cf-test
+        x-cf-test: a
+      /rules/cors
+        access-control-allow-origin: *
+        access-control-allow-methods: GET
+        access-control-allow-headers: *
+        access-control-max-age: 0
+      /rules/headers
+        cache-control: s-maxage=60"
+    `);
   });
 });

--- a/test/presets/cloudflare-module.test.ts
+++ b/test/presets/cloudflare-module.test.ts
@@ -1,69 +1,13 @@
 import { Miniflare } from "miniflare";
-import { resolve } from "pathe";
+import { join, resolve } from "pathe";
 import { Response as _Response } from "undici";
 import { describe, expect, it } from "vitest";
 
 import { setupTest, testNitro } from "../tests";
-import { promises as fsp } from "node:fs";
+import { existsSync, promises as fsp } from "node:fs";
 
 describe("nitro:preset:cloudflare-module", async () => {
-  const ctx = await setupTest("cloudflare-module", {
-    config: {
-      routeRules: {
-        "/": {
-          headers: {
-            "x-test": "test",
-            "x-cf-test-root": "test",
-          },
-        },
-        "/cf/_header/**": {
-          headers: {
-            "x-cf-test": "0",
-          },
-        },
-        "/cf/_header/0": {
-          headers: {
-            "x-cf-test": "0",
-          },
-        },
-        "/cf/_header/a": {
-          headers: {
-            "x-cf-test": "a",
-          },
-        },
-        "/cf/_header/B": {
-          headers: {
-            "X-CF-Test": "0",
-          },
-        },
-        "/cf/_header/1/**": {
-          headers: {
-            "x-cf-test": "1",
-          },
-        },
-        "/cf/_header/1/2/**": {
-          headers: {
-            "x-cf-test": "2",
-          },
-        },
-        "/cf/_header/1/2/1": {
-          headers: {
-            "x-cf-test": "1",
-          },
-        },
-        "/cf/_header/1/2/2": {
-          headers: {
-            "x-cf-test": "2",
-          },
-        },
-        "/cf/_header/2/2/0": {
-          headers: {
-            "x-cf-test": "0",
-          },
-        },
-      },
-    },
-  });
+  const ctx = await setupTest("cloudflare-module");
 
   testNitro(ctx, () => {
     const mf = new Miniflare({
@@ -97,13 +41,70 @@ describe("nitro:preset:cloudflare-module", async () => {
       return res as unknown as Response;
     };
   });
+});
 
+describe("nitro:preset:cloudflare-module:_headers", () => {
   it("should generate a _headers file", async () => {
+    const ctx = await setupTest("cloudflare-module", {
+      config: {
+        routeRules: {
+          "/": {
+            headers: {
+              "x-test": "test",
+              "x-cf-test-root": "test",
+            },
+          },
+          "/cf/_header/**": {
+            headers: {
+              "x-cf-test": "0",
+            },
+          },
+          "/cf/_header/0": {
+            headers: {
+              "x-cf-test": "0",
+            },
+          },
+          "/cf/_header/a": {
+            headers: {
+              "x-cf-test": "a",
+            },
+          },
+          "/cf/_header/B": {
+            headers: {
+              "X-CF-Test": "0",
+            },
+          },
+          "/cf/_header/1/**": {
+            headers: {
+              "x-cf-test": "1",
+            },
+          },
+          "/cf/_header/1/2/**": {
+            headers: {
+              "x-cf-test": "2",
+            },
+          },
+          "/cf/_header/1/2/1": {
+            headers: {
+              "x-cf-test": "1",
+            },
+          },
+          "/cf/_header/1/2/2": {
+            headers: {
+              "x-cf-test": "2",
+            },
+          },
+          "/cf/_header/2/2/0": {
+            headers: {
+              "x-cf-test": "0",
+            },
+          },
+        },
+      },
+    });
+
     const config = await fsp.readFile(
-      resolve(
-        ctx.nitro?.options.output.publicDir || ctx.outDir + "/public",
-        "_headers"
-      ),
+      resolve(ctx.outDir + "/public", "_headers"),
       "utf8"
     );
     expect(config).toMatchInlineSnapshot(`
@@ -136,5 +137,36 @@ describe("nitro:preset:cloudflare-module", async () => {
       /rules/headers
         cache-control: s-maxage=60"
     `);
+  });
+});
+
+describe("nitro:preset:cloudflare-module:_headers:baseURL", () => {
+  it("should place _headers file in the correct location with baseURL", async () => {
+    const ctx = await setupTest("cloudflare-module", {
+      config: {
+        baseURL: "/app/",
+      },
+    });
+
+    const config = await fsp.readFile(
+      resolve(ctx.outDir, "public/_headers"),
+      "utf8"
+    );
+    expect(config).toMatchInlineSnapshot(`
+      "/app/*
+        x-test: test
+      /app/build/*
+        cache-control: public, max-age=3600, immutable
+        x-build-header: works
+      /app/rules/cors
+        access-control-allow-origin: *
+        access-control-allow-methods: GET
+        access-control-allow-headers: *
+        access-control-max-age: 0
+      /app/rules/headers
+        cache-control: s-maxage=60"
+    `);
+
+    expect(existsSync(join(ctx.outDir, "public/app/_headers"))).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#2909 
Baroshem/nuxt-security#575

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
1. Cloudflare's `_headers` file merges all rules that apply to a path, resulting in duplicated or conflicting values.  This may prevent a browser from parsing the header value, or to interpret the value incorrectly.
https://developers.cloudflare.com/workers/static-assets/headers/#attach-a-header

2. Cloudflare requires that the `_headers` file always be placed at the top of `public/` within the output directory, but when a `baseURL` is defined it gets placed in `public/{baseURL}/` instead.

#### Examples
**Nuxt** provides some nested wildcard path rules. Responses at increasing path depth receive successively appended values.
```
/_nuxt/builds/meta/*
  cache-control: public, max-age=31536000, immutable
/_nuxt/builds/*
  cache-control: public, max-age=1, immutable
/_nuxt/*
  cache-control: public, max-age=31536000, immutable
```
A route matching `/_nuxt/builds/meta/*` will receive all three values appended:
```
cache-control: public, max-age=31536000, immutable, public, max-age=1, immutable, public, max-age=31536000, immutable
```

**nuxt-security** defines some headers to apply to all paths, and also defines those values for each prerendered page.
```
/
  referrer-policy: no-referrer
  strict-transport-security: max-age=31536000; includeSubDomains; preload;
  content-security-policy: [...]
/*
  Referrer-Policy: no-referrer
  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload;
```

Will result in the `/` path receiving the header values:
```
  referrer-policy: no-referrer, no-referrer
  strict-transport-security: max-age=31536000; includeSubDomains; preload;, max-age=31536000; includeSubDomains; preload;
  content-security-policy: [...]
```

#### The change

This PR first builds all routeRules that include headers into a tree before processing the values to be output.  This allows checking path rules against matching wildcard rules in order to either:
- Omit the header value for a path if it matches the closest matching wildcard rule, or
- First detach the more general rule before defining the value for the path.

With this PR the above examples output:
```
/_nuxt/*
  cache-control: public, max-age=31536000, immutable
/_nuxt/builds/*
  ! cache-control
  cache-control: public, max-age=1, immutable
/_nuxt/builds/meta/*
  ! cache-control
  cache-control: public, max-age=31536000, immutable
```

```
/*
  Referrer-Policy: no-referrer
  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload;
/
  content-security-policy: [...]
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
