### PR TITLE
fix: exclude `wrangler` from generated `NitroRuntimeConfig` type

### DIFF
--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -137,7 +137,7 @@ export async function writeTypes(nitro: Nitro) {
           await resolveSchema(
             Object.fromEntries(
               Object.entries(nitro.options.runtimeConfig).filter(
-                ([key]) => !["app", "nitro"].includes(key)
+                ([key]) => !["app", "nitro", "wrangler"].includes(key)
               )
             ) as Record<string, JSValue>
           ),


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4148

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Cloudflare dev preset (`src/presets/cloudflare/dev.ts`) injects a `wrangler` key into `runtimeConfig` at module installation time to share Miniflare configuration (config path, persist dir, environment) with the runtime plugin.

However, this internal key is not filtered out during type generation in `src/build/types.ts`. The existing filter only excludes `app` and `nitro`:

```ts
Object.entries(nitro.options.runtimeConfig).filter(
  ([key]) => !["app", "nitro"].includes(key)
)
```

This causes `wrangler` to appear in the generated `NitroRuntimeConfig` interface (`node_modules/.nitro/types/nitro-config.d.ts`), which then produces a type error in the user's `nitro.config.ts` because `wrangler` is a required property that the user never defined.

**Steps to reproduce:**

1. Create a Nitro project with `preset: 'cloudflare_module'`
2. Run `nitro dev` (or `nitro prepare` — the Cloudflare dev module runs in both)
3. Stop the dev server
4. Run `tsc --noEmit`
5. Type error: `Property 'wrangler' is missing in type '...' but required in type 'NitroRuntimeConfig'`

**Fix:** Add `wrangler` to the exclusion list alongside `app` and `nitro`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
