### PR TITLE
fix(bun): support `NITRO_BUN_IDLE_TIMEOUT=0`

### DIFF
--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -10,12 +10,16 @@ const ws = import.meta._websocket
   ? wsAdapter(nitroApp.h3App.websocket)
   : undefined;
 
+function parseInt(value: string) {
+  const parsedValue = Number.parseInt(value);
+  return Number.isNaN(parsedValue) ? undefined : parsedValue;
+}
+
 // @ts-expect-error
 const server = Bun.serve({
   port: process.env.NITRO_PORT || process.env.PORT || 3000,
   host: process.env.NITRO_HOST || process.env.HOST,
-  idleTimeout:
-    Number.parseInt(process.env.NITRO_BUN_IDLE_TIMEOUT as string) || undefined,
+  idleTimeout: parseInt(process.env.NITRO_BUN_IDLE_TIMEOUT as string),
   websocket: import.meta._websocket ? ws!.websocket : (undefined as any),
   async fetch(req: Request, server: any) {
     // https://crossws.unjs.io/adapters/bun


### PR DESCRIPTION
### 🔗 Linked issue

#4189

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The PR fixes parsing of `NITRO_BUN_IDLE_TIMEOUT=0`.

- Without the fix, it's treated as undefined, and the default timeout of 10 seconds is used.
- With the fix, 0 is correctly passed to Bun, and timeout is disabled entirely.

Resolves #4189.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
