### PR TITLE
feat(vite): support preview

### DIFF
--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -4,7 +4,7 @@ import type { NitroPluginContext } from "./types.ts";
 import { basename, dirname, resolve } from "pathe";
 import { formatCompatibilityDate } from "compatx";
 import { colors as C } from "consola/utils";
-import { copyPublicAssets } from "../../builder.ts";
+import { copyPublicAssets, prerender } from "../../builder.ts";
 import { existsSync } from "node:fs";
 import { writeBuildInfo } from "../info.ts";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -104,8 +104,7 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
   ctx.nitro!.routing.sync();
 
   // Prerender routes if configured
-  // TODO
-  // await prerender(nitro);
+  await prerender(nitro);
 
   // Build the Nitro server bundle
   const output = (await builder.build(builder.environments.nitro)) as RolldownOutput;

--- a/src/prerender/prerender.ts
+++ b/src/prerender/prerender.ts
@@ -2,7 +2,13 @@ import { pathToFileURL } from "node:url";
 import { defu } from "defu";
 import mime from "mime";
 import { writeFile } from "../utils/fs.ts";
-import type { Nitro, NitroRouteRules, PrerenderRoute, PublicAssetDir } from "nitro/types";
+import type {
+  Nitro,
+  NitroConfig,
+  NitroRouteRules,
+  PrerenderRoute,
+  PublicAssetDir,
+} from "nitro/types";
 import { join, relative, resolve } from "pathe";
 import { createRouter, addRoute, findAllRoutes } from "rou3";
 import { joinURL, withBase, withoutBase, withTrailingSlash } from "ufo";
@@ -21,11 +27,6 @@ const JsonSigRx = /^\s*["[{]|^\s*-?\d{1,16}(\.\d{1,17})?([Ee][+-]?\d+)?\s*$/; //
 export async function prerender(nitro: Nitro) {
   if (nitro.options.noPublicDir) {
     nitro.logger.warn("Skipping prerender since `noPublicDir` option is enabled.");
-    return;
-  }
-
-  if (nitro.options.builder === "vite") {
-    nitro.logger.warn("Skipping prerender since not supported with vite builder yet...");
     return;
   }
 
@@ -63,6 +64,7 @@ export async function prerender(nitro: Nitro) {
     rootDir: nitro.options.rootDir,
     logLevel: 0,
     preset: "nitro-prerender",
+    builder: nitro.options.builder === "vite" ? "rolldown" : nitro.options.builder,
   };
   await nitro.hooks.callHook("prerender:config", prerendererConfig);
   const nitroRenderer = await createNitro(prerendererConfig);


### PR DESCRIPTION
This PR adds support for prerendering in vite prod mode.

Since rolldown is a default dependency, we can just keep using older method of building intermediate prerender-only server and use it for prerendering.