### PR TITLE
chore: try new versioning (`[major]..[date]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,5 @@ test/fixture/functions
 .wrangler
 
 CHANGELOG.md
+RELEASE_NOTES.md
 skills/nitro/docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro",
-  "version": "3.0.1-alpha.2",
+  "version": "3.0.260311-beta",
   "description": "Build and Deploy Universal JavaScript Servers",
   "keywords": [
     "api-routes",

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,92 @@
+#!/bin/env node
+import { promises as fsp } from "node:fs";
+import { resolve } from "pathe";
+
+const c = {
+  cyan: (s: string) => `\x1B[36m${s}\x1B[0m`,
+  green: (s: string) => `\x1B[32m${s}\x1B[0m`,
+  yellow: (s: string) => `\x1B[33m${s}\x1B[0m`,
+  gray: (s: string) => `\x1B[90m${s}\x1B[0m`,
+  red: (s: string) => `\x1B[31m${s}\x1B[0m`,
+  bold: (s: string) => `\x1B[1m${s}\x1B[0m`,
+};
+
+function fmtDate(d: Date): string {
+  const y = d.getFullYear() % 100;
+  const m = (d.getMonth() + 1).toString().padStart(2, "0");
+  const day = d.getDate().toString().padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+async function fetchExistingVersions(pkgName: string): Promise<string[]> {
+  const url = `https://registry.npmjs.org/${pkgName}`;
+  console.log(c.gray(`Fetching versions from npm registry for ${c.cyan(pkgName)}...`));
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.log(c.yellow(`  Registry returned ${res.status}, assuming first release`));
+      return [];
+    }
+    const data = (await res.json()) as { versions?: Record<string, unknown> };
+    const versions = Object.keys(data.versions || {});
+    return versions;
+  } catch (err) {
+    console.log(c.yellow(`  Failed to fetch registry: ${err}`));
+    return [];
+  }
+}
+
+async function resolveDateSuffix(pkgName: string, dateStr: string): Promise<string> {
+  const versions = await fetchExistingVersions(pkgName);
+  const prefix = `3.0.${dateStr}-beta`;
+  const matching = versions.filter((v) => v.startsWith(prefix));
+
+  if (matching.length === 0) {
+    console.log(c.gray(`  No existing releases for ${c.cyan(dateStr)}`));
+    return dateStr;
+  }
+
+  let max = 0;
+  for (const v of matching) {
+    const rest = v.slice(prefix.length);
+    if (rest === "") {
+      max = Math.max(max, 1);
+    } else if (rest.startsWith(".")) {
+      const n = Number.parseInt(rest.slice(1), 10);
+      if (!Number.isNaN(n)) {
+        max = Math.max(max, n);
+      }
+    }
+  }
+
+  const suffix = `${dateStr}.${max + 1}`;
+  console.log(c.gray(`  Using suffix ${c.cyan(suffix)}`));
+  return suffix;
+}
+
+async function main() {
+  console.log(c.bold("\nBump version to beta\n"));
+
+  const pkgPath = resolve(process.cwd(), "package.json");
+  const pkg = JSON.parse(await fsp.readFile(pkgPath, "utf8"));
+  const oldVersion = pkg.version;
+
+  const dateStr = fmtDate(new Date());
+  console.log(c.gray(`Date: ${c.cyan(dateStr)}`));
+
+  const suffix = await resolveDateSuffix(pkg.name, dateStr);
+  const newVersion = `3.0.${suffix}-beta`;
+
+  console.log();
+  console.log(`  ${c.cyan(pkg.name)} ${c.gray(oldVersion)} → ${c.green(newVersion)}`);
+
+  pkg.version = newVersion;
+  await fsp.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+  console.log(c.green(`\nDone!\n`));
+}
+
+main().catch((error) => {
+  console.error(c.red(`\nError: ${error.message}\n`));
+  process.exit(1);
+});

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,59 @@
+#!/bin/env node
+import { execSync } from "node:child_process";
+import { parseArgs } from "node:util";
+
+const { values: args } = parseArgs({
+  allowNegative: true,
+  options: {
+    tests: { type: "boolean", default: true },
+  },
+});
+
+const c = {
+  cyan: (s: string) => `\x1B[36m${s}\x1B[0m`,
+  green: (s: string) => `\x1B[32m${s}\x1B[0m`,
+  red: (s: string) => `\x1B[31m${s}\x1B[0m`,
+  bold: (s: string) => `\x1B[1m${s}\x1B[0m`,
+  gray: (s: string) => `\x1B[90m${s}\x1B[0m`,
+};
+
+function run(cmd: string, opts?: { silent?: boolean }) {
+  console.log(c.gray(`$ ${cmd}`));
+  return execSync(cmd, {
+    stdio: opts?.silent ? "pipe" : "inherit",
+    encoding: "utf8",
+  });
+}
+
+async function main() {
+  console.log(c.bold("\n🚀 Nitro Release\n"));
+
+  // 1. Test
+  if (!args.tests) {
+    console.log(c.gray("→ Skipping tests (--no-tests)\n"));
+  } else {
+    console.log(c.cyan("→ Running tests...\n"));
+    run("pnpm test");
+  }
+
+  // 2. Build
+  console.log(c.cyan("\n→ Building...\n"));
+  run("pnpm build");
+
+  // 3. Bump version
+  console.log(c.cyan("\n→ Bumping version...\n"));
+  run("node scripts/bump-version.ts");
+
+  // 4. Generate release notes
+  console.log(c.cyan("\n→ Generating release notes...\n"));
+  run("pnpx changelogen --output CHANGELOG.md");
+  console.log(c.green("  Written to CHANGELOG.md"));
+  execSync("code CHANGELOG.md", { stdio: "ignore" });
+
+  console.log(c.green(c.bold("\n✅ Release prepared!\n")));
+}
+
+main().catch((error) => {
+  console.error(c.red(`\nError: ${error.message}\n`));
+  process.exit(1);
+});


### PR DESCRIPTION
Trying a new verisoning convention for Nitro. `[major]..[date]` like `3.0.260311`

Nitro releases are different from most of the npm packages. We are rolling out changes based on platforms (and ecosystem) updates. 

We introduced a `compatibilityDate` flag in v2 to pin the platform's compatibility support per preset, and it will be supported as an opt-in way when needed (it defaults to `latest`).

Another benefit of versioning in name is that we can clearly signal to users when they are using an outdated version (even if they don't need the latest features). Keeping an old version is not the best idea for platforms.

With this system, we can also roll out versions more often. Previously, we were bound to strict minor vs patch cycles. Releases can go out even on a weekly basis now.

Major is reserved for Nitro API breaking changes. Second digit is unused for now (it is also a failsafe if we want to be back on normal semver for anyreason, since `3.2026` would be `> 3.1`.)

