### PR TITLE
fix(vite): broaden checks for existing client input

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -100,7 +100,7 @@ function nitroEnv(ctx: NitroPluginContext): VitePlugin {
       let clientEntry: string | undefined;
       let clientEntryConfigured = !!(
         userConfig.environments?.client?.build?.rolldownOptions?.input ||
-          userConfig.environments?.client?.build?.rollupOptions?.input
+        userConfig.environments?.client?.build?.rollupOptions?.input
       );
       if (!clientEntryConfigured) {
         const rendererTemplate = useNitro(ctx).options.renderer?.template;


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Closes https://github.com/nitrojs/nitro/issues/4069

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Removes using `getEntry()` since we don't need the exact input, just to know whether an existing client entrypoint is configured.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
