### PR TITLE
docs(node): mark unimplemented env vars

### DIFF
--- a/docs/2.deploy/10.runtimes/1.node.md
+++ b/docs/2.deploy/10.runtimes/1.node.md
@@ -31,12 +31,12 @@ You can customize server behavior using following environment variables:
 
 - `NITRO_PORT` or `PORT` (defaults to `3000`)
 - `NITRO_HOST` or `HOST`
-- `NITRO_UNIX_SOCKET` - if provided (a path to the desired socket file) the service will be served over the provided UNIX socket.
+- `NITRO_UNIX_SOCKET` - if provided (a path to the desired socket file) the service will be served over the provided UNIX socket. :badge[Not yet implemented]{type="warning"}
 - `NITRO_SSL_CERT` and `NITRO_SSL_KEY` - if both are present, this will launch the server in HTTPS mode. In the vast majority of cases, this should not be used other than for testing, and the Nitro server should be run behind a reverse proxy like nginx or Cloudflare which terminates SSL.
-- `NITRO_SHUTDOWN_DISABLED` - Disables the graceful shutdown feature when set to `'true'`. If it's set to `'true'`, the graceful shutdown is bypassed to speed up the development process. Defaults to `'false'`.
-- `NITRO_SHUTDOWN_SIGNALS` - Allows you to specify which signals should be handled. Each signal should be separated with a space. Defaults to `'SIGINT SIGTERM'`.
-- `NITRO_SHUTDOWN_TIMEOUT` - Sets the amount of time (in milliseconds) before a forced shutdown occurs. Defaults to `'30000'` milliseconds.
-- `NITRO_SHUTDOWN_FORCE` - When set to true, it triggers `process.exit()` at the end of the shutdown process. If it's set to `'false'`, the process will simply let the event loop clear. Defaults to `'true'`.
+- `NITRO_SHUTDOWN_DISABLED` - Disables the graceful shutdown feature when set to `'true'`. If it's set to `'true'`, the graceful shutdown is bypassed to speed up the development process. Defaults to `'false'`. :badge[Not yet implemented]{type="warning"}
+- `NITRO_SHUTDOWN_SIGNALS` - Allows you to specify which signals should be handled. Each signal should be separated with a space. Defaults to `'SIGINT SIGTERM'`. :badge[Not yet implemented]{type="warning"}
+- `NITRO_SHUTDOWN_TIMEOUT` - Sets the amount of time (in milliseconds) before a forced shutdown occurs. Defaults to `'30000'` milliseconds. :badge[Not yet implemented]{type="warning"}
+- `NITRO_SHUTDOWN_FORCE` - When set to true, it triggers `process.exit()` at the end of the shutdown process. If it's set to `'false'`, the process will simply let the event loop clear. Defaults to `'true'`. :badge[Not yet implemented]{type="warning"}
 
 ## Cluster mode
 


### PR DESCRIPTION
### 🔗 Linked issue

- Resolves #1243
- Resolves #2376

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Node.js server docs list several environment variables that are not actually implemented in the production node server runtime (or at any layer: srvx, h3, etc.):

- `NITRO_UNIX_SOCKET` -- commented out with `// TODO` in `src/presets/node/runtime/node-server.ts`
- `NITRO_SHUTDOWN_DISABLED` -- not referenced in the codebase
- `NITRO_SHUTDOWN_SIGNALS` -- not referenced in the codebase
- `NITRO_SHUTDOWN_TIMEOUT` -- only used in the dev runner, not the production server
- `NITRO_SHUTDOWN_FORCE` -- not referenced in the codebase

This adds "Not yet implemented" warning badges to those env vars so users are not misled.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.