### PR TITLE
fix: respect compress settings in dev server

### DIFF
--- a/src/dev/app.ts
+++ b/src/dev/app.ts
@@ -10,6 +10,7 @@ import { stat } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { createGzip, createBrotliCompress } from "node:zlib";
 import { createVFSHandler } from "./vfs.ts";
+import type { CompressOptions } from "../types/config.ts";
 
 import devErrorHandler, {
   defaultHandler as devErrorHandlerInternal,
@@ -70,6 +71,7 @@ export class NitroDevApp {
           dir: asset.dir,
           base: assetBase,
           fallthrough: asset.fallthrough,
+          compress: this.nitro.options.compressPublicAssets,
         })
       );
     }
@@ -97,7 +99,7 @@ export class NitroDevApp {
 // TODO: upstream to h3/node
 function serveStaticDir(
   event: H3Event,
-  opts: { dir: string; base: string; fallthrough?: boolean }
+  opts: { dir: string; base: string; fallthrough?: boolean; compress?: boolean | CompressOptions }
 ) {
   const dir = resolve(opts.dir) + "/";
   const r = (id: string) => {
@@ -107,6 +109,15 @@ function serveStaticDir(
       return resolved;
     }
   };
+
+  // Determine compression settings
+  const compressOpts =
+    opts.compress === true
+      ? { gzip: true, brotli: true, zstd: false }
+      : opts.compress === false
+        ? { gzip: false, brotli: false, zstd: false }
+        : opts.compress || { gzip: false, brotli: false, zstd: false };
+
   return serveStatic(event, {
     fallthrough: opts.fallthrough,
     getMeta: async (id) => {
@@ -126,12 +137,12 @@ function serveStaticDir(
       if (!path) return;
       const stream = createReadStream(path);
       const acceptEncoding = event.req.headers.get("accept-encoding") || "";
-      if (acceptEncoding.includes("br")) {
+      if (compressOpts.brotli && acceptEncoding.includes("br")) {
         event.res.headers.set("Content-Encoding", "br");
         event.res.headers.delete("Content-Length");
         event.res.headers.set("Vary", "Accept-Encoding");
         return stream.pipe(createBrotliCompress());
-      } else if (acceptEncoding.includes("gzip")) {
+      } else if (compressOpts.gzip && acceptEncoding.includes("gzip")) {
         event.res.headers.set("Content-Encoding", "gzip");
         event.res.headers.delete("Content-Length");
         event.res.headers.set("Vary", "Accept-Encoding");


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 [Linked issue](https://github.com/nitrojs/nitro/issues/4158)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Implements handling of "compressPublicAssets" option from nitro.config.ts in development mode.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
