### PR TITLE
feat(cloudflare): support durable instance selection

### DIFF
--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -146,6 +146,49 @@ Then you can deploy the application with:
 
 :pm-x{command="wrangler pages deploy"}
 
+## Cloudflare Durable Objects
+
+**Preset:** `cloudflare_durable`
+
+Use this preset when Nitro should route websocket traffic through its internal Durable Object.
+
+```ts [nitro.config.ts]
+import { defineNitroConfig } from "nitro/config";
+
+export default defineNitroConfig({
+  preset: "cloudflare_durable",
+  cloudflare: {
+    deployConfig: true,
+    durable: {
+      bindingName: "NitroDurable",
+      instanceName: "app-server",
+      resolver: "./server/utils/cloudflare-durable-resolver.ts"
+    }
+  }
+})
+```
+
+Nitro defaults to one internal binding named `$DurableObject` and one default instance named `server`.
+The optional resolver must export a default function that returns the instance name for a request; returning `undefined` falls back to `instanceName`, then `server`.
+
+```ts [server/utils/cloudflare-durable-resolver.ts]
+import type { CloudflareDurableResolver } from "nitro/types";
+
+const resolveInstanceName: CloudflareDurableResolver = ({
+  request,
+  defaultInstanceName
+}) => {
+  const room = request
+    ? new URL(request.url).searchParams.get("room")
+    : undefined;
+  return room || defaultInstanceName;
+};
+
+export default resolveInstanceName;
+```
+
+With `deployConfig: true`, Nitro still generates one Durable Object binding in `wrangler.json` for its internal `$DurableObject` class. Resolver-based sharding only changes the runtime instance id. If you do not want Nitro-managed Durable Object routing, use `cloudflare_module` instead.
+
 
 ## Deploy within CI/CD using GitHub Actions
 

--- a/src/build/virtual/_all.ts
+++ b/src/build/virtual/_all.ts
@@ -1,5 +1,6 @@
 import type { Nitro } from "nitro/types";
 
+import cloudflareDurable from "./cloudflare-durable.ts";
 import database from "./database.ts";
 import errorHandler from "./error-handler.ts";
 import featureFlags from "./feature-flags.ts";
