### PR TITLE
fix(externals): trace CJS require() dependencies in production builds

### DIFF
--- a/src/build/plugins/externals.ts
+++ b/src/build/plugins/externals.ts
@@ -71,21 +71,33 @@ export function externals(opts: ExternalsOptions): Plugin {
           };
         }
 
-        // Skip nested rollup-node resolutions
+        let resolved;
+
         if (rOpts.custom?.["node-resolve"]) {
-          return null;
-        }
-
-        // Resolve by other resolvers
-        let resolved = await this.resolve(id, importer, rOpts);
-
-        // Skip rolldown-plugin-commonjs resolver for externals
-        const cjsResolved = resolved?.meta?.commonjs?.resolved;
-        if (cjsResolved) {
-          if (!filter(cjsResolved.id)) {
-            return resolved; // Bundled and wrapped by CJS plugin
+          // For nested node-resolve resolutions (e.g., CJS require()),
+          // resolve directly to avoid recursion but still externalize
+          // modules that match the include filter (e.g., native deps).
+          // Only applies when tracing is active (production builds).
+          if (!opts.trace) {
+            return null;
           }
-          resolved = cjsResolved /* non-wrapped */;
+          const resolvedPath = tryResolve(id, importer);
+          if (!resolvedPath || !filter(resolvedPath)) {
+            return null;
+          }
+          resolved = { id: resolvedPath };
+        } else {
+          // Resolve by other resolvers
+          resolved = await this.resolve(id, importer, rOpts);
+
+          // Skip rolldown-plugin-commonjs resolver for externals
+          const cjsResolved = resolved?.meta?.commonjs?.resolved;
+          if (cjsResolved) {
+            if (!filter(cjsResolved.id)) {
+              return resolved; // Bundled and wrapped by CJS plugin
+            }
+            resolved = cjsResolved /* non-wrapped */;
+          }
         }
 
         // Check if not resolved or explicitly marked as excluded

--- a/src/presets/_all.gen.ts
+++ b/src/presets/_all.gen.ts
@@ -1,7 +1,5 @@
 // Auto-generated using gen-presets script
 
-import _nitro from "./_nitro/preset.ts";
-import _static from "./_static/preset.ts";
 import _alwaysdata from "./alwaysdata/preset.ts";
 import _awsAmplify from "./aws-amplify/preset.ts";
 import _awsLambda from "./aws-lambda/preset.ts";
@@ -27,10 +25,10 @@ import _vercel from "./vercel/preset.ts";
 import _winterjs from "./winterjs/preset.ts";
 import _zeabur from "./zeabur/preset.ts";
 import _zerops from "./zerops/preset.ts";
+import _nitro from "./_nitro/preset.ts";
+import _static from "./_static/preset.ts";
 
 export default [
-  ..._nitro,
-  ..._static,
   ..._alwaysdata,
   ..._awsAmplify,
   ..._awsLambda,
@@ -56,4 +54,6 @@ export default [
   ..._winterjs,
   ..._zeabur,
   ..._zerops,
+  ..._nitro,
+  ..._static,
 ] as const;

--- a/test/fixture/node_modules/@fixture/nitro-native-mock/index.js
+++ b/test/fixture/node_modules/@fixture/nitro-native-mock/index.js
@@ -1,0 +1,2 @@
+// Mock native dependency (simulates packages like bufferutil)
+module.exports = "@fixture/nitro-native-mock";

--- a/test/fixture/node_modules/@fixture/nitro-native-mock/package.json
+++ b/test/fixture/node_modules/@fixture/nitro-native-mock/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/nitro-native-mock",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/test/fixture/node_modules/nitro-cjs-untrace/index.js
+++ b/test/fixture/node_modules/nitro-cjs-untrace/index.js
@@ -1,0 +1,5 @@
+// CJS package NOT in traceDeps that require()s a package that IS in traceDeps.
+// Simulates: ws (not traced) -> require('bufferutil') (in NodeNativePackages).
+// Without the fix, @fixture/nitro-native-mock is bundled instead of externalized.
+const nativeDep = require("@fixture/nitro-native-mock");
+module.exports = nativeDep;

--- a/test/fixture/node_modules/nitro-cjs-untrace/package.json
+++ b/test/fixture/node_modules/nitro-cjs-untrace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nitro-cjs-untrace",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/test/fixture/server/routes/modules.ts
+++ b/test/fixture/server/routes/modules.ts
@@ -8,6 +8,9 @@ import depLib from "@fixture/nitro-lib";
 import subpathLib from "@fixture/nitro-lib/subpath";
 // @ts-ignore
 import extraUtils from "@fixture/nitro-utils/extra";
+// @ts-ignore - Untraced CJS package that require()s @fixture/nitro-native-mock (traced).
+// Simulates: ws (not in traceDeps) -> require('bufferutil') (in NodeNativePackages).
+import cjsUntrace from "nitro-cjs-untrace";
 
 export default () => {
   return {
@@ -16,5 +19,6 @@ export default () => {
     depLib, // expected to all be 2.0.0
     subpathLib, // expected to 2.0.0
     extraUtils,
+    cjsUntrace,
   };
 };

--- a/test/presets/node.test.ts
+++ b/test/presets/node.test.ts
@@ -37,4 +37,15 @@ describe("nitro:preset:node-middleware", async () => {
     const serverNodeModules = resolve(ctx.outDir, "server/node_modules");
     expect(existsSync(resolve(serverNodeModules, "@fixture/nitro-utils/extra.mjs"))).toBe(true);
   });
+
+  it("should trace CJS require() dependencies", () => {
+    // Verifies that packages loaded via CJS require() inside bundled code
+    // are properly externalized and traced (not silently bundled as JS).
+    // This covers the case where @rollup/plugin-node-resolve resolves a
+    // require() call with custom: { "node-resolve": { isRequire: true } }.
+    const serverNodeModules = resolve(ctx.outDir, "server/node_modules");
+    expect(existsSync(resolve(serverNodeModules, "@fixture/nitro-native-mock/index.js"))).toBe(
+      true
+    );
+  });
 });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#4093 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->


The resolveId handler had `if (rOpts.custom?.["node-resolve"]) return null;` which blanket-skipped CJS require resolutions, preventing packages like `bufferutil` (in NodeNativePackages) from being externalized and traced even when matched by the include filter.

Fix: check `opts.trace` before skipping. In dev mode (no tracing), skip as before. In production, resolve directly via `tryResolve` to avoid recursion and externalize if the resolved path matches the include filter.

Includes test fixtures (nitro-cjs-untrace → @fixture/nitro-native-mock) and a node preset test that verifies CJS require deps are traced to the output node_modules.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
