### PR TITLE
fix: avoid adding extra additional export conditions

### DIFF
--- a/src/build/plugins.ts
+++ b/src/build/plugins.ts
@@ -64,7 +64,7 @@ export async function baseBuildPlugins(nitro: Nitro, base: BaseBuildConfig) {
     plugins.push(
       externals({
         rootDir: nitro.options.rootDir,
-        conditions: nitro.options.exportConditions || ["default"],
+        conditions: nitro.options.exportConditions!,
         exclude: [...base.noExternal],
         include: isDevOrPrerender
           ? undefined

--- a/src/config/resolvers/export-conditions.ts
+++ b/src/config/resolvers/export-conditions.ts
@@ -9,35 +9,28 @@ export async function resolveExportConditionsOptions(options: NitroOptions) {
 }
 
 function _resolveExportConditions(
-  conditions: string[],
+  userConditions: string[],
   opts: { dev: boolean; node: boolean; wasm?: boolean }
 ) {
-  const negated = new Set(conditions.filter((c) => c.startsWith("!")).map((c) => c.slice(1)));
+  const conditions: string[] = [...userConditions.filter((c) => !c.startsWith("!"))];
 
-  const resolvedConditions: string[] = [];
+  conditions.push(opts.dev ? "development" : "production");
 
-  // 1. Add dev or production
-  resolvedConditions.push(opts.dev ? "development" : "production");
-
-  // 2. Add user specified conditions
-  resolvedConditions.push(...conditions.filter((c) => !c.startsWith("!")));
-
-  // 3. Add unwasm conditions
   if (opts.wasm) {
-    resolvedConditions.push("wasm", "unwasm");
+    conditions.push("wasm", "unwasm");
   }
 
-  // 4. Add default conditions
-  // "module" is NOT A STANDARD CONDITION but widely used in the ecosystem adding helps with compatibility
-  resolvedConditions.push("module");
+  if (opts.node) {
+    conditions.push("node");
+  }
 
-  // 5. Auto detect bun and deno (builder)
   if ("Bun" in globalThis) {
-    resolvedConditions.push("bun");
+    conditions.push("bun");
   } else if ("Deno" in globalThis) {
-    resolvedConditions.push("deno");
+    conditions.push("deno");
   }
 
-  // 6. Dedup and remove negated conditions
-  return [...new Set(resolvedConditions)].filter((c) => !negated.has(c));
+  const negated = new Set(userConditions.filter((c) => c.startsWith("!")).map((c) => c.slice(1)));
+
+  return [...new Set(conditions)].filter((c) => !negated.has(c));
 }

--- a/src/presets/bun/preset.ts
+++ b/src/presets/bun/preset.ts
@@ -5,7 +5,7 @@ const bun = defineNitroPreset(
     entry: "./bun/runtime/bun",
     serveStatic: true,
     // https://bun.sh/docs/runtime/modules#resolution
-    exportConditions: ["bun", "node", "import", "default"],
+    exportConditions: ["bun"],
     commands: {
       preview: "bun run ./server/index.mjs",
     },


### PR DESCRIPTION
This PR fixes issues related to the nitro adding extra resolve conditions.

- Nitro v2 used to add all wintertc keys in nodeless mode, this would cause e.g `workerd` condition used for deno and netlify edge. Presets add their specific condition, shared fallback removed
- Not adding `import` condition by default. it WAS the root cause of `pg` bundling failing! Bundlers, automatically apply either `import` or `require` condition based on how module is imported themselves. 
- Added a mini feature to support nagated conditions to opt-out by users or presets if needed.