### PR TITLE
fix(cloudflare): use explicit imports in dev plugin instead of `#imports`

### DIFF
--- a/src/presets/cloudflare/runtime/plugin.dev.ts
+++ b/src/presets/cloudflare/runtime/plugin.dev.ts
@@ -1,8 +1,7 @@
-import type { NitroAppPlugin } from "nitropack";
+import type { NitroAppPlugin } from "nitropack/types";
 import type { GetPlatformProxyOptions, PlatformProxy } from "wrangler";
-
-// @ts-ignore
-import { useRuntimeConfig, getRequestURL } from "#imports";
+import { useRuntimeConfig } from "nitropack/runtime";
+import { getRequestURL } from "h3";
 
 const proxy = await _getPlatformProxy().catch((error) => {
   console.error("Failed to initialize wrangler bindings proxy", error);


### PR DESCRIPTION
## Summary

The Cloudflare dev plugin (`plugin.dev.ts`) imports `useRuntimeConfig` and `getRequestURL` from `#imports`, which is a virtual module that depends on Nitro's auto-import system being enabled.

When used with Nuxt's `compatibilityVersion: 5` (which sets `nitroAutoImports: false` by default), the `#imports` virtual module is never created, causing the dev server to fail:

```
[nitro] ERROR Error: Could not load .nuxt/imports
  (imported by nitropack/dist/presets/cloudflare/runtime/plugin.dev.mjs):
  ENOENT: no such file or directory, open '.nuxt/imports'
```

## Root Cause

1. Nuxt `compatibilityVersion: 5` defaults `nitroAutoImports` to `false` ([source](https://github.com/nuxt/nuxt/blob/main/packages/schema/src/config/experimental.ts))
2. This passes `imports: false` to Nitro, disabling the unimport system entirely
3. The `#imports` virtual module (`nitro.options.virtual["#imports"]`) relies on `nitro.unimport?.toExports()` which returns empty or is never registered
4. The Cloudflare dev plugin is the **only** preset plugin in Nitro that imports from `#imports` — all other 50+ preset plugins don't use it

## Fix

Replace `#imports` with explicit imports from `nitropack/runtime` and `h3`, consistent with how other Nitro runtime files already import these utilities:

```diff
- // @ts-ignore
- import { useRuntimeConfig, getRequestURL } from "#imports";
+ import { useRuntimeConfig } from "nitropack/runtime";
+ import { getRequestURL } from "h3";
```

Also updated `NitroAppPlugin` type import from `"nitropack"` to `"nitropack/types"` for consistency with other runtime files (e.g., `src/runtime/internal/plugin.ts`).

## Reproduction

- **Repro repo**: https://github.com/vinayakkulkarni/nuxt-cloudflare-imports-bug
- **Nuxt issue**: https://github.com/nuxt/nuxt/issues/34282

### Minimal config that triggers the bug (all three required):

```typescript
export default defineNuxtConfig({
  future: { compatibilityVersion: 5 },
  compatibilityDate: 'latest',
  nitro: { preset: 'cloudflare-pages' },
});
```

### Workaround (until this fix is released):

```typescript
export default defineNuxtConfig({
  experimental: {
    nitroAutoImports: true, // Override the v5 default
  },
});
```

Closes nuxt/nuxt#34282