### PR TITLE
docs(cloudflare): remove invalid docs and add note about wrangler env

### DIFF
--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -280,7 +280,7 @@ defineHandler(async (event) => {
 
 ### Access to the bindings in local dev
 
-To access bindings in dev mode, we first define them. You can do this in a `wrangler.toml`/`wrangler.json` file, or directly in your Nitro config under `cloudflare.wrangler` (accepts the same type as `wrangler.json`).
+To access bindings in dev mode, we first define them. You can do this in a `wrangler.jsonc`/`wrangler.json`/`wrangler.toml` file
 
 For example, to define a variable and a KV namespace in `wrangler.toml`:
 
@@ -311,6 +311,18 @@ id = "xxx"
 
 ::
 
+Next we install the required `wrangler` package (if not already installed):
+
+:pm-install{name="wrangler -D"}
+
+From this moment, when running
+
+:pm-run{script="dev"}
+
+you will be able to access the `MY_VARIABLE` and `MY_KV` from the request event just as illustrated above.
+
+#### Wrangler environments 
+
 If you have multiple Wrangler environments, you can specify which Wrangler environment to use during Cloudflare dev emulation:
 
 ```ts [nitro.config.ts]
@@ -325,13 +337,3 @@ export default defineNitroConfig({
   }
 })
 ```
-
-Next we install the required `wrangler` package (if not already installed):
-
-:pm-install{name="wrangler -D"}
-
-From this moment, when running
-
-:pm-run{script="dev"}
-
-you will be able to access the `MY_VARIABLE` and `MY_KV` from the request event just as illustrated above.


### PR DESCRIPTION


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

1. Cloudflare dev emulation via `getPlatformProxy()` only accepts a file path (wrangler.<toml/json/jsonc>), and not via `nitro.cloudflare.wrangler`.
2. 
https://github.com/nitrojs/nitro/blob/9c6abf1790d9743504ea244b5856e171cc4c3ee1/src/presets/cloudflare/runtime/plugin.dev.ts#L55-L83


3. Adds a note about the environment property in dev to use a different Wrangler environment.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
