### PR TITLE
refactor: include name of hoisted libs in chunk name

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -108,7 +108,7 @@ export default defineBuildConfig({
                     )?.groups?.package
                 )
                 .filter(Boolean)
-                .map((name) => name!.split("/").pop()!)
+                .map((name) => name!.split(/[/\\]/).pop()!)
                 .filter(Boolean)
             ),
           ].sort((a, b) => a.length - b.length);

--- a/src/build/chunks.ts
+++ b/src/build/chunks.ts
@@ -33,7 +33,7 @@ export function getChunkName(
               )?.groups?.package
           )
           .filter(Boolean)
-          .map((name) => name!.split("/").pop()!)
+          .map((name) => name!.split(/[/\\]/).pop()!)
           .filter(Boolean)
       ),
     ].sort((a, b) => a.length - b.length);


### PR DESCRIPTION
rolldown sometimes prefers to create a group of multiple libraries in a single chunk (hoisting)

This PR makes the chunk name clearer by adding all names concatenated by `+`. 

To avoid potential fs limits, after hitting 30 chars, we switch to hash

<img width="968" height="341" alt="image" src="https://github.com/user-attachments/assets/94e7484c-4d78-42f2-8eaa-81a1ad68c3be" />
