### PR TITLE
fix(runtime): avoid infinite recursion in fetch for external URLs

### DIFF
--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -90,7 +90,7 @@ export function fetch(
     return serverFetch(resource, init, context);
   }
   resource = (resource as any)._request || resource; // unwrap srvx request
-  return fetch(resource, init);
+  return globalThis.fetch(resource, init);
 }
 
 function createNitroApp(): NitroApp {

--- a/test/fixture/server/routes/fetch.ts
+++ b/test/fixture/server/routes/fetch.ts
@@ -10,6 +10,9 @@ export default async () => {
     ).then((res) => res.json()),
     "nitro/runtime.serverFetch": await runtimeServerFetch("/api/hello").then((res) => res.json()),
     "nitro/runtime.fetch": await runtimeFetch("/api/hello").then((res) => res.json()),
+    "nitro/runtime.fetch.url": await runtimeFetch(new URL("http://localhost/api/hello")).then(
+      (res) => res.json()
+    ),
     "nitro/serverFetch": await nitroServerFetch("/api/hello").then((res) => res.json()),
     "nitro/fetch": await nitroFetch("/api/hello").then((res) => res.json()),
   };


### PR DESCRIPTION
## Description

The exported `fetch` function in `src/runtime/internal/app.ts` shadows the global `fetch`, causing it to recursively call itself when handling non-root-relative URLs (e.g., full URL strings, `URL` objects, or `Request` objects for external endpoints). This results in a `RangeError: Maximum call stack size exceeded`.

## Root Cause

In the `fetch()` function, the fallback branch for external URLs calls `fetch(resource, init)` — which resolves to the local function itself rather than the native `globalThis.fetch`:

```ts
// Before (broken)
return fetch(resource, init);
```

## Fix

Explicitly use `globalThis.fetch` to delegate external requests to the runtime's native fetch implementation:

```ts
// After (fixed)
return globalThis.fetch(resource, init);
```

## Changes

- **`src/runtime/internal/app.ts`**: Changed `fetch(resource, init)` → `globalThis.fetch(resource, init)` on the external URL fallback path.
- **`test/fixture/server/routes/fetch.ts`**: Added a regression test case using a `URL` object to verify external fetch does not recurse.

## How to reproduce

Call `fetch(new URL('https://example.com'))` or `fetch('https://example.com')` from any Nitro route handler — it crashes with a stack overflow.

## Linked Issues

N/A (discovered during code review)