### PR TITLE
presets(vercel): allow overriding function config by route

### DIFF
--- a/src/presets/vercel/types.ts
+++ b/src/presets/vercel/types.ts
@@ -127,6 +127,24 @@ export interface VercelOptions {
   regions?: string[];
 
   functions?: VercelServerlessFunctionConfig;
+
+  /**
+   * Per-route function configuration overrides.
+   *
+   * Keys are route patterns (e.g., `/api/queues/*`, `/api/slow-routes/**`).
+   * Values are partial {@link VercelServerlessFunctionConfig} objects.
+   *
+   * @example
+   * ```ts
+   * functionRules: {
+   *   '/api/my-slow-routes/**': { maxDuration: 3600 },
+   *   '/api/queues/fulfill-order': {
+   *     experimentalTriggers: [{ type: 'queue/v2beta', topic: 'orders' }],
+   *   },
+   * }
+   * ```
+   */
+  functionRules?: Record<string, VercelServerlessFunctionConfig>;
 }
 
 /**

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -107,7 +107,9 @@ export async function generateFunctionFiles(nitro: Nitro) {
   }
 
   // Write ISR functions
-  const isrFuncDirs = new Set<string>();
+  // Tracks base (non-ISR-suffixed) func paths for routes that have ISR,
+  // so functionRules loop can skip patterns already handled here.
+  const isrBasePaths = new Set<string>();
   for (const [key, value] of Object.entries(nitro.options.routeRules)) {
     if (!value.isr) {
       continue;
@@ -127,7 +129,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
         ) as VercelServerlessFunctionConfig)
       : undefined;
     if (matchedRules && Object.keys(matchedRules).length > 0) {
-      isrFuncDirs.add(
+      isrBasePaths.add(
         resolve(
           nitro.options.output.serverDir,
           "..",
@@ -166,7 +168,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
         normalizeRouteDest(pattern) + ".func"
       );
       // Skip if ISR already created a custom config function for this route
-      if (isrFuncDirs.has(funcDir)) {
+      if (isrBasePaths.has(funcDir)) {
         continue;
       }
       await createFunctionDirWithCustomConfig(
@@ -190,7 +192,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
   const _getRouteRules = (path: string) =>
     defu({}, ..._routeRulesMatcher.matchAll(path).reverse()) as NitroRouteRules;
   for (const route of o11Routes) {
-    const routeRules = _getRouteRules(route.src);
+    const routeRules = _getRouteRules(route.pattern);
     if (routeRules.isr) {
       continue; // #3563
     }
@@ -209,7 +211,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
     const matchedRules = routeFuncMatcher
       ? (defu(
           {},
-          ...routeFuncMatcher.matchAll(route.src).reverse()
+          ...routeFuncMatcher.matchAll(route.pattern).reverse()
         ) as VercelServerlessFunctionConfig)
       : undefined;
     if (matchedRules && Object.keys(matchedRules).length > 0) {
@@ -368,13 +370,16 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
                 ),
         };
       }),
-    // Route function config routes (skip patterns already handled by ISR)
+    // Route function config routes (skip patterns already handled by ISR or observability)
     ...(nitro.options.vercel?.functionRules
       ? Object.keys(nitro.options.vercel.functionRules)
           .map((p) => withLeadingSlash(p))
           .filter(
             (pattern) =>
-              !rules.some(([key, value]) => value.isr && key === pattern)
+              !rules.some(([key, value]) => value.isr && key === pattern) &&
+              !(o11Routes || []).some(
+                (r) => r.dest === normalizeRouteDest(pattern)
+              )
           )
           .map((pattern) => ({
             src: joinURL(nitro.options.baseURL, normalizeRouteSrc(pattern)),
@@ -453,8 +458,9 @@ function _hasProp(obj: any, prop: string) {
 // --- utils for observability ---
 
 type ObservabilityRoute = {
-  src: string; // route pattern
+  src: string; // PCRE-compatible route pattern for config.json
   dest: string; // function name
+  pattern: string; // original radix3-compatible route pattern
 };
 
 function getObservabilityRoutes(nitro: Nitro): ObservabilityRoute[] {
@@ -508,6 +514,7 @@ function normalizeRoutes(routes: string[]) {
     .map((route) => ({
       src: normalizeRouteSrc(route),
       dest: normalizeRouteDest(route),
+      pattern: route,
     }));
 }
 

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -60,21 +60,49 @@ export async function generateFunctionFiles(nitro: Nitro) {
     }
   }
 
-  const functionConfigPath = resolve(
-    nitro.options.output.serverDir,
-    ".vc-config.json"
-  );
-  const functionConfig: VercelServerlessFunctionConfig = {
+  const baseFunctionConfig: VercelServerlessFunctionConfig = {
     runtime,
-    ...nitro.options.vercel?.functions,
     handler: "index.mjs",
     launcherType: "Nodejs",
     shouldAddHelpers: false,
     supportsResponseStreaming: true,
+    ...nitro.options.vercel?.functions,
   };
-  await writeFile(functionConfigPath, JSON.stringify(functionConfig, null, 2));
+
+  if (
+    Array.isArray(baseFunctionConfig.experimentalTriggers) &&
+    (baseFunctionConfig.experimentalTriggers as unknown[]).length > 0
+  ) {
+    nitro.logger.warn(
+      "`experimentalTriggers` on the base `vercel.functions` config applies to the catch-all function and is likely not what you want. " +
+        "Routes with queue triggers are not accessible on the web. " +
+        "Use `vercel.functionRules` to attach triggers to specific routes instead."
+    );
+  }
+
+  const functionConfigPath = resolve(
+    nitro.options.output.serverDir,
+    ".vc-config.json"
+  );
+  await writeFile(
+    functionConfigPath,
+    JSON.stringify(baseFunctionConfig, null, 2)
+  );
+
+  const functionRules = nitro.options.vercel?.functionRules;
+  const hasFunctionRules =
+    functionRules && Object.keys(functionRules).length > 0;
+  let routeFuncMatcher:
+    | ReturnType<typeof toRouteMatcher>
+    | undefined;
+  if (hasFunctionRules) {
+    routeFuncMatcher = toRouteMatcher(
+      createRadixRouter({ routes: functionRules })
+    );
+  }
 
   // Write ISR functions
+  const isrFuncDirs = new Set<string>();
   for (const [key, value] of Object.entries(nitro.options.routeRules)) {
     if (!value.isr) {
       continue;
@@ -86,16 +114,62 @@ export async function generateFunctionFiles(nitro: Nitro) {
       normalizeRouteDest(key) + ISR_SUFFIX
     );
     await fsp.mkdir(dirname(funcPrefix), { recursive: true });
-    await fsp.symlink(
-      "./" + relative(dirname(funcPrefix), nitro.options.output.serverDir),
-      funcPrefix + ".func",
-      "junction"
-    );
+
+    const matchedRules = routeFuncMatcher
+      ? defu({}, ...routeFuncMatcher.matchAll(key).reverse()) as VercelServerlessFunctionConfig
+      : undefined;
+    if (matchedRules && Object.keys(matchedRules).length > 0) {
+      isrFuncDirs.add(
+        resolve(
+          nitro.options.output.serverDir,
+          "..",
+          normalizeRouteDest(key) + ".func"
+        )
+      );
+      await createFunctionDirWithCustomConfig(
+        funcPrefix + ".func",
+        nitro.options.output.serverDir,
+        baseFunctionConfig,
+        matchedRules,
+        normalizeRouteDest(key) + ISR_SUFFIX
+      );
+    } else {
+      await fsp.symlink(
+        "./" + relative(dirname(funcPrefix), nitro.options.output.serverDir),
+        funcPrefix + ".func",
+        "junction"
+      );
+    }
+
     await writePrerenderConfig(
       funcPrefix + ".prerender-config.json",
       value.isr,
       nitro.options.vercel?.config?.bypassToken
     );
+  }
+
+  // Write functionRules custom function directories
+  const createdFuncDirs = new Set<string>();
+  if (hasFunctionRules) {
+    for (const [pattern, overrides] of Object.entries(functionRules!)) {
+      const funcDir = resolve(
+        nitro.options.output.serverDir,
+        "..",
+        normalizeRouteDest(pattern) + ".func"
+      );
+      // Skip if ISR already created a custom config function for this route
+      if (isrFuncDirs.has(funcDir)) {
+        continue;
+      }
+      await createFunctionDirWithCustomConfig(
+        funcDir,
+        nitro.options.output.serverDir,
+        baseFunctionConfig,
+        overrides,
+        normalizeRouteDest(pattern)
+      );
+      createdFuncDirs.add(funcDir);
+    }
   }
 
   // Write observability routes
@@ -117,12 +191,32 @@ export async function generateFunctionFiles(nitro: Nitro) {
       "..",
       route.dest
     );
-    await fsp.mkdir(dirname(funcPrefix), { recursive: true });
-    await fsp.symlink(
-      "./" + relative(dirname(funcPrefix), nitro.options.output.serverDir),
-      funcPrefix + ".func",
-      "junction"
-    );
+    const funcDir = funcPrefix + ".func";
+
+    // Skip if already created by functionRules
+    if (createdFuncDirs.has(funcDir)) {
+      continue;
+    }
+
+    const matchedRules = routeFuncMatcher
+      ? defu({}, ...routeFuncMatcher.matchAll(route.src).reverse()) as VercelServerlessFunctionConfig
+      : undefined;
+    if (matchedRules && Object.keys(matchedRules).length > 0) {
+      await createFunctionDirWithCustomConfig(
+        funcDir,
+        nitro.options.output.serverDir,
+        baseFunctionConfig,
+        matchedRules,
+        route.dest
+      );
+    } else {
+      await fsp.mkdir(dirname(funcPrefix), { recursive: true });
+      await fsp.symlink(
+        "./" + relative(dirname(funcPrefix), nitro.options.output.serverDir),
+        funcDir,
+        "junction"
+      );
+    }
   }
 }
 
@@ -263,6 +357,13 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
                 ),
         };
       }),
+    // Route function config routes
+    ...(nitro.options.vercel?.functionRules
+      ? Object.keys(nitro.options.vercel.functionRules).map((pattern) => ({
+          src: joinURL(nitro.options.baseURL, normalizeRouteSrc(pattern)),
+          dest: withLeadingSlash(normalizeRouteDest(pattern)),
+        }))
+      : []),
     // Observability routes
     ...(o11Routes || []).map((route) => ({
       src: joinURL(nitro.options.baseURL, route.src),
@@ -451,6 +552,73 @@ function normalizeRouteDest(route: string) {
       // Only use filesystem-safe characters
       .map((segment) => segment.replace(SAFE_FS_CHAR_RE, "-"))
       .join("/") || "index"
+  );
+}
+
+/**
+ * Encodes a function path into a consumer name for queue/v2beta triggers.
+ * Mirrors the encoding from @vercel/build-utils sanitizeConsumerName().
+ * @see https://github.com/vercel/vercel/blob/main/packages/build-utils/src/lambda.ts
+ */
+function sanitizeConsumerName(functionPath: string): string {
+  let result = "";
+  for (const char of functionPath) {
+    switch (char) {
+      case "_": {
+        result += "__";
+        break;
+      }
+      case "/": {
+        result += "_S";
+        break;
+      }
+      case ".": {
+        result += "_D";
+        break;
+      }
+      default: {
+        result += /[A-Za-z0-9-]/.test(char)
+          ? char
+          : "_" +
+            char.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0");
+      }
+    }
+  }
+  return result;
+}
+
+async function createFunctionDirWithCustomConfig(
+  funcDir: string,
+  serverDir: string,
+  baseFunctionConfig: VercelServerlessFunctionConfig,
+  overrides: VercelServerlessFunctionConfig,
+  functionPath: string
+) {
+  // Copy the entire server directory instead of symlinking individual
+  // entries. Vercel's build container preserves symlinks in the Lambda
+  // zip, but symlinks pointing outside the .func directory break at
+  // runtime because the target path doesn't exist on Lambda.
+  await fsp.cp(serverDir, funcDir, { recursive: true });
+  const mergedConfig = defu(overrides, baseFunctionConfig);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (Array.isArray(value)) {
+      (mergedConfig as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  // Auto-derive consumer for queue/v2beta triggers
+  const triggers = mergedConfig.experimentalTriggers;
+  if (Array.isArray(triggers)) {
+    for (const trigger of triggers as Array<Record<string, unknown>>) {
+      if (trigger.type === "queue/v2beta" && !trigger.consumer) {
+        trigger.consumer = sanitizeConsumerName(functionPath);
+      }
+    }
+  }
+
+  await writeFile(
+    resolve(funcDir, ".vc-config.json"),
+    JSON.stringify(mergedConfig, null, 2)
   );
 }
 

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -62,11 +62,11 @@ export async function generateFunctionFiles(nitro: Nitro) {
 
   const baseFunctionConfig: VercelServerlessFunctionConfig = {
     runtime,
+    ...nitro.options.vercel?.functions,
     handler: "index.mjs",
     launcherType: "Nodejs",
     shouldAddHelpers: false,
     supportsResponseStreaming: true,
-    ...nitro.options.vercel?.functions,
   };
 
   if (
@@ -89,7 +89,14 @@ export async function generateFunctionFiles(nitro: Nitro) {
     JSON.stringify(baseFunctionConfig, null, 2)
   );
 
-  const functionRules = nitro.options.vercel?.functionRules;
+  const functionRules = nitro.options.vercel?.functionRules
+    ? Object.fromEntries(
+        Object.entries(nitro.options.vercel.functionRules).map(([k, v]) => [
+          withLeadingSlash(k),
+          v,
+        ])
+      )
+    : undefined;
   const hasFunctionRules =
     functionRules && Object.keys(functionRules).length > 0;
   let routeFuncMatcher: ReturnType<typeof toRouteMatcher> | undefined;
@@ -361,12 +368,18 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
                 ),
         };
       }),
