### PR TITLE
fix: support PORT=0 for random port assignment

### DIFF
--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -8,9 +8,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 
-const _parsedPort = Number.parseInt(
-  process.env.NITRO_PORT ?? process.env.PORT ?? ""
-);
+const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 const host = process.env.NITRO_HOST || process.env.HOST;
 const cert = process.env.NITRO_SSL_CERT;

--- a/src/presets/deno/runtime/deno-server.ts
+++ b/src/presets/deno/runtime/deno-server.ts
@@ -8,9 +8,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 
-const _parsedPort = Number.parseInt(
-  process.env.NITRO_PORT ?? process.env.PORT ?? ""
-);
+const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 
 const host = process.env.NITRO_HOST || process.env.HOST;

--- a/src/presets/node/runtime/node-cluster.ts
+++ b/src/presets/node/runtime/node-cluster.ts
@@ -8,9 +8,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 
-const _parsedPort = Number.parseInt(
-  process.env.NITRO_PORT ?? process.env.PORT ?? ""
-);
+const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 
 const host = process.env.NITRO_HOST || process.env.HOST;

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -7,9 +7,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 
-const _parsedPort = Number.parseInt(
-  process.env.NITRO_PORT ?? process.env.PORT ?? ""
-);
+const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 
 const host = process.env.NITRO_HOST || process.env.HOST;


### PR DESCRIPTION
### 🔗 Linked issue

N/A - Minor fix discovered while using the library.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current port parsing pattern in all runtime files:

```typescript
const port = Number.parseInt(process.env.NITRO_PORT || process.env.PORT || "") || 3000;
```

Has two issues with `PORT=0`:

1. `Number.parseInt("0")` returns `0`
2. `0 || 3000` evaluates to `3000` because `0` is falsy in JavaScript

This prevents users from using `PORT=0` for random port assignment (a common pattern where the OS assigns an available port).

**Solution:** Replace the double-`||` pattern with explicit `NaN` checking:

```typescript
const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
```

This correctly handles:

- `PORT=0` → port is `0` (random assignment)
- `PORT` not set → port is `3000` (default)
- `PORT="8080"` → port is `8080`
- `PORT="abc"` → port is `3000` (invalid input fallback)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.