### PR TITLE
fix(prerender): skip writing redirect responses to disk

### DIFF
--- a/src/core/prerender/prerender.ts
+++ b/src/core/prerender/prerender.ts
@@ -245,10 +245,16 @@ export async function prerender(nitro: Nitro) {
 
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
     const redirectCodes = [301, 302, 303, 304, 307, 308];
+    const isRedirect = redirectCodes.includes(res.status);
     if (![200, ...redirectCodes].includes(res.status)) {
       _route.error = new Error(`[${res.status}] ${res.statusText}`) as any;
       _route.error!.statusCode = res.status;
       _route.error!.statusMessage = res.statusText;
+    }
+
+    // Skip writing redirect responses to disk - they would conflict with actual HTML files
+    if (isRedirect) {
+      _route.skip = true;
     }
 
     // Measure actual time taken for generating route


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/nuxt#33924

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While investigating nuxt/nuxt#33924 together with @danielroe, we found that redirect responses were being written to disk as extensionless files during prerendering.

**The problem:** When a route returns a redirect (e.g., due to `baseURL` handling), Nitro writes a file like `/admin-dashboard` with just `"Redirecting..."` as content. Later, when the actual HTML page is generated with `autoSubfolderIndex`, Nitro tries to create `/admin-dashboard/index.html` - but `mkdir("/admin-dashboard")` fails because a file with that name already exists.

**The fix:** Simply skip writing redirect responses to disk. They don't serve any purpose as static files anyway - redirects on static hosting are handled through server configuration (`_redirects`, `.htaccess`, etc.), not HTML files.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.