### PR TITLE
refactor: use built-in escapeRegExp util

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "destr": "^2.0.5",
     "dot-prop": "^10.1.0",
     "edge-runtime": "^4.0.1",
-    "escape-string-regexp": "^5.0.0",
+    "tiny-escape": "^1.1.0",
     "etag": "^1.8.1",
     "execa": "^9.6.1",
     "expect-type": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "destr": "^2.0.5",
     "dot-prop": "^10.1.0",
     "edge-runtime": "^4.0.1",
-    "tiny-escape": "^1.1.0",
     "etag": "^1.8.1",
     "execa": "^9.6.1",
     "expect-type": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,6 @@ importers:
       edge-runtime:
         specifier: ^4.0.1
         version: 4.0.1
-      escape-string-regexp:
-        specifier: ^5.0.0
-        version: 5.0.0
       etag:
         specifier: ^1.8.1
         version: 1.8.1

--- a/src/config/resolvers/imports.ts
+++ b/src/config/resolvers/imports.ts
@@ -1,6 +1,6 @@
-import escapeRE from "tiny-escape";
 import type { NitroOptions } from "nitro/types";
 import { join } from "pathe";
+import { escapeRegExp } from "../../utils/regex.ts";
 
 export async function resolveImportsOptions(options: NitroOptions) {
   // Skip loader entirely if imports disabled
@@ -27,7 +27,7 @@ export async function resolveImportsOptions(options: NitroOptions) {
     options.imports.exclude.push(
       scanDirsInNodeModules.length > 0
         ? new RegExp(
-            `node_modules\\/(?!${scanDirsInNodeModules.map((dir) => escapeRE(dir)).join("|")})`
+            `node_modules\\/(?!${scanDirsInNodeModules.map((dir) => escapeRegExp(dir)).join("|")})`
           )
         : /[/\\]node_modules[/\\]/
     );

--- a/src/config/resolvers/imports.ts
+++ b/src/config/resolvers/imports.ts
@@ -1,4 +1,4 @@
-import escapeRE from "escape-string-regexp";
+import escapeRE from "tiny-escape";
 import type { NitroOptions } from "nitro/types";
 import { join } from "pathe";
 


### PR DESCRIPTION
tiny-escape has the same API as escape-string-regexp. Ships ESM + CJS with built-in TypeScript types. 192 bytes gzipped, zero deps.

https://npmgraph.js.org/?q=tiny-escape