### PR TITLE
fix: allow to run tasks via nitro cli

### DIFF
--- a/src/runtime/internal/routes/dev-tasks.ts
+++ b/src/runtime/internal/routes/dev-tasks.ts
@@ -1,7 +1,20 @@
-import { H3 } from "h3";
+import { H3, type H3Event } from "h3";
 import { runTask } from "../task.ts";
 
 import { scheduledTasks, tasks } from "#nitro/virtual/tasks";
+
+const taskHandler = async (event: H3Event) => {
+  const name = event.context.params?.name;
+  const body = (await event.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const payload = {
+    ...Object.fromEntries(event.url.searchParams.entries()),
+    ...((body.payload as Record<string, unknown>) ?? body),
+  };
+  return await runTask(name!, {
+    context: { waitUntil: event.req.waitUntil },
+    payload,
+  });
+};
 
 const app: H3 = new H3()
   .get("/_nitro/tasks", async () => {
@@ -16,17 +29,7 @@ const app: H3 = new H3()
       scheduledTasks,
     };
   })
-  .get("/_nitro/tasks/:name", async (event) => {
-    const name = event.context.params?.name;
-    const body = (await event.req.json().catch(() => ({}))) as Record<string, unknown>;
-    const payload = {
-      ...Object.fromEntries(event.url.searchParams.entries()),
-      ...body,
-    };
-    return await runTask(name!, {
-      context: { waitUntil: event.req.waitUntil },
-      payload,
-    });
-  });
+  .get("/_nitro/tasks/:name", taskHandler)
+  .post("/_nitro/tasks/:name", taskHandler);
 
 export default app;

--- a/test/presets/nitro-dev.test.ts
+++ b/test/presets/nitro-dev.test.ts
@@ -22,6 +22,58 @@ describe("nitro:preset:nitro-dev", async () => {
         expect(status).toBe(200);
       });
 
+      describe("tasks", () => {
+        it("GET /_nitro/tasks lists tasks", async () => {
+          const { data, status } = await callHandler({ url: "/_nitro/tasks" });
+          expect(status).toBe(200);
+          expect(data.tasks).toBeTypeOf("object");
+          expect(data.tasks.test).toMatchObject({ description: "task to debug" });
+          expect(data.tasks["db:migrate"]).toMatchObject({
+            description: "Run database migrations",
+          });
+          expect(data.scheduledTasks).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ cron: "* * * * *", tasks: ["test"] }),
+            ])
+          );
+        });
+
+        it("GET /_nitro/tasks/:name runs a task", async () => {
+          const { data, status } = await callHandler({
+            url: "/_nitro/tasks/db:migrate",
+          });
+          expect(status).toBe(200);
+          expect(data.result).toBe("Success");
+        });
+
+        it("POST /_nitro/tasks/:name runs a task", async () => {
+          const { data, status } = await callHandler({
+            url: "/_nitro/tasks/db:migrate",
+            method: "POST",
+          });
+          expect(status).toBe(200);
+          expect(data.result).toBe("Success");
+        });
+
+        it("POST /_nitro/tasks/:name accepts payload", async () => {
+          const { data, status } = await callHandler({
+            url: "/_nitro/tasks/test",
+            method: "POST",
+            body: JSON.stringify({ payload: { key: "value" } }),
+          });
+          expect(status).toBe(200);
+          expect(data.result.payload.key).toBe("value");
+        });
+
+        it("GET /_nitro/tasks/:name accepts query params as payload", async () => {
+          const { data, status } = await callHandler({
+            url: "/_nitro/tasks/test?key=value",
+          });
+          expect(status).toBe(200);
+          expect(data.result.payload.key).toBe("value");
+        });
+      });
+
       describe("openAPI", () => {
         let spec: OpenAPI3;
         it("/_openapi.json", async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4187 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the current beta version and `main` branch it is not possible to run tasks via the CLI, e.g.: `npx nitro task run example` (doesn't matter which package manager you use).

The CLI runs the command using `POST`, while on the Dev Server only `GET` is registered, so it doesn't work. I've just added a `POST` method as well (using the same business logic). In my eyes if makes sense aswell, since executing Tasks is doing something which I would classify more under `POST`.

Before:
<img width="2198" height="358" alt="CleanShot 2026-04-07 at 14 12 35@2x" src="https://github.com/user-attachments/assets/15bd7228-fb47-489c-965f-6de74beb4311" />

Reproduction is available here: https://stackblitz.com/edit/github-wtbduyfz?file=README.md

When the dev server runs, open a second terminal as seen in the screenshot and try to run the example command.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
