### PR TITLE
fix: swr cache invalidation

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -109,6 +109,16 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         // Make sure entries that reject get removed.
         if (!isPending) {
           delete pending[key];
+          // Remove stale cache entry when resolver throws (e.g. handler returns 404)
+          const promise = useStorage()
+            .removeItem(cacheKey)
+            .catch((error) => {
+              console.error(`[cache] Cache remove error.`, error);
+              useNitroApp().captureError(error, { event, tags: ["cache"] });
+            });
+          if (event?.waitUntil) {
+            event.waitUntil(promise);
+          }
         }
         // Re-throw error to make sure the caller knows the task failed.
         throw error;
@@ -119,7 +129,18 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         entry.mtime = Date.now();
         entry.integrity = integrity;
         delete pending[key];
-        if (validate(entry) !== false) {
+        if (validate(entry) === false) {
+          // Remove stale cache entry when revalidation produces an invalid response (e.g. 404)
+          const promise = useStorage()
+            .removeItem(cacheKey)
+            .catch((error) => {
+              console.error(`[cache] Cache remove error.`, error);
+              useNitroApp().captureError(error, { event, tags: ["cache"] });
+            });
+          if (event?.waitUntil) {
+            event.waitUntil(promise);
+          }
+        } else {
           let setOpts: TransactionOptions | undefined;
           if (opts.maxAge && !opts.swr /* TODO: respect staleMaxAge */) {
             setOpts = { ttl: opts.maxAge };

--- a/test/fixture/api/cached-error-toggle.ts
+++ b/test/fixture/api/cached-error-toggle.ts
@@ -1,0 +1,6 @@
+import { toggleCachedError } from "../utils/cached-error-state";
+
+export default defineEventHandler(() => {
+  toggleCachedError();
+  return { toggled: true };
+});

--- a/test/fixture/api/cached-error-toggle.ts
+++ b/test/fixture/api/cached-error-toggle.ts
@@ -1,6 +1,7 @@
-import { toggleCachedError } from "../utils/cached-error-state";
+import { setCachedError } from "../utils/cached-error-state";
 
-export default defineEventHandler(() => {
-  toggleCachedError();
-  return { toggled: true };
+export default defineEventHandler((event) => {
+  const { error } = getQuery(event);
+  setCachedError(error === "true");
+  return { shouldError: error === "true" };
 });

--- a/test/fixture/api/cached-error.ts
+++ b/test/fixture/api/cached-error.ts
@@ -1,0 +1,13 @@
+import { cachedErrorShouldError } from "../utils/cached-error-state";
+
+export default defineCachedEventHandler(
+  () => {
+    if (cachedErrorShouldError) {
+      throw createError({ statusCode: 404, statusMessage: "Not found" });
+    }
+    return {
+      timestamp: Date.now(),
+    };
+  },
+  { swr: true, maxAge: 1 }
+);

--- a/test/fixture/utils/cached-error-state.ts
+++ b/test/fixture/utils/cached-error-state.ts
@@ -1,0 +1,5 @@
+export let cachedErrorShouldError = false;
+
+export function toggleCachedError() {
+  cachedErrorShouldError = !cachedErrorShouldError;
+}

--- a/test/fixture/utils/cached-error-state.ts
+++ b/test/fixture/utils/cached-error-state.ts
@@ -1,5 +1,5 @@
 export let cachedErrorShouldError = false;
 
-export function toggleCachedError() {
-  cachedErrorShouldError = !cachedErrorShouldError;
+export function setCachedError(value: boolean) {
+  cachedErrorShouldError = value;
 }

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -338,6 +338,14 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/api/db",
               },
               {
+                "dest": "/api/cached-error-toggle",
+                "src": "/api/cached-error-toggle",
+              },
+              {
+                "dest": "/api/cached-error",
+                "src": "/api/cached-error",
+              },
+              {
                 "dest": "/api/cached",
                 "src": "/api/cached",
               },
@@ -469,6 +477,8 @@ describe("nitro:preset:vercel", async () => {
             "functions/__fallback.func/node_modules",
             "functions/__fallback.func/package.json",
             "functions/__fallback.func/timing.js",
+            "functions/api/cached-error-toggle.func (symlink)",
+            "functions/api/cached-error.func (symlink)",
             "functions/api/cached.func (symlink)",
             "functions/api/db.func (symlink)",
             "functions/api/echo.func (symlink)",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -755,6 +755,34 @@ export function testNitro(
         }
       }
     );
+
+    it.skipIf(ctx.isIsolated || (isWindows && ctx.preset === "nitro-dev"))(
+      "should invalidate cache when SWR revalidation returns error",
+      async () => {
+        // 1. Prime the cache with a successful response
+        const { data, status } = await callHandler({ url: "/api/cached-error" });
+        expect(status).toBe(200);
+        expect(data.timestamp).toBeDefined();
+
+        // 2. Toggle error state so handler throws 404
+        await callHandler({ url: "/api/cached-error-toggle" });
+
+        // 3. Wait for cache to expire (maxAge: 1 second)
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+
+        // 4. First request after expiry: SWR serves stale, triggers background revalidation
+        const staleResult = await callHandler({ url: "/api/cached-error" });
+        expect(staleResult.status).toBe(200);
+        expect(staleResult.data.timestamp).toBe(data.timestamp);
+
+        // 5. Wait for background revalidation to complete and remove cache entry
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // 6. Subsequent request should return 404 (cache entry removed)
+        const errorResult = await callHandler({ url: "/api/cached-error" });
+        expect(errorResult.status).toBe(404);
+      }
+    );
   });
 
   describe("scanned files", () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -760,7 +760,9 @@ export function testNitro(
       "should invalidate cache when SWR revalidation returns error",
       async () => {
         // 1. Prime the cache with a successful response
-        const { data, status } = await callHandler({ url: "/api/cached-error" });
+        const { data, status } = await callHandler({
+          url: "/api/cached-error",
+        });
         expect(status).toBe(200);
         expect(data.timestamp).toBeDefined();
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -759,6 +759,9 @@ export function testNitro(
     it.skipIf(ctx.isIsolated || (isWindows && ctx.preset === "nitro-dev"))(
       "should invalidate cache when SWR revalidation returns error",
       async () => {
+        // 0. Reset error state
+        await callHandler({ url: "/api/cached-error-toggle?error=false" });
+
         // 1. Prime the cache with a successful response
         const { data, status } = await callHandler({
           url: "/api/cached-error",
@@ -766,8 +769,8 @@ export function testNitro(
         expect(status).toBe(200);
         expect(data.timestamp).toBeDefined();
 
-        // 2. Toggle error state so handler throws 404
-        await callHandler({ url: "/api/cached-error-toggle" });
+        // 2. Enable error state so handler throws 404
+        await callHandler({ url: "/api/cached-error-toggle?error=true" });
 
         // 3. Wait for cache to expire (maxAge: 1 second)
         await new Promise((resolve) => setTimeout(resolve, 1100));


### PR DESCRIPTION
Hi @pi0!

### 🔗 Linked issue

fixes: https://github.com/nuxt/nuxt/issues/34189

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a cached api endpoint  correctly returns a 404 response, the cached entry for that page is not removed or invalidated. This can result in stale content being served from cache even after the page has been unpublished. Now on such errors the cache will be correct invalidated and deleted if needed.

### Testing
Added integration tests for it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
