### PR TITLE
chore: add ai config in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ coverage
 .AppleDouble
 .LSOverride
 
+# AI config 
+.agents
+.claude
+
 # Files that might appear in the root of a volume
 .DocumentRevisions-V100
 .fseventsd


### PR DESCRIPTION
Recently I've learned about skills. Suppose we're using skills. Then we may create those 2 folders. maybe we need to put that in gitignore.