### PR TITLE
fix(rolldown): fix CJS require handling for nodeless worker builds

### DIFF
--- a/src/build/rolldown/require-condition.ts
+++ b/src/build/rolldown/require-condition.ts
@@ -1,0 +1,64 @@
+import type { Nitro } from "nitro/types";
+import type { RolldownPlugin } from "rolldown";
+
+import { builtinModules } from "node:module";
+import { resolveModulePath } from "exsolve";
+import { isAbsolute } from "pathe";
+
+const RESOLVE_SKIP_RE = /^(?:[\0#~.]|[a-z0-9]{2,}:)|\?/;
+const BUILTIN_MODULE_SET = new Set([
+  ...builtinModules,
+  ...builtinModules.map((id) => `node:${id}`),
+]);
+
+export function getRequireConditionNames(exportConditions: string[]) {
+  return [
+    ...new Set([
+      "require",
+      ...exportConditions.filter((condition) => condition !== "import"),
+      "default",
+    ]),
+  ];
+}
+
+export function resolveRequireCallPath(options: {
+  id: string;
+  importer?: string;
+  rootDir: string;
+  conditionNames: string[];
+}) {
+  if (RESOLVE_SKIP_RE.test(options.id) || BUILTIN_MODULE_SET.has(options.id)) {
+    return;
+  }
+  return resolveModulePath(options.id, {
+    try: true,
+    from: options.importer && isAbsolute(options.importer) ? options.importer : options.rootDir,
+    conditions: options.conditionNames,
+  });
+}
+
+export function requireConditionResolver(nitro: Nitro): RolldownPlugin {
+  const conditionNames = getRequireConditionNames(nitro.options.exportConditions || []);
+
+  return {
+    name: "nitro:rolldown-require-conditions",
+    resolveId: {
+      order: "pre",
+      handler(source, importer, resolveOptions) {
+        if (resolveOptions.kind !== "require-call") {
+          return null;
+        }
+        const resolved = resolveRequireCallPath({
+          id: source,
+          importer,
+          rootDir: nitro.options.rootDir,
+          conditionNames,
+        });
+        if (!resolved) {
+          return null;
+        }
+        return { id: resolved };
+      },
+    },
+  };
+}

--- a/test/unit/rolldown-require-condition.test.ts
+++ b/test/unit/rolldown-require-condition.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { join } from "pathe";
+import { tmpdir } from "node:os";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import {
+  getRequireConditionNames,
+  resolveRequireCallPath,
+} from "../../src/build/rolldown/require-condition.ts";
+
+describe("resolveRequireCallPath", () => {
+  const tmpDirs: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(tmpDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("prefers require condition for require-call package resolution", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "nitro-rolldown-require-condition-"));
+    tmpDirs.push(rootDir);
+
+    const pkgDir = join(rootDir, "node_modules/dual-entry");
+    await mkdir(join(pkgDir, "esm"), { recursive: true });
+    await mkdir(join(pkgDir, "cjs"), { recursive: true });
+    await writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "dual-entry",
+          version: "0.0.0",
+          exports: {
+            ".": {
+              import: "./esm/index.mjs",
+              require: "./cjs/index.cjs",
+              default: "./cjs/index.cjs",
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+    await writeFile(join(pkgDir, "esm/index.mjs"), "export default { entry: 'esm' };\n");
+    await writeFile(join(pkgDir, "cjs/index.cjs"), "module.exports = class DualEntry {};\n");
+
+    const resolved = resolveRequireCallPath({
+      id: "dual-entry",
+      rootDir,
+      conditionNames: getRequireConditionNames(["workerd", "import", "default"]),
+    });
+
+    expect(resolved?.replaceAll("\\", "/")).toMatch(/dual-entry\/cjs\/index\.cjs$/);
+  });
+
+  it("skips builtins and relative imports", () => {
+    const conditionNames = getRequireConditionNames(["workerd", "import", "default"]);
+    const rootDir = process.cwd();
+    expect(resolveRequireCallPath({ id: "events", rootDir, conditionNames })).toBeUndefined();
+    expect(resolveRequireCallPath({ id: "./local", rootDir, conditionNames })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

#4010

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes the rolldown regression reported in #4010 for Cloudflare worker targets.

- Add a rolldown pre-resolver for `require-call` to resolve package exports with `require`-first conditions (instead of accidentally selecting `import` entries for CJS requires).
- Enable rolldown `esmExternalRequirePlugin` for nodeless builds so Node builtins used via CJS `require()` are emitted as ESM-compatible externals for worker runtimes.
- Keep Node-target behavior unchanged.
- Add unit coverage for dual export (`import`/`require`) resolution behavior.

Validated with the minimal repro:
[medz/nitro-issue-4010-pg-cloudflare-repro](https://github.com/medz/nitro-issue-4010-pg-cloudflare-repro)

`NITRO_BUILDER=rolldown nitro build` + `wrangler dev` now starts successfully and serves requests (no `require("events")` startup failure).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
