### PR TITLE
docs: fix typos

### DIFF
--- a/docs/2.deploy/0.index.md
+++ b/docs/2.deploy/0.index.md
@@ -29,7 +29,7 @@ When deploying to production using CI/CD, Nitro tries to automatically detect th
 - [zeabur](/deploy/providers/zeabur)
 
 ::warning
-For Turborepo users, zero config detection will be interferenced by its Strict Environment Mode. You may need to allowing the variables explictly or use its Loose Environment Mode (with `--env-mode=loose` flag).
+For Turborepo users, zero config detection will be interfered by its Strict Environment Mode. You may need to allow the variables explicitly or use its Loose Environment Mode (with `--env-mode=loose` flag).
 ::
 
 Other built-in providers are available with an explicit preset, including [zephyr](/deploy/providers/zephyr).

--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -236,7 +236,7 @@ For production, use the Cloudflare dashboard or the [`wrangler secret`](https://
 You can specify a custom `wrangler.toml`/`wrangler.json` file and define vars inside.
 
 ::warning
-Note that this isn't recommend for sensitive data like secrets.
+Note that this isn't recommended for sensitive data like secrets.
 ::
 
 **Example:**


### PR DESCRIPTION
## Summary

Fixed a few small typos and grammar errors in the deployment documentation:

- `docs/2.deploy/0.index.md`: Fixed 3 errors in the Turborepo warning:
  - `interferenced` → `interfered`
  - `allowing` → `allow`
  - `explictly` → `explicitly`

- `docs/2.deploy/20.providers/cloudflare.md`: Fixed grammar error:
  - `isn't recommend` → `isn't recommended`

No logic changes — documentation only.