### PR TITLE
fix(route-meta): unique handlers by hash + method + route

### DIFF
--- a/src/build/virtual/routing-meta.ts
+++ b/src/build/virtual/routing-meta.ts
@@ -4,9 +4,10 @@ export default function routingMeta(nitro: Nitro) {
   return {
     id: "#nitro/virtual/routing-meta",
     template: () => {
+      const handlers = Object.values(nitro.routing.routes.routes).flatMap((h) => h.data);
       const routeHandlers = uniqueBy(
-        Object.values(nitro.routing.routes.routes).flatMap((h) => h.data),
-        "_importHash"
+        handlers,
+        (h) => `${h._importHash}_${h.method?.toLowerCase() || ""}_${h.route || ""}`
       );
 
       return /* js */ `
@@ -14,7 +15,7 @@ export default function routingMeta(nitro: Nitro) {
     .map((h) => /* js */ `import ${h._importHash}Meta from "${h.handler}?meta";`)
     .join("\n")}
 export const handlersMeta = [
-  ${routeHandlers
+  ${handlers
     .map(
       (h) =>
         /* js */ `{ route: ${JSON.stringify(h.route)}, method: ${JSON.stringify(
@@ -28,6 +29,6 @@ export const handlersMeta = [
   };
 }
 
-function uniqueBy<T>(arr: T[], key: keyof T): T[] {
-  return [...new Map(arr.map((item) => [item[key], item])).values()];
+function uniqueBy<T>(arr: T[], key: (item: T) => string): T[] {
+  return [...new Map(arr.map((item) => [key(item), item])).values()];
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- N/A -->

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Nitro itself follows a one-file-per-route convention, so this issue does not occur in standard usage. However, integrations like [Vercube](https://github.com/vercube/vercube) register multiple routes from a single file - each class method can be a separate route handler - which exposed the bug.

When a single handler file registered multiple routes, `handlersMeta` in the `routing-meta` virtual module only contained the last route. This happened because `uniqueBy` was applied to the full handler list before building both the imports and the meta array.

The fix separates the two concerns: imports are deduplicated by `_importHash` (one import per file), while `handlersMeta` uses the full unfiltered handler list so all routes are correctly included.

Note: this PR only resolves the route registration problem. Proper per-route metadata resolution (where each route from the same file could carry its own metadata) is a separate concern and will be addressed as a follow-up.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
