### PR TITLE
fix(vite): invalidate shared modules in SSR environment on HMR

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -251,15 +251,14 @@ function nitroMain(ctx: NitroPluginContext): VitePlugin {
       const clientEnvs = Object.values(server.environments).filter(
         (env) => env.config.consumer === "client"
       );
-      let hasServerOnlyModule = false;
+      let hasServerModule = false;
       const invalidated = new Set<EnvironmentModuleNode>();
       for (const mod of modules) {
-        if (mod.id && !clientEnvs.some((env) => env.moduleGraph.getModuleById(mod.id!))) {
-          hasServerOnlyModule = true;
-          env.moduleGraph.invalidateModule(mod, invalidated, timestamp, false);
-        }
+        if (!mod.id) continue;
+        hasServerModule = true;
+        env.moduleGraph.invalidateModule(mod, invalidated, timestamp, false);
       }
-      if (hasServerOnlyModule) {
+      if (hasServerModule) {
         env.hot.send({ type: "full-reload" });
         server.ws.send({ type: "full-reload" });
         return [];


### PR DESCRIPTION
Modules present in both client and server environments were skipped during server-side invalidation due to an overly strict guard. This caused SSR to render stale HTML after HMR updates, leading to React hydration mismatches.

### 🔗 Linked issue

Fixes #4043
Related to #4020

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

In `src/build/vite/plugin.ts`, the `hotUpdate` hook skipped server-side
invalidation for any module that also exists in a client environment:

```ts
if (mod.id && !clientEnvs.some((env) => env.moduleGraph.getModuleById(mod.id!))) {
  hasServerOnlyModule = true;
  env.moduleGraph.invalidateModule(mod, invalidated, timestamp, false);
}
```

The !clientEnvs.some(...) guard means: if a module is present in a client
environment, don't invalidate it in the server environment. The intent was
presumably to defer to Vite's normal client HMR — but the server-side copy of
that module still needs invalidation for SSR to re-render correctly.

The fix removes the exclusion guard so that all modules with an id are
invalidated in the server module graph on HMR, regardless of whether they also
appear in a client environment.
### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