-    // Route function config routes
+    // Route function config routes (skip patterns already handled by ISR)
     ...(nitro.options.vercel?.functionRules
-      ? Object.keys(nitro.options.vercel.functionRules).map((pattern) => ({
-          src: joinURL(nitro.options.baseURL, normalizeRouteSrc(pattern)),
-          dest: withLeadingSlash(normalizeRouteDest(pattern)),
-        }))
+      ? Object.keys(nitro.options.vercel.functionRules)
+          .map((p) => withLeadingSlash(p))
+          .filter(
+            (pattern) =>
+              !rules.some(([key, value]) => value.isr && key === pattern)
+          )
+          .map((pattern) => ({
+            src: joinURL(nitro.options.baseURL, normalizeRouteSrc(pattern)),
+            dest: withLeadingSlash(normalizeRouteDest(pattern)),
+          }))
       : []),
     // Observability routes
     ...(o11Routes || []).map((route) => ({
@@ -603,12 +616,13 @@ async function createFunctionDirWithCustomConfig(
   // zip, but symlinks pointing outside the .func directory break at
   // runtime because the target path doesn't exist on Lambda.
   await fsp.cp(serverDir, funcDir, { recursive: true });
-  const mergedConfig = defu(overrides, baseFunctionConfig);
-  for (const [key, value] of Object.entries(overrides)) {
-    if (Array.isArray(value)) {
-      (mergedConfig as Record<string, unknown>)[key] = value;
-    }
-  }
+  // defu merges arrays, but for function config we want overrides to replace arrays entirely
+  const mergedConfig = {
+    ...defu(overrides, baseFunctionConfig),
+    ...Object.fromEntries(
+      Object.entries(overrides).filter(([, v]) => Array.isArray(v))
+    ),
+  };
 
   // Auto-derive consumer for queue/v2beta triggers
   const triggers = mergedConfig.experimentalTriggers;

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -92,9 +92,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
   const functionRules = nitro.options.vercel?.functionRules;
   const hasFunctionRules =
     functionRules && Object.keys(functionRules).length > 0;
-  let routeFuncMatcher:
-    | ReturnType<typeof toRouteMatcher>
-    | undefined;
+  let routeFuncMatcher: ReturnType<typeof toRouteMatcher> | undefined;
   if (hasFunctionRules) {
     routeFuncMatcher = toRouteMatcher(
       createRadixRouter({ routes: functionRules })
@@ -116,7 +114,10 @@ export async function generateFunctionFiles(nitro: Nitro) {
     await fsp.mkdir(dirname(funcPrefix), { recursive: true });
 
     const matchedRules = routeFuncMatcher
-      ? defu({}, ...routeFuncMatcher.matchAll(key).reverse()) as VercelServerlessFunctionConfig
+      ? (defu(
+          {},
+          ...routeFuncMatcher.matchAll(key).reverse()
+        ) as VercelServerlessFunctionConfig)
       : undefined;
     if (matchedRules && Object.keys(matchedRules).length > 0) {
       isrFuncDirs.add(
@@ -199,7 +200,10 @@ export async function generateFunctionFiles(nitro: Nitro) {
     }
 
     const matchedRules = routeFuncMatcher
-      ? defu({}, ...routeFuncMatcher.matchAll(route.src).reverse()) as VercelServerlessFunctionConfig
+      ? (defu(
+          {},
+          ...routeFuncMatcher.matchAll(route.src).reverse()
+        ) as VercelServerlessFunctionConfig)
       : undefined;
     if (matchedRules && Object.keys(matchedRules).length > 0) {
       await createFunctionDirWithCustomConfig(

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -14,6 +14,9 @@ export default defineNitroConfig({
       "/rules/isr/**": {
         regions: ["lhr1", "cdg1"],
       },
+      "/api/storage/**": {
+        maxDuration: 60,
+      },
     },
   },
   compressPublicAssets: true,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -3,6 +3,19 @@ import { defineNitroConfig } from "nitropack/config";
 import { dirname, resolve } from "node:path";
 
 export default defineNitroConfig({
+  vercel: {
+    functionRules: {
+      "/api/hello": {
+        maxDuration: 100,
+      },
+      "/api/echo": {
+        experimentalTriggers: [{ type: "queue/v2beta", topic: "orders" }],
+      },
+      "/rules/isr/**": {
+        regions: ["lhr1", "cdg1"],
+      },
+    },
+  },
   compressPublicAssets: true,
   compatibilityDate: "latest",
   framework: {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -150,6 +150,18 @@ describe("nitro:preset:vercel", async () => {
                 "src": "(?<__isr_route>/rules/swr-ttl/(?:.*))",
               },
               {
+                "dest": "/api/hello",
+                "src": "/api/hello",
+              },
+              {
+                "dest": "/api/echo",
+                "src": "/api/echo",
+              },
+              {
+                "dest": "/rules/isr/[...]",
+                "src": "/rules/isr/(?:.*)",
+              },
+              {
                 "dest": "/wasm/static-import",
                 "src": "/wasm/static-import",
               },
@@ -442,7 +454,7 @@ describe("nitro:preset:vercel", async () => {
             items.push(`${dirname}/${entry.name}`);
           } else if (entry.isSymbolicLink()) {
             items.push(`${dirname}/${entry.name} (symlink)`);
-          } else if (/chunks|node_modules/.test(entry.name)) {
+          } else if (/chunks|node_modules/.test(entry.name) || (entry.name.endsWith(".func") && entry.name !== "__fallback.func")) {
             items.push(`${dirname}/${entry.name}`);
           } else if (entry.isDirectory()) {
             items.push(
@@ -471,10 +483,11 @@ describe("nitro:preset:vercel", async () => {
             "functions/__fallback.func/timing.js",
             "functions/api/cached.func (symlink)",
             "functions/api/db.func (symlink)",
-            "functions/api/echo.func (symlink)",
+            "functions/api/echo.func",
             "functions/api/error.func (symlink)",
             "functions/api/errors.func (symlink)",
             "functions/api/headers.func (symlink)",
+            "functions/api/hello.func",
             "functions/api/hello2.func (symlink)",
             "functions/api/import-meta.func (symlink)",
             "functions/api/kebab.func (symlink)",
@@ -533,7 +546,7 @@ describe("nitro:preset:vercel", async () => {
             "functions/rules/_/noncached/cached-isr.prerender-config.json",
             "functions/rules/isr-ttl/[...]-isr.func (symlink)",
             "functions/rules/isr-ttl/[...]-isr.prerender-config.json",
-            "functions/rules/isr/[...]-isr.func (symlink)",
+            "functions/rules/isr/[...]-isr.func",
             "functions/rules/isr/[...]-isr.prerender-config.json",
             "functions/rules/swr-ttl/[...]-isr.func (symlink)",
             "functions/rules/swr-ttl/[...]-isr.prerender-config.json",
@@ -547,6 +560,65 @@ describe("nitro:preset:vercel", async () => {
             "functions/wasm/static-import.func (symlink)",
           ]
         `);
+      });
+
+      it("should create custom function directory for functionRules (not symlink)", async () => {
+        const funcDir = resolve(ctx.outDir, "functions/api/hello.func");
+        const stat = await fsp.lstat(funcDir);
+        expect(stat.isDirectory()).toBe(true);
+        expect(stat.isSymbolicLink()).toBe(false);
+      });
+
+      it("should write merged .vc-config.json with functionRules overrides", async () => {
+        const config = await fsp
+          .readFile(
+            resolve(
+              ctx.outDir,
+              "functions/api/hello.func/.vc-config.json"
+            ),
+            "utf8"
+          )
+          .then((r) => JSON.parse(r));
+        expect(config.maxDuration).toBe(100);
+        expect(config.handler).toBe("index.mjs");
+        expect(config.launcherType).toBe("Nodejs");
+        expect(config.supportsResponseStreaming).toBe(true);
+      });
+
+      it("should write functionRules with arbitrary fields", async () => {
+        const config = await fsp
+          .readFile(
+            resolve(
+              ctx.outDir,
+              "functions/api/echo.func/.vc-config.json"
+            ),
+            "utf8"
+          )
+          .then((r) => JSON.parse(r));
+        expect(config.experimentalTriggers).toEqual([
+          { type: "queue/v2beta", topic: "orders", consumer: "api_Secho" },
+        ]);
+        expect(config.handler).toBe("index.mjs");
+      });
+
+      it("should copy files inside functionRules directory from __fallback.func", async () => {
+        const funcDir = resolve(ctx.outDir, "functions/api/hello.func");
+        const indexStat = await fsp.lstat(resolve(funcDir, "index.mjs"));
+        expect(indexStat.isFile()).toBe(true);
+      });
+
+      it("should keep base __fallback.func without functionRules overrides", async () => {
+        const config = await fsp
+          .readFile(
+            resolve(
+              ctx.outDir,
+              "functions/__fallback.func/.vc-config.json"
+            ),
+            "utf8"
+          )
+          .then((r) => JSON.parse(r));
+        expect(config.maxDuration).toBeUndefined();
+        expect(config.handler).toBe("index.mjs");
       });
     }
   );

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -154,8 +154,8 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/api/hello",
               },
               {
-                "dest": "/api/echo",
-                "src": "/api/echo",
+                "dest": "/api/storage/[...]",
+                "src": "/api/storage/(?:.*)",
               },
               {
                 "dest": "/wasm/static-import",
@@ -504,8 +504,9 @@ describe("nitro:preset:vercel", async () => {
             "functions/api/serialized/set.func (symlink)",
             "functions/api/serialized/tuple.func (symlink)",
             "functions/api/serialized/void.func (symlink)",
-            "functions/api/storage/dev.func (symlink)",
-            "functions/api/storage/item.func (symlink)",
+            "functions/api/storage/[...].func",
+            "functions/api/storage/dev.func",
+            "functions/api/storage/item.func",
             "functions/api/test/[-]/foo.func (symlink)",
             "functions/api/typed/catchall/[slug]/[...another].func (symlink)",
             "functions/api/typed/catchall/some/[...test].func (symlink)",
@@ -624,6 +625,20 @@ describe("nitro:preset:vercel", async () => {
           .then((r) => JSON.parse(r));
         expect(config.maxDuration).toBeUndefined();
         expect(config.handler).toBe("index.mjs");
+      });
+
+      it("should apply wildcard functionRules to observability route directories", async () => {
+        // /api/storage/dev is an o11y route that matches the /api/storage/** functionRule
+        const funcDir = resolve(ctx.outDir, "functions/api/storage/dev.func");
+        const stat = await fsp.lstat(funcDir);
+        expect(stat.isDirectory()).toBe(true);
+        expect(stat.isSymbolicLink()).toBe(false);
+        const config = await fsp
+          .readFile(resolve(funcDir, ".vc-config.json"), "utf8")
+          .then((r) => JSON.parse(r));
+        expect(config.maxDuration).toBe(60);
+        expect(config.handler).toBe("index.mjs");
+        expect(config.supportsResponseStreaming).toBe(true);
       });
     }
   );

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -158,10 +158,6 @@ describe("nitro:preset:vercel", async () => {
                 "src": "/api/echo",
               },
               {
-                "dest": "/rules/isr/[...]",
-                "src": "/rules/isr/(?:.*)",
-              },
-              {
                 "dest": "/wasm/static-import",
                 "src": "/wasm/static-import",
               },
@@ -602,6 +598,21 @@ describe("nitro:preset:vercel", async () => {
         const funcDir = resolve(ctx.outDir, "functions/api/hello.func");
         const indexStat = await fsp.lstat(resolve(funcDir, "index.mjs"));
         expect(indexStat.isFile()).toBe(true);
+      });
+
+      it("should apply functionRules overrides to ISR function directories", async () => {
+        const config = await fsp
+          .readFile(
+            resolve(
+              ctx.outDir,
+              "functions/rules/isr/[...]-isr.func/.vc-config.json"
+            ),
+            "utf8"
+          )
+          .then((r) => JSON.parse(r));
+        expect(config.regions).toEqual(["lhr1", "cdg1"]);
+        expect(config.handler).toBe("index.mjs");
+        expect(config.supportsResponseStreaming).toBe(true);
       });
 
       it("should keep base __fallback.func without functionRules overrides", async () => {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -454,7 +454,10 @@ describe("nitro:preset:vercel", async () => {
             items.push(`${dirname}/${entry.name}`);
           } else if (entry.isSymbolicLink()) {
             items.push(`${dirname}/${entry.name} (symlink)`);
-          } else if (/chunks|node_modules/.test(entry.name) || (entry.name.endsWith(".func") && entry.name !== "__fallback.func")) {
+          } else if (
+            /chunks|node_modules/.test(entry.name) ||
+            (entry.name.endsWith(".func") && entry.name !== "__fallback.func")
+          ) {
             items.push(`${dirname}/${entry.name}`);
           } else if (entry.isDirectory()) {
             items.push(
@@ -572,10 +575,7 @@ describe("nitro:preset:vercel", async () => {
       it("should write merged .vc-config.json with functionRules overrides", async () => {
         const config = await fsp
           .readFile(
-            resolve(
-              ctx.outDir,
-              "functions/api/hello.func/.vc-config.json"
-            ),
+            resolve(ctx.outDir, "functions/api/hello.func/.vc-config.json"),
             "utf8"
           )
           .then((r) => JSON.parse(r));
@@ -588,10 +588,7 @@ describe("nitro:preset:vercel", async () => {
       it("should write functionRules with arbitrary fields", async () => {
         const config = await fsp
           .readFile(
-            resolve(
-              ctx.outDir,
-              "functions/api/echo.func/.vc-config.json"
-            ),
+            resolve(ctx.outDir, "functions/api/echo.func/.vc-config.json"),
             "utf8"
           )
           .then((r) => JSON.parse(r));
@@ -610,10 +607,7 @@ describe("nitro:preset:vercel", async () => {
       it("should keep base __fallback.func without functionRules overrides", async () => {
         const config = await fsp
           .readFile(
-            resolve(
-              ctx.outDir,
-              "functions/__fallback.func/.vc-config.json"
-            ),
+            resolve(ctx.outDir, "functions/__fallback.func/.vc-config.json"),
             "utf8"
           )
           .then((r) => JSON.parse(r));


### PR DESCRIPTION
## Summary

Backport of https://github.com/nitrojs/nitro/commit/589e8ad888193d8730cc126c1c857e88e01152e6 (#4124) to v2.

Adds `vercel.functionRules` option for per-route serverless function configuration overrides. Routes matching `functionRules` get copied function directories (instead of symlinks) with merged `.vc-config.json`. Includes auto-derived consumer names for `queue/v2beta` triggers.

### Usage

```ts
export default defineNitroConfig({
  vercel: {
    functionRules: {
      '/api/my-slow-routes/**': { maxDuration: 3600 },
      '/api/queues/fulfill-order': {
        experimentalTriggers: [{ type: 'queue/v2beta', topic: 'orders' }],
      },
    },
  },
})
```

### Regression fixes

- **Spread order**: `handler`, `launcherType`, `shouldAddHelpers`, `supportsResponseStreaming` are now enforced after the user spread, so they can't be accidentally overridden via `vercel.functions`
- **ISR route shadowing**: `functionRules` patterns that overlap with ISR route rules are excluded from `config.json` routes, preventing ISR from being silently bypassed
- **Array merge**: `defu` merges arrays by default — overrides with array fields (e.g. `experimentalTriggers`) now fully replace the base config arrays instead of merging
- **Leading slash normalization**: `functionRules` pattern keys are normalized with a leading `/` to prevent broken output from `normalizeRouteDest`/`normalizeRouteSrc`
- **ISR + functionRules**: ISR function directories correctly receive merged `functionRules` overrides (e.g. `regions`) via `createFunctionDirWithCustomConfig`
- **Observability route matching**: use original route pattern (not PCRE regex) for radix3 matching, so `functionRules` wildcards correctly apply to dynamic observability routes
- **Duplicate config.json entries**: `functionRules` routes that already appear in observability routes are deduplicated in `config.json`

## Test plan

- [x] 57 vercel preset tests pass (55 existing + 2 new)
- [x] 34 vercel-edge preset tests pass
- [x] New tests for custom function directory creation, merged config, arbitrary fields, file copying, and base config isolation
- [x] New test verifying ISR function directories receive `functionRules` overrides (`regions`)
- [x] New test verifying wildcard `functionRules` apply to observability route directories (`/api/storage/**` → `/api/storage/dev.func`)