### PR TITLE
fix(cache): sanitize cache key segments to prevent ENOTDIR on fs drivers

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -13,6 +13,16 @@ import type { CacheOptions, CachedEventHandlerOptions } from "nitro/types";
 
 let _storageReady = false;
 
+/**
+ * Sanitize a cache group or name so it is safe for filesystem-based storage
+ * drivers (fs, fs-lite). Unstorage maps ":" to "/" on disk, so any "/" already
+ * present in the value would create unexpected directory nesting and cause
+ * ENOTDIR errors when a path is both a file and a prefix of another path.
+ */
+function sanitizeCacheKey(value: string | undefined): string | undefined {
+  return value?.replace(/\//g, "_");
+}
+
 function ensureStorage() {
   if (_storageReady) {
     return;
@@ -37,9 +47,10 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 ): (...args: ArgsT) => Promise<T> {
   ensureStorage();
   return _defineCachedFunction(fn, {
-    group: "nitro/functions",
+    group: "nitro-functions",
     onError: defaultOnError,
     ...opts,
+    name: sanitizeCacheKey(opts.name),
   });
 }
 
@@ -49,12 +60,13 @@ export function defineCachedHandler(
 ): EventHandler {
   ensureStorage();
   const ocacheHandler = _defineCachedHandler(handler as any, {
-    group: "nitro/handlers",
+    group: "nitro-handlers",
     onError: defaultOnError,
     toResponse: (value, event) => toResponse(value, event as H3Event),
     createResponse: (body, init) => new FastResponse(body, init),
     handleCacheHeaders: (event, conditions) => handleCacheHeaders(event as H3Event, conditions),
     ...opts,
+    name: sanitizeCacheKey(opts.name),
   });
   return defineHandler((event) => ocacheHandler(event as any));
 }

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -47,9 +47,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 ): (...args: ArgsT) => Promise<T> {
   ensureStorage();
   return _defineCachedFunction(fn, {
-    group: "nitro-functions",
     onError: defaultOnError,
     ...opts,
+    group: sanitizeCacheKey(opts.group || "nitro-functions"),
     name: sanitizeCacheKey(opts.name),
   });
 }
@@ -60,12 +60,12 @@ export function defineCachedHandler(
 ): EventHandler {
   ensureStorage();
   const ocacheHandler = _defineCachedHandler(handler as any, {
-    group: "nitro-handlers",
     onError: defaultOnError,
     toResponse: (value, event) => toResponse(value, event as H3Event),
     createResponse: (body, init) => new FastResponse(body, init),
     handleCacheHeaders: (event, conditions) => handleCacheHeaders(event as H3Event, conditions),
     ...opts,
+    group: sanitizeCacheKey(opts.group || "nitro-handlers"),
     name: sanitizeCacheKey(opts.name),
   });
   return defineHandler((event) => ocacheHandler(event as any));

--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -70,9 +70,14 @@ export const cache: RouteRuleCtor<"cache"> = ((m) =>
     const key = `${m.route}:${route}`;
     let cachedHandler = cachedHandlers.get(key);
     if (!cachedHandler) {
+      // Sanitize the name to avoid filesystem path conflicts.
+      // Route paths contain "/" which unstorage's fs drivers interpret as
+      // directory separators, causing ENOTDIR when a path like "/foo" is
+      // cached as a file but "/foo/bar" needs it to be a directory.
+      const safeName = key.replace(/\//g, "_");
       cachedHandler = defineCachedHandler(handler, {
-        group: "nitro/route-rules",
-        name: key,
+        group: "nitro-route-rules",
+        name: safeName,
         ...m.options,
       });
       cachedHandlers.set(key, cachedHandler);


### PR DESCRIPTION
## Problem

Fixes #4142

When using `fs` or `fs-lite` as the storage driver, caching routes that share path prefixes crashes with `ENOTDIR`. For example:

1. Cache `/foo` → creates a **file** at `.cache/nitro/route-rules/**/foo/foo.abc123.json`
2. Cache `/foo/bar` → needs `foo` to be a **directory** → `ENOTDIR: not a directory`

This breaks any Nitro/Nuxt app where a route can be both a leaf and a prefix of another route (e.g. `/en` and `/en/about`, `/items/123` and `/items/123/details`).

**Real-world impact:** Nuxt 4.4.0's runtime payload caching (nuxt/nuxt#34410) triggers this for any site with nested routes, as reported in nuxt/nuxt#34547. @danielroe's Nuxt-side workaround (nuxt/nuxt#34569) covers `devStorage` but not production `storage` with `fs-lite`, and he suggested fixing this upstream in Nitro.

## Root Cause

Cache `group` and `name` values contain `/` characters:
- Groups: `"nitro/route-rules"`, `"nitro/handlers"`, `"nitro/functions"`
- Names: `"/**:/foo"` (route path keys)

Unstorage's fs drivers convert `:` (key separator) to `/` (path separator). But the `/` characters already embedded in group/name values also become path separators, creating unpredictable directory structures where a path segment can be both a file and a directory prefix.

```
ocache _buildCacheKey: "/cache:nitro/route-rules:/**:/foo:key.json"
                                  ↑                 ↑
                        "/" in group          "/" in name
                                  ↓                 ↓
unstorage fs-lite:     .cache/nitro/route-rules/**/foo/key.json
                                                    ↑
                                              "foo" is a FILE
                                              but /foo/bar needs
                                              it as a DIRECTORY
```

## Fix

Three layers of defense:

1. **Group names** — Replace `/` with `-` in all cache group constants (`nitro/functions` → `nitro-functions`, etc.)
2. **Route-rules name** — Sanitize route path keys by replacing `/` with `_` before passing to ocache
3. **Public API** — Apply `sanitizeCacheKey()` to user-provided `name` values in `defineCachedFunction` and `defineCachedHandler`, protecting any custom cache names from the same issue

No collision risk: ocache's `getKey` already appends a hash of the full path to the storage key, so the `name` is only a namespace prefix, not the unique identifier.