### PR TITLE
fix(cache): respect zero ttl

### DIFF
--- a/src/config/resolvers/route-rules.ts
+++ b/src/config/resolvers/route-rules.ts
@@ -49,8 +49,8 @@ export function normalizeRouteRules(config: NitroConfig): Record<string, NitroRo
         ...routeRules.headers,
       };
     }
-    // Cache: swr
-    if (routeConfig.swr) {
+    // Cache: swr - allow `swr: 0` to set maxAge=0 (no cache)
+    if (routeConfig.swr != null && routeConfig.swr !== false) {
       routeRules.cache = routeRules.cache || {};
       routeRules.cache.swr = true;
       if (typeof routeConfig.swr === "number") {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #4125
Fixes: https://github.com/nuxt/nuxt/issues/34307

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`swr: 0` set in `nuxt.config.ts` (see linked issue to Nuxt) it should be handled like `max-age=0` - but it will be ignored, because Nitro checks `if (swr)` what is false with 0, too.
This fix checks explicitly for 0.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
