### PR TITLE
fix(route-meta): deduplicate routing-meta imports by _importHash only

### DIFF
--- a/src/build/virtual/routing-meta.ts
+++ b/src/build/virtual/routing-meta.ts
@@ -5,10 +5,7 @@ export default function routingMeta(nitro: Nitro) {
     id: "#nitro/virtual/routing-meta",
     template: () => {
       const handlers = Object.values(nitro.routing.routes.routes).flatMap((h) => h.data);
-      const routeHandlers = uniqueBy(
-        handlers,
-        "_importHash"
-      );
+      const routeHandlers = uniqueBy(handlers, "_importHash");
 
       return /* js */ `
   ${routeHandlers


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #4119

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

In #4119 I made an error - the `uniqueBy` key was incorrectly set to `hash + method + route`, which caused the same import to be generated multiple times for a single file with multiple routes (one duplicate import per route).

The fix reverts the deduplication key back to `_importHash` only for imports (one import per file), while `handlersMeta` still uses the full unfiltered handler list so all routes are correctly included.

Now work as intended.

| Before | After |
|--------|--------|
|  <img width="1645" height="324" alt="obraz" src="https://github.com/user-attachments/assets/daeebdc0-6d38-4fe5-a952-fd32f394a423" />  |  <img width="1645" height="324" alt="obraz" src="https://github.com/user-attachments/assets/550be8f9-cef3-4d6b-9c36-4f8253f75db7" />  |

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