@@ -24,6 +25,7 @@ export function virtualTemplates(
   _polyfills: string[]
 ): VirtualTemplate[] {
   const nitroTemplates = [
+    cloudflareDurable,
     database,
     errorHandler,
     featureFlags,

--- a/src/build/virtual/cloudflare-durable.ts
+++ b/src/build/virtual/cloudflare-durable.ts
@@ -1,0 +1,49 @@
+import type { Nitro } from "nitro/types";
+import { resolveModulePath } from "exsolve";
+import { prettyPath } from "../../utils/fs.ts";
+
+const RESOLVE_EXTENSIONS = [".ts", ".js", ".mts", ".mjs"];
+const DEFAULT_DURABLE_BINDING_NAME = "$DurableObject";
+const DEFAULT_DURABLE_INSTANCE_NAME = "server";
+
+export default function cloudflareDurable(nitro: Nitro) {
+  return {
+    id: "#nitro/virtual/cloudflare-durable",
+    template: async () => {
+      const bindingName =
+        nitro.options.cloudflare?.durable?.bindingName ||
+        DEFAULT_DURABLE_BINDING_NAME;
+      const instanceName =
+        nitro.options.cloudflare?.durable?.instanceName ||
+        DEFAULT_DURABLE_INSTANCE_NAME;
+      const resolver = resolveDurableResolver(nitro);
+
+      return /* js */ `
+${resolver ? `export { default as resolveInstanceName } from ${JSON.stringify(resolver)};` : "export const resolveInstanceName = undefined;"}
+export const bindingName = ${JSON.stringify(bindingName)};
+export const instanceName = ${JSON.stringify(instanceName)};
+`;
+    },
+  };
+}
+
+function resolveDurableResolver(nitro: Nitro) {
+  const resolverPath = nitro.options.cloudflare?.durable?.resolver;
+  if (!resolverPath) {
+    return;
+  }
+
+  const resolverEntry = resolveModulePath(resolverPath, {
+    from: nitro.options.rootDir,
+    extensions: RESOLVE_EXTENSIONS,
+    try: true,
+  });
+
+  if (!resolverEntry) {
+    nitro.logger.warn(
+      `Your custom Cloudflare durable resolver \`${prettyPath(resolverPath)}\` file does not exist.`
+    );
+  }
+
+  return resolverEntry;
+}

--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -2,6 +2,7 @@ import { defineNitroPreset } from "../_utils/preset.ts";
 import { writeFile } from "../_utils/fs.ts";
 import type { Nitro } from "nitro/types";
 import { resolve } from "pathe";
+import type { CloudflareOptions } from "./types.ts";
 import { unenvCfExternals } from "./unenv/preset.ts";
 import {
   enableNodeCompat,
@@ -13,7 +14,7 @@ import {
 import { cloudflareDevModule } from "./dev.ts";
 import { setupEntryExports } from "./entry-exports.ts";
 
-export type { CloudflareOptions as PresetOptions } from "./types.ts";
+export type PresetOptions = CloudflareOptions;
 
 const cloudflarePages = defineNitroPreset(
   {
@@ -173,3 +174,8 @@ export default [
   cloudflareDurable,
   cloudflareDev,
 ];
+
+export {
+  type CloudflareDurableResolver,
+  type CloudflareDurableResolverContext,
+} from "./types.ts";

--- a/src/presets/cloudflare/runtime/_durable.ts
+++ b/src/presets/cloudflare/runtime/_durable.ts
@@ -1,0 +1,65 @@
+import type * as CF from "@cloudflare/workers-types";
+import type {
+  CloudflareDurableResolver,
+  CloudflareDurableResolverContext,
+} from "../types.ts";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface ResolveDurableStubOptions {
+  bindingName: string;
+  instanceName: string;
+  request?: Request;
+  env: Record<string, unknown>;
+  context?: CF.ExecutionContext;
+  resolveInstanceName?: CloudflareDurableResolver;
+}
+
+export async function getDurableStub({
+  bindingName,
+  instanceName,
+  request,
+  env,
+  context,
+  resolveInstanceName,
+}: ResolveDurableStubOptions) {
+  const binding = env[bindingName] as CF.DurableObjectNamespace | undefined;
+  if (!binding) {
+    throw new Error(`Durable Object binding "${bindingName}" not available.`);
+  }
+
+  const durableInstanceName = await resolveDurableInstanceName({
+    request,
+    env,
+    context,
+    defaultInstanceName: instanceName,
+    resolveInstanceName,
+  });
+
+  return binding.get(binding.idFromName(durableInstanceName));
+}
+
+export async function resolveDurableInstanceName({
+  request,
+  env,
+  context,
+  defaultInstanceName,
+  resolveInstanceName,
+}: CloudflareDurableResolverContext & {
+  resolveInstanceName?: CloudflareDurableResolver;
+}) {
+  const durableInstanceName = await resolveMaybe(
+    resolveInstanceName?.({
+      request,
+      env,
+      context,
+      defaultInstanceName,
+    })
+  );
+
+  return durableInstanceName || defaultInstanceName || "server";
+}
+
+async function resolveMaybe<T>(value: MaybePromise<T> | undefined) {
+  return value ? await value : value;
+}

--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -6,36 +6,36 @@ import { createHandler, augmentReq } from "./_module-handler.ts";
 
 import { useNitroApp, useNitroHooks } from "nitro/app";
 import { isPublicAssetURL } from "#nitro/virtual/public-assets";
+import {
+  bindingName,
+  instanceName,
+  resolveInstanceName,
+} from "#nitro/virtual/cloudflare-durable";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { hasWebSocket } from "#nitro/virtual/feature-flags";
-
-const DURABLE_BINDING = "$DurableObject";
-const DURABLE_INSTANCE = "server";
+import { getDurableStub } from "./_durable.ts";
 
 interface Env {
   ASSETS?: { fetch: typeof CF.fetch };
-  [DURABLE_BINDING]?: CF.DurableObjectNamespace;
+  [key: string]: unknown;
 }
 
 const nitroApp = useNitroApp();
 const nitroHooks = useNitroHooks();
 
-const getDurableStub = (env: Env) => {
-  const binding = env[DURABLE_BINDING];
-  if (!binding) {
-    throw new Error(
-      `Durable Object binding "${DURABLE_BINDING}" not available.`
-    );
-  }
-  const id = binding.idFromName(DURABLE_INSTANCE);
-  return binding.get(id);
-};
-
 const ws = hasWebSocket
   ? wsAdapter({
       resolve: resolveWebsocketHooks,
-      instanceName: DURABLE_INSTANCE,
-      bindingName: DURABLE_BINDING,
+      resolveDurableStub(request, env, context) {
+        return getDurableStub({
+          bindingName,
+          instanceName,
+          request: request as Request | undefined,
+          env: env as Env,
+          context,
+          resolveInstanceName,
+        });
+      },
     })
   : undefined;
 
@@ -47,8 +47,17 @@ export default createHandler<Env>({
     }
 
     // Expose stub fetch to the context
-    ctxExt.durableFetch = (req = request) =>
-      getDurableStub(env).fetch(req as any);
+    ctxExt.durableFetch = async (req = request) =>
+      (
+        await getDurableStub({
+          bindingName,
+          instanceName,
+          request,
+          env,
+          context,
+          resolveInstanceName,
+        })
+      ).fetch(req as any);
 
     // Websocket upgrade
     // https://crossws.unjs.io/adapters/cloudflare#durable-objects

--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -14,6 +14,17 @@ import type {
 
 export type WranglerConfig = Partial<Omit<_Config, keyof _ComputedFields>>;
 
+export interface CloudflareDurableResolverContext {
+  request?: Request;
+  env: unknown;
+  context?: ExecutionContext;
+  defaultInstanceName: string;
+}
+
+export type CloudflareDurableResolver = (
+  context: CloudflareDurableResolverContext
+) => string | undefined | Promise<string | undefined>;
+
 /**
  * https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes
  */
@@ -61,6 +72,15 @@ export interface CloudflareOptions {
     configPath?: string;
     environment?: string;
     persistDir?: string;
+  };
+
+  durable?: {
+    /** @default "$DurableObject" */
+    bindingName?: string;
+    /** @default "server" */
+    instanceName?: string;
+    /** Path to a module exporting the default instance-name resolver. */
+    resolver?: string;
   };
 
   pages?: {

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -18,6 +18,9 @@ import {
 } from "ufo";
 import { unenvCfNodeCompat } from "./unenv/preset.ts";
 
+const DURABLE_CLASS_NAME = "$DurableObject";
+const DURABLE_BINDING_NAME = "$DurableObject";
+
 export async function writeCFRoutes(nitro: Nitro) {
   const _cfPagesConfig = nitro.options.cloudflare?.pages || {};
   const routes: CloudflarePagesRoutes = {
@@ -327,6 +330,26 @@ export async function writeWranglerConfig(
         type: "ESModule",
         globs: ["**/*.mjs", "**/*.js"],
       });
+    }
+
+    if (nitro.options.preset === "cloudflare-durable") {
+      const bindingName =
+        nitro.options.cloudflare?.durable?.bindingName || DURABLE_BINDING_NAME;
+      wranglerConfig.durable_objects ??= { bindings: [] };
+      wranglerConfig.durable_objects.bindings ??= [];
+
+      if (
+        !wranglerConfig.durable_objects.bindings.some(
+          (binding) =>
+            binding.name === bindingName &&
+            binding.class_name === DURABLE_CLASS_NAME
+        )
+      ) {
+        wranglerConfig.durable_objects.bindings.push({
+          name: bindingName,
+          class_name: DURABLE_CLASS_NAME,
+        });
+      }
     }
   }
 

--- a/src/runtime/virtual/cloudflare-durable.ts
+++ b/src/runtime/virtual/cloudflare-durable.ts
@@ -1,0 +1,7 @@
+import "./_runtime_warn.ts";
+import type { CloudflareDurableResolver } from "nitro/types";
+
+export const bindingName = "$DurableObject";
+export const instanceName = "server";
+export const resolveInstanceName: CloudflareDurableResolver | undefined =
+  undefined;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,10 @@ import "nitro/task";
 export * from "./fetch/index.ts";
 export * from "./runtime/index.ts";
 export * from "./config.ts";
+export type {
+  CloudflareDurableResolver,
+  CloudflareDurableResolverContext,
+} from "../presets/cloudflare/types.ts";
 export * from "./runner.ts";
 export * from "./global.ts";
 export * from "./h3.ts";

--- a/test/fixture/server/utils/cloudflare-durable-resolver.ts
+++ b/test/fixture/server/utils/cloudflare-durable-resolver.ts
@@ -1,0 +1,15 @@
+import type { CloudflareDurableResolver } from "nitro/types";
+
+const resolveInstanceName: CloudflareDurableResolver = ({
+  request,
+  defaultInstanceName,
+}) => {
+  if (!request) {
+    return;
+  }
+
+  const room = new URL(request.url).searchParams.get("room");
+  return room || defaultInstanceName;
+};
+
+export default resolveInstanceName;

--- a/test/presets/cloudflare-durable.test.ts
+++ b/test/presets/cloudflare-durable.test.ts
@@ -1,0 +1,69 @@
+import { promises as fsp } from "node:fs";
+import { resolve } from "pathe";
+import { describe, expect, it } from "vitest";
+
+import { setupTest } from "../tests.ts";
+
+describe("nitro:preset:cloudflare-durable", async () => {
+  const staticCtx = await setupTest("cloudflare-durable", {
+    outDirSuffix: "-static",
+    config: {
+      cloudflare: {
+        durable: {
+          bindingName: "MyCustomDO",
+          instanceName: "app-server",
+        },
+      },
+    },
+  });
+
+  const resolverCtx = await setupTest("cloudflare-durable", {
+    outDirSuffix: "-resolver",
+    config: {
+      cloudflare: {
+        durable: {
+          bindingName: "ResolverDO",
+          instanceName: "fallback-server",
+          resolver: "./server/utils/cloudflare-durable-resolver.ts",
+        },
+      },
+    },
+  });
+
+  it("uses custom durable binding and instance names in the built worker", async () => {
+    const entry = await fsp.readFile(
+      resolve(staticCtx.outDir, "server", "index.mjs"),
+      "utf8"
+    );
+
+    expect(entry).toContain('bindingName: "MyCustomDO"');
+    expect(entry).toContain('instanceName: "app-server"');
+    expect(entry).not.toContain('instanceName: "server"');
+  });
+
+  it("generates a durable object binding for the configured binding name", async () => {
+    const wranglerConfig = await fsp
+      .readFile(resolve(staticCtx.outDir, "server", "wrangler.json"), "utf8")
+      .then((r) => JSON.parse(r));
+
+    expect(wranglerConfig.durable_objects?.bindings).toEqual([
+      {
+        name: "MyCustomDO",
+        class_name: "$DurableObject",
+      },
+    ]);
+  });
+
+  it("bundles the configured resolver module into the worker entry", async () => {
+    const entry = await fsp.readFile(
+      resolve(resolverCtx.outDir, "server", "index.mjs"),
+      "utf8"
+    );
+
+    expect(entry).toContain(
+      "resolveInstanceName: cloudflare_durable_resolver_default"
+    );
+    expect(entry).toContain('searchParams.get("room")');
+    expect(entry).toContain('instanceName: "fallback-server"');
+  });
+});

--- a/test/unit/cloudflare-durable.test.ts
+++ b/test/unit/cloudflare-durable.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getDurableStub,
+  resolveDurableInstanceName,
+} from "../../src/presets/cloudflare/runtime/_durable.ts";
+
+describe("cloudflare durable helpers", () => {
+  it("falls back to the configured default instance name", async () => {
+    await expect(
+      resolveDurableInstanceName({
+        env: {},
+        defaultInstanceName: "app-server",
+      })
+    ).resolves.toBe("app-server");
+    await expect(
+      resolveDurableInstanceName({
+        env: {},
+        defaultInstanceName: "",
+      })
+    ).resolves.toBe("server");
+  });
+
+  it("uses the resolver result when available", async () => {
+    await expect(
+      resolveDurableInstanceName({
+        request: new Request("https://nitro.build/chat"),
+        env: { foo: "bar" },
+        defaultInstanceName: "app-server",
+        resolveInstanceName: ({ request }) =>
+          request?.url.includes("/chat") ? "chat-room" : undefined,
+      })
+    ).resolves.toBe("chat-room");
+  });
+
+  it("resolves a durable stub with requestless fallback", async () => {
+    const get = vi.fn();
+    const idFromName = vi.fn(() => "durable-id");
+
+    await getDurableStub({
+      bindingName: "$DurableObject",
+      instanceName: "app-server",
+      env: {
+        $DurableObject: {
+          idFromName,
+          get,
+        },
+      },
+    });
+
+    expect(idFromName).toHaveBeenCalledWith("app-server");
+    expect(get).toHaveBeenCalledWith("durable-id");
+  });
+});


### PR DESCRIPTION
## Summary
- add `cloudflare.durable.instanceName` and `cloudflare.durable.resolver`
- route Nitro durable-object stub resolution through a shared helper and virtual module
- generate the internal durable object binding in `wrangler.json` for `cloudflare_durable`
- add docs and regression coverage for static and resolver-based instance selection

## Verification
- `pnpm build --stub`
- `pnpm lint:fix`
- `pnpm test:types`
- `pnpm vitest run test/unit/cloudflare-durable.test.ts test/presets/cloudflare-durable.test.ts`
- `pnpm vitest run test/presets/cloudflare-module.test.ts test/presets/cloudflare-pages.test.ts`