### PR TITLE
fix: add `typeFrom` support for autoimports exports generation

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -50,10 +50,9 @@ export async function writeTypes(nitro: Nitro) {
 
     const allImports = await nitro.unimport.getImports();
 
-    autoImportExports = toExports(allImports, undefined, false, { declaration: true }).replace(
-      /#internal\/nitro/g,
-      relative(typesDir, runtimeDir)
-    );
+    autoImportExports = toExports(allImports, undefined, false, {
+      declaration: true,
+    }).replace(/#internal\/nitro/g, relative(typesDir, runtimeDir));
 
     const resolvedImportPathMap = new Map<string, string>();
 

--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -50,7 +50,7 @@ export async function writeTypes(nitro: Nitro) {
 
     const allImports = await nitro.unimport.getImports();
 
-    autoImportExports = toExports(allImports).replace(
+    autoImportExports = toExports(allImports, undefined, false, { declaration: true }).replace(
       /#internal\/nitro/g,
       relative(typesDir, runtimeDir)
     );


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#3669 part 2

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

PR #3670 added imports' `typeForm` support for global declarations; this PR adds `typeFrom` support for autoimports' `export` statements, so that explicit imports from `#imports` may also find type declarations.

Inside the `writeTypes` function, `toExports` call is updated to use imports' `typeFrom` property when available (see https://github.com/unjs/unimport/pull/477).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
