### PR TITLE
fix: preserve sourcemap mappings for chunks containing user code

### DIFF
--- a/src/build/plugins/sourcemap-min.ts
+++ b/src/build/plugins/sourcemap-min.ts
@@ -19,7 +19,7 @@ export function sourcemapMinify() {
         // Remove x_google_ignoreList
         delete sourcemap.x_google_ignoreList;
 
-        if ((sourcemap.sources || []).some((s) => s.includes("node_modules"))) {
+        if ((sourcemap.sources || []).every((s) => s.includes("node_modules"))) {
           sourcemap.mappings = ""; // required key
         }
 

--- a/test/unit/sourcemap-min.test.ts
+++ b/test/unit/sourcemap-min.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { sourcemapMinify } from "../../src/build/plugins/sourcemap-min.ts";
+
+type BundleAsset = { type: "asset"; source: string };
+
+function createSourcemapAsset(sourcemap: {
+  sources?: string[];
+  sourcesContent?: string[];
+  mappings?: string;
+  x_google_ignoreList?: number[];
+}): BundleAsset {
+  return {
+    type: "asset",
+    source: JSON.stringify({
+      version: 3,
+      sources: [],
+      mappings: "AAAA,CAAC",
+      ...sourcemap,
+    }),
+  };
+}
+
+function runPlugin(bundle: Record<string, BundleAsset>) {
+  const plugin = sourcemapMinify();
+  (plugin.generateBundle as Function).call(null, {}, bundle);
+  const results: Record<string, ReturnType<typeof JSON.parse>> = {};
+  for (const [key, asset] of Object.entries(bundle)) {
+    if (key.endsWith(".map")) {
+      results[key] = JSON.parse(asset.source);
+    }
+  }
+  return results;
+}
+
+describe("sourcemapMinify", () => {
+  it("removes sourcesContent from all sourcemaps", () => {
+    const bundle = {
+      "index.mjs.map": createSourcemapAsset({
+        sources: ["src/index.ts"],
+        sourcesContent: ["export default 42;"],
+      }),
+    };
+    const results = runPlugin(bundle);
+    expect(results["index.mjs.map"].sourcesContent).toBeUndefined();
+  });
+
+  it("removes x_google_ignoreList from all sourcemaps", () => {
+    const bundle = {
+      "index.mjs.map": createSourcemapAsset({
+        sources: ["src/index.ts"],
+        x_google_ignoreList: [0],
+      }),
+    };
+    const results = runPlugin(bundle);
+    expect(results["index.mjs.map"].x_google_ignoreList).toBeUndefined();
+  });
+
+  it("wipes mappings for pure library chunks", () => {
+    const bundle = {
+      "_libs/express.mjs.map": createSourcemapAsset({
+        sources: [
+          "../../node_modules/express/index.js",
+          "../../node_modules/express/lib/router.js",
+        ],
+        mappings: "AAAA,CAAC",
+      }),
+    };
+    const results = runPlugin(bundle);
+    expect(results["_libs/express.mjs.map"].mappings).toBe("");
+  });
+
+  it("preserves mappings for pure user code chunks", () => {
+    const bundle = {
+      "_routes/api/hello.mjs.map": createSourcemapAsset({
+        sources: ["src/routes/api/hello.ts"],
+        mappings: "AAAA,CAAC",
+      }),
+    };
+    const results = runPlugin(bundle);
+    expect(results["_routes/api/hello.mjs.map"].mappings).toBe("AAAA,CAAC");
+  });
+
+  it("preserves mappings when library is hoisted into user chunk", () => {
+    const bundle = {
+      "_routes/api/hello.mjs.map": createSourcemapAsset({
+        sources: ["src/routes/api/hello.ts", "../../node_modules/some-lib/index.js"],
+        mappings: "AAAA,CAAC",
+      }),
+    };
+    const results = runPlugin(bundle);
+    expect(results["_routes/api/hello.mjs.map"].mappings).toBe("AAAA,CAAC");
+  });
+
+  it("skips non-sourcemap files", () => {
+    const bundle = {
+      "index.mjs": { type: "asset" as const, source: "console.log(42)" },
+    };
+    runPlugin(bundle as any);
+    expect(bundle["index.mjs"].source).toBe("console.log(42)");
+  });
+
+  it("handles empty sources array", () => {
+    const bundle = {
+      "chunk.mjs.map": createSourcemapAsset({
+        sources: [],
+        mappings: "AAAA,CAAC",
+      }),
+    };
+    const results = runPlugin(bundle);
+    expect(results["chunk.mjs.map"].mappings).toBe("");
+  });
+});


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I took a look at this while working on https://github.com/getsentry/sentry-javascript/pull/19304 and thought about how to address this and I though we could **_first_** do a stop gap measure to prevent the worst case which wipes all user code mappings along with the lib code.

So the change from `some` to `every` effectively makes the mappings get wiped only if the entire chunk is from `node_modules`, if some user code makes into the chunk it doesn't get wiped.

In a follow up PR, we can try more aggressive approaches like parsing the VLQ and find the segments containing `node_modules` and strip only those. Not sure if this can work tho.


But this fixes #3826 from what I tested and means I don't have to explicitly disable it for the SDK.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
