### PR TITLE
presets(aws-lambda): avoid modifying response headers in streaming mode

### DIFF
--- a/src/presets/aws-lambda/runtime/_utils.ts
+++ b/src/presets/aws-lambda/runtime/_utils.ts
@@ -23,9 +23,7 @@ export function awsRequest(
   return new Request(url, { method, headers, body });
 }
 
-function awsEventMethod(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2
-): string {
+function awsEventMethod(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string {
   return (
     (event as APIGatewayProxyEvent).httpMethod ||
     (event as APIGatewayProxyEventV2).requestContext?.http?.method ||
@@ -33,31 +31,20 @@ function awsEventMethod(
   );
 }
 
-function awsEventURL(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2
-): URL {
+function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): URL {
   const hostname =
-    event.headers.host ||
-    event.headers.Host ||
-    event.requestContext?.domainName ||
-    ".";
+    event.headers.host || event.headers.Host || event.requestContext?.domainName || ".";
 
-  const path =
-    (event as APIGatewayProxyEvent).path ||
-    (event as APIGatewayProxyEventV2).rawPath;
+  const path = (event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath;
 
   const query = awsEventQuery(event);
 
   const protocol =
-    (event.headers["X-Forwarded-Proto"] ||
-      event.headers["x-forwarded-proto"]) === "http"
+    (event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"]) === "http"
       ? "http"
       : "https";
 
-  return new URL(
-    `${path}${query ? `?${query}` : ""}`,
-    `${protocol}://${hostname}`
-  );
+  return new URL(`${path}${query ? `?${query}` : ""}`, `${protocol}://${hostname}`);
 }
 
 function awsEventQuery(event: APIGatewayProxyEvent | APIGatewayProxyEventV2) {
@@ -71,9 +58,7 @@ function awsEventQuery(event: APIGatewayProxyEvent | APIGatewayProxyEventV2) {
   return stringifyQuery(queryObj);
 }
 
-function awsEventHeaders(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2
-): Headers {
+function awsEventHeaders(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): Headers {
   const headers = new Headers();
   for (const [key, value] of Object.entries(event.headers)) {
     if (value) {
@@ -88,9 +73,7 @@ function awsEventHeaders(
   return headers;
 }
 
-function awsEventBody(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2
-): BodyInit | undefined {
+function awsEventBody(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): BodyInit | undefined {
   if (!event.body) {
     return undefined;
   }

--- a/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
+++ b/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
@@ -32,10 +32,7 @@ export const handler = awslambda.streamifyResponse(
         },
       });
 
-    const writer = awslambda.HttpResponseStream.from(
-      responseStream,
-      httpResponseMetadata
-    );
+    const writer = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata);
 
     const reader = body.getReader();
     await streamToNodeStream(reader, responseStream);


### PR DESCRIPTION
(In an investigation with @sommeeeer and https://github.com/h3js/h3/pull/1287)

AWS lambda (streaming) preset tries to modify web response headers which might be frozen.

This PR simply updated implementation to add missing `transfer-encoding` only on the final lambda headers object.