### PR TITLE
fix(dev): prevent X-Forwarded-For spoofing on Unix socket VFS access

### DIFF
--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -14,10 +14,8 @@ export function createVFSHandler(nitro: Nitro) {
       // Socket is readable/writable but has no port info
       socket?.readable && socket?.writable && !socket?.remotePort;
 
-    // Never trust X-Forwarded-For for VFS access - it's attacker-controlled
     const ip = getRequestIP(event, { xForwardedFor: false });
 
-    // Deny access on Unix socket since IP cannot be reliably determined
     if (isUnixSocket) {
       throw new HTTPError({
         statusText: "VFS access not available on Unix socket",

--- a/test/unit/vfs-security.test.ts
+++ b/test/unit/vfs-security.test.ts
@@ -3,6 +3,13 @@ import { mockEvent } from "h3";
 import { createVFSHandler } from "../../src/dev/vfs.ts";
 import type { Nitro } from "nitro/types";
 
+function createMockNitro() {
+  return {
+    options: { rootDir: "/test/root" },
+    vfs: new Map([["/test/root/test.js", { render: () => "test content" }]]),
+  } as unknown as Nitro;
+}
+
 // Mock a socket that appears to be a Unix socket
 function createUnixSocketMock() {
   return {
@@ -52,13 +59,7 @@ function createMockEvent(
 
 describe("VFS Security - X-Forwarded-For spoofing on Unix socket", () => {
   it("should reject requests with spoofed X-Forwarded-For header on Unix socket", async () => {
-    // Create a mock Nitro instance with some VFS content
-    const mockNitro = {
-      options: {
-        rootDir: "/test/root",
-      },
-      vfs: new Map([["/test/root/test.js", { render: () => "test content" }]]),
-    } as unknown as Nitro;
+    const mockNitro = createMockNitro();
 
     const handler = createVFSHandler(mockNitro);
 
@@ -73,12 +74,7 @@ describe("VFS Security - X-Forwarded-For spoofing on Unix socket", () => {
   });
 
   it("should reject requests without X-Forwarded-For on Unix socket", async () => {
-    const mockNitro = {
-      options: {
-        rootDir: "/test/root",
-      },
-      vfs: new Map([["/test/root/test.js", { render: () => "test content" }]]),
-    } as unknown as Nitro;
+    const mockNitro = createMockNitro();
 
     const handler = createVFSHandler(mockNitro);
 
@@ -91,12 +87,7 @@ describe("VFS Security - X-Forwarded-For spoofing on Unix socket", () => {
   });
 
   it("should reject requests from non-local IP on regular network socket", async () => {
-    const mockNitro = {
-      options: {
-        rootDir: "/test/root",
-      },
-      vfs: new Map([["/test/root/test.js", { render: () => "test content" }]]),
-    } as unknown as Nitro;
+    const mockNitro = createMockNitro();
 
     const handler = createVFSHandler(mockNitro);
 
@@ -109,12 +100,7 @@ describe("VFS Security - X-Forwarded-For spoofing on Unix socket", () => {
   });
 
   it("should NOT trust X-Forwarded-For header on regular network socket", async () => {
-    const mockNitro = {
-      options: {
-        rootDir: "/test/root",
-      },
-      vfs: new Map([["/test/root/test.js", { render: () => "test content" }]]),
-    } as unknown as Nitro;
+    const mockNitro = createMockNitro();
 
     const handler = createVFSHandler(mockNitro);
 


### PR DESCRIPTION
🔗 Linked issue
#4103

❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes a security issue)

📚 Description
This PR fixes a security vulnerability where the VFS handler trusted the `X-Forwarded-For` header when running on a Unix socket behind a reverse proxy.

**The vulnerability:**
When `NITRO_UNIX_SOCKET` is used, the code passed `{ xForwardedFor: isUnixSocket }` to `getRequestIP()`. An attacker behind a reverse proxy could send `X-Forwarded-For: 127.0.0.1` to satisfy the localhost check and access VFS content (application source code).

**The fix:**
1. Never trust `X-Forwarded-For` for VFS access - it's attacker-controlled
2. Deny access on Unix socket entirely since IP cannot be reliably determined

📝 Checklist
- [x] I have linked an issue or discussion.
- [x] I have added tests (4 new security tests)
- [x] I have run `pnpm format` and `pnpm typecheck`