### PR TITLE
feat(cache): add `allowQuery` option to filter query params in cache key

### DIFF
--- a/docs/1.docs/7.cache.md
+++ b/docs/1.docs/7.cache.md
@@ -223,6 +223,10 @@ The `defineCachedHandler` and `defineCachedFunction` functions accept the follow
   ::field{name="varies" type="string[]"}
     An array of request headers to be considered for the cache, [learn more](https://github.com/nitrojs/nitro/issues/1031). If utilizing in a multi-tenant environment, you may want to pass `['host', 'x-forwarded-host']` to ensure these headers are not discarded and that the cache is unique per tenant.
   ::
+  ::field{name="allowQuery" type="string[]"}
+    List of query parameter names to include in the cache key. If `undefined`, all query parameters are included. If an empty array `[]`, all query parameters are ignored (only the pathname is used for caching). Only applicable to cached event handlers. :br
+    Defaults to `undefined`.
+  ::
 ::
 
 ## Cache keys and invalidation

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -201,7 +201,20 @@ export function defineCachedHandler(
         return escapeKey(customKey);
       }
       // Auto-generated key
-      const _path = event.url.pathname + event.url.search;
+      let _path: string;
+      if (opts.allowQuery) {
+        const params = new URLSearchParams();
+        for (const key of opts.allowQuery) {
+          const value = event.url.searchParams.get(key);
+          if (value !== null) {
+            params.set(key, value);
+          }
+        }
+        const search = params.size > 0 ? `?${params.toString()}` : "";
+        _path = event.url.pathname + search;
+      } else {
+        _path = event.url.pathname + event.url.search;
+      }
       let _pathname: string;
       try {
         _pathname = escapeKey(decodeURI(parseURL(_path).pathname)).slice(0, 16) || "index";

--- a/src/types/runtime/cache.ts
+++ b/src/types/runtime/cache.ts
@@ -44,5 +44,5 @@ export interface CachedEventHandlerOptions extends Omit<
    * - If an empty array `[]`, all query parameters are ignored (only pathname is used for caching).
    * - If a list of parameter names, only those parameters are included in the cache key.
    */
-  allowQuery?: string[];
+  allowQuery?: string[] | readonly string[];
 }

--- a/src/types/runtime/cache.ts
+++ b/src/types/runtime/cache.ts
@@ -38,4 +38,11 @@ export interface CachedEventHandlerOptions extends Omit<
 > {
   headersOnly?: boolean;
   varies?: string[] | readonly string[];
+  /**
+   * List of query string parameter names that will be considered for caching.
+   * - If undefined, all query parameters are included in the cache key.
+   * - If an empty array `[]`, all query parameters are ignored (only pathname is used for caching).
+   * - If a list of parameter names, only those parameters are included in the cache key.
+   */
+  allowQuery?: string[];
 }

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
     },
     "/rules/dynamic": { cache: false, isr: false },
     "/rules/redirect": { redirect: "/base" },
+    "/rules/allow-query/**": { cache: { swr: true, maxAge: 60, allowQuery: ["q"] } },
     "/rules/isr/**": { isr: { allowQuery: ["q"] } },
     "/rules/isr-ttl/**": { isr: 60 },
     "/rules/swr/**": { swr: true },

--- a/test/fixture/server/routes/api/cached-allow-query.ts
+++ b/test/fixture/server/routes/api/cached-allow-query.ts
@@ -1,0 +1,10 @@
+import { defineCachedHandler } from "nitro/cache";
+
+export default defineCachedHandler(
+  (event) => {
+    return {
+      timestamp: Date.now(),
+    };
+  },
+  { swr: true, maxAge: 60, allowQuery: ["q"] }
+);

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -152,6 +152,10 @@ describe("nitro:preset:vercel:web", async () => {
                 "src": "(?<__isr_route>/rules/dynamic)",
               },
               {
+                "dest": "/rules/allow-query/[...]-isr?__isr_route=$__isr_route",
+                "src": "(?<__isr_route>/rules/allow-query/(?:.*))",
+              },
+              {
                 "dest": "/rules/isr/[...]-isr?__isr_route=$__isr_route",
                 "src": "(?<__isr_route>/rules/isr/(?:.*))",
               },
@@ -320,6 +324,10 @@ describe("nitro:preset:vercel:web", async () => {
                 "src": "/api/db",
               },
               {
+                "dest": "/api/cached-allow-query",
+                "src": "/api/cached-allow-query",
+              },
+              {
                 "dest": "/api/cached",
                 "src": "/api/cached",
               },
@@ -418,6 +426,7 @@ describe("nitro:preset:vercel:web", async () => {
             "functions/_scalar.func (symlink)",
             "functions/_swagger.func (symlink)",
             "functions/_vercel",
+            "functions/api/cached-allow-query.func (symlink)",
             "functions/api/cached.func (symlink)",
             "functions/api/db.func (symlink)",
             "functions/api/echo.func (symlink)",
@@ -460,6 +469,8 @@ describe("nitro:preset:vercel:web", async () => {
             "functions/rules/_/cached/[...]-isr.prerender-config.json",
             "functions/rules/_/noncached/cached-isr.func (symlink)",
             "functions/rules/_/noncached/cached-isr.prerender-config.json",
+            "functions/rules/allow-query/[...]-isr.func (symlink)",
+            "functions/rules/allow-query/[...]-isr.prerender-config.json",
             "functions/rules/isr-ttl/[...]-isr.func (symlink)",
             "functions/rules/isr-ttl/[...]-isr.prerender-config.json",
             "functions/rules/isr/[...]-isr.func (symlink)",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -692,6 +692,27 @@ export function testNitro(
         }
       }
     );
+
+    it.skipIf(ctx.isIsolated || (isWindows && ctx.preset === "nitro-dev"))(
+      "allowQuery should ignore unlisted query params in cache key",
+      async () => {
+        const { data: first } = await callHandler({
+          url: "/api/cached-allow-query?q=search&utm_source=email",
+        });
+
+        // Same q param, different unlisted param should hit cache
+        const { data: second } = await callHandler({
+          url: "/api/cached-allow-query?q=search&utm_source=twitter",
+        });
+        expect(second.timestamp).toBe(first.timestamp);
+
+        // Different q param should get a different cache entry
+        const { data: third } = await callHandler({
+          url: "/api/cached-allow-query?q=other&utm_source=email",
+        });
+        expect(third.timestamp).not.toBe(first.timestamp);
+      }
+    );
   });
 
   describe("scanned files", () => {


### PR DESCRIPTION
## Summary
- Adds `allowQuery` option to `defineCachedHandler` and route rules `cache` config
- When set, only the listed query parameter names are included in the cache key
- If set to an empty array `[]`, all query parameters are ignored (only pathname is used)
- If `undefined` (default), all query parameters are included — no behavior change
- Useful for ignoring tracking params like `utm_source`, `fbclid`, etc.

Closes nuxt/nuxt#33728

## Test plan
- [x] Added test fixture `api/cached-allow-query.ts` with `allowQuery: ["q"]`
- [x] Added route rule `/rules/allow-query/**` with `allowQuery: ["q"]`
- [x] Added test: same `q` param with different unlisted params hits cache
- [x] Added test: different `q` param gets different cache entry
- [x] Tests pass on multiple presets (node, cloudflare-pages, cloudflare-module, etc.)
- [x] Updated cache docs with `allowQuery` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)