### PR TITLE
fix: guard against `createRequire(import.meta.url)` in bundled output

### DIFF
--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -26,13 +26,10 @@ function guardCreateRequire(): Plugin {
     name: "nitro:cloudflare-guard-createRequire",
     generateBundle(_options, bundle) {
       for (const chunk of Object.values(bundle)) {
-        if (
-          chunk.type === "chunk" &&
-          chunk.code?.includes("createRequire(import.meta.url)")
-        ) {
+        if (chunk.type === "chunk" && chunk.code?.includes("createRequire(import.meta.url)")) {
           chunk.code = chunk.code.replace(
             /createRequire\(import\.meta\.url\)/g,
-            'createRequire(import.meta.url || "file:///")',
+            'createRequire(import.meta.url || "file:///")'
           );
         }
       }


### PR DESCRIPTION
## Problem

When `rolldown-vite` (or other bundlers) bundles SSR apps for Cloudflare Workers, it emits `createRequire(import.meta.url)` in shared chunks. On the Workers runtime, `import.meta.url` is `undefined`, so `createRequire` throws `TypeError: The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received undefined` — crashing every route.

See https://github.com/vitejs/vite/issues/21962 for the upstream Vite issue.

Fixes #4132

## Solution

Adds a rollup output plugin (`nitro:cloudflare-guard-createRequire`) to the **cloudflare-module**, **cloudflare-pages**, and **cloudflare-durable** presets that rewrites:

```js
createRequire(import.meta.url)
```

to:

```js
createRequire(import.meta.url || "file:///")
```

in the `generateBundle` hook, after all other transforms have completed.

The `"file:///"` fallback allows `createRequire` to construct a valid resolver. Any subsequent `require()` calls go through the normal Node.js compat layer provided by the Workers runtime (with the `nodejs_compat` flag).

## Why defense-in-depth

This is a defense-in-depth fix on the Nitro side. The root cause is in rolldown-vite (vitejs/vite#21962), but since Nitro controls the final output and knows the target is Cloudflare Workers, it can safely guard against this pattern regardless of which bundler is used upstream.

## Affected presets

- `cloudflare-module`
- `cloudflare-pages`
- `cloudflare-durable` (inherits from `cloudflare-module`)