### PR TITLE
fix(vercel): fix preview mode compat with srvx

### DIFF
--- a/src/presets/vercel/runtime/vercel.web.ts
+++ b/src/presets/vercel/runtime/vercel.web.ts
@@ -20,10 +20,8 @@ export default {
       }
     }
 
-    req.runtime = {
-      name: "vercel",
-      vercel: { context },
-    };
+    req.runtime ??= { name: "vercel" };
+    req.runtime.vercel = { context };
 
     let ip: string | undefined;
     Object.defineProperty(req, "ip", {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3905

Also related: https://github.com/TanStack/router/issues/6562

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Vercel preset was replacing the entire `req.runtime` object (`req.runtime = { name: "vercel", vercel: { context } }`), discarding `req.runtime.node` and causing a `TypeError: Cannot destructure property 'req' of 'this.runtime.node' as it is undefined` in srvx's Node adapter.

This fix uses `??=` to match the same pattern used in the Netlify, Netlify Edge, and Cloudflare presets to set `req.runtime` and then sets `req.runtime.vercel` separately.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
