### PR TITLE
fix(azure): prevent azure-swa runtime errors, and response body returning {}

### DIFF
--- a/docs/2.deploy/20.providers/azure.md
+++ b/docs/2.deploy/20.providers/azure.md
@@ -29,7 +29,7 @@ npx @azure/static-web-apps-cli start .output/public --api-location .output/serve
 
 Azure Static Web Apps are [configured](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration) using the `staticwebapp.config.json` file.
 
-Nitro automatically generates this configuration file whenever the application is built with the `azure` preset.
+Nitro automatically generates this configuration file whenever the application is built with the `azure-swa` preset.
 
 Nitro will automatically add the following properties based on the following criteria:
 

--- a/docs/2.deploy/20.providers/azure.md
+++ b/docs/2.deploy/20.providers/azure.md
@@ -6,13 +6,13 @@
 
 **Preset:** `azure-swa`
 
-:read-more{title="Azure Static Web Apps" to="https://azure.microsoft.com/en-us/products/app-service/static"}
+:read-more{title="Azure Static Web Apps" to="[https://azure.microsoft.com/en-us/products/app-service/static"}](https://azure.microsoft.com/en-us/products/app-service/static"})
 
 ::note
 Integration with this provider is possible with [zero configuration](/deploy/#zero-config-providers).
 ::
 
-[Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static) are designed to be deployed continuously in a [GitHub Actions workflow](https://docs.microsoft.com/en-us/azure/static-web-apps/github-actions-workflow). By default, Nitro will detect this deployment environment and enable the `azure` preset.
+[Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static) are designed to be deployed continuously in a [GitHub Actions workflow](https://docs.microsoft.com/en-us/azure/static-web-apps/github-actions-workflow). By default, Nitro will detect this deployment environment and enable the `azure-swa` preset.
 
 ### Local preview
 
@@ -21,7 +21,7 @@ Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azur
 You can invoke a development environment to preview before deploying.
 
 ```bash
-NITRO_PRESET=azure npx nypm@latest build
+NITRO_PRESET=azure-swa npx nypm@latest build
 npx @azure/static-web-apps-cli start .output/public --api-location .output/server
 ```
 
@@ -32,11 +32,14 @@ Azure Static Web Apps are [configured](https://learn.microsoft.com/en-us/azure/s
 Nitro automatically generates this configuration file whenever the application is built with the `azure` preset.
 
 Nitro will automatically add the following properties based on the following criteria:
-| Property | Criteria | Default |
-| --- | --- | --- |
-| **[platform.apiRuntime](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#platform)** | Will automatically set to `node:16` or `node:14` depending on your package configuration. | `node:16` |
-| **[navigationFallback.rewrite](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#fallback-routes)** | Is always `/api/server` | `/api/server` |
-| **[routes](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#routes)** | All prerendered routes are added. Additionally, if you do not have an `index.html` file an empty one is created for you for compatibility purposes and also requests to `/index.html` are redirected to the root directory which is handled by `/api/server`.  | `[]` |
+
+
+| Property                                                                                                                | Criteria                                                                                                                                                                                                                                                      | Default       |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| **[platform.apiRuntime](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#platform)**               | Uses `node:20` or `node:22` when `package.json` `engines.node` (or your current Node major version) matches those supported versions; otherwise falls back to `node:18`.                                                                                      | `node:18`     |
+| **[navigationFallback.rewrite](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#fallback-routes)** | Is always `/api/server`                                                                                                                                                                                                                                       | `/api/server` |
+| **[routes](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#routes)**                              | All prerendered routes are added. Additionally, if you do not have an `index.html` file an empty one is created for you for compatibility purposes and also requests to `/index.html` are redirected to the root directory which is handled by `/api/server`. | `[]`          |
+
 
 ### Custom configuration
 
@@ -50,11 +53,13 @@ When you link your GitHub repository to Azure Static Web Apps, a workflow file i
 
 When you are asked to select your framework, select custom and provide the following information:
 
-| Input | Value |
-| --- | --- |
-| **app_location** | '/' |
-| **api_location** | '.output/server' |
+
+| Input               | Value            |
+| ------------------- | ---------------- |
+| **app_location**    | '/'              |
+| **api_location**    | '.output/server' |
 | **output_location** | '.output/public' |
+
 
 If you miss this step, you can always find the build configuration section in your workflow and update the build configuration:
 
@@ -69,4 +74,3 @@ output_location: '.output/public'
 That's it! Now Azure Static Web Apps will automatically deploy your Nitro-powered application on push.
 
 If you are using runtimeConfig, you will likely want to configure the corresponding [environment variables on Azure](https://docs.microsoft.com/en-us/azure/static-web-apps/application-settings).
-

--- a/docs/2.deploy/20.providers/azure.md
+++ b/docs/2.deploy/20.providers/azure.md
@@ -6,7 +6,7 @@
 
 **Preset:** `azure-swa`
 
-:read-more{title="Azure Static Web Apps" to="[https://azure.microsoft.com/en-us/products/app-service/static"}](https://azure.microsoft.com/en-us/products/app-service/static"})
+:read-more{title="Azure Static Web Apps" to="https://azure.microsoft.com/en-us/products/app-service/static"}
 
 ::note
 Integration with this provider is possible with [zero configuration](/deploy/#zero-config-providers).

--- a/src/presets/azure/runtime/_utils.ts
+++ b/src/presets/azure/runtime/_utils.ts
@@ -37,7 +37,15 @@ export function resolveBaseUrl(req: HttpRequest) {
   const forwardedHost = req.headers["x-forwarded-host"];
   const host = forwardedHost || req.headers["host"];
   if (host) {
-    return `${forwardedProto || "http"}://${host}`;
+    const candidate = `${forwardedProto || "http"}://${host}`;
+    try {
+      return new URL(candidate).origin;
+    } catch (error) {
+      console.warn("[nitro] Invalid Azure SWA forwarded origin", {
+        candidate,
+        error,
+      });
+    }
   }
   const originalUrl = req.headers["x-ms-original-url"];
   if (originalUrl) {
@@ -46,6 +54,8 @@ export function resolveBaseUrl(req: HttpRequest) {
     } catch {
       // ignore invalid original URL
     }
+  }
+}
   }
   return "http://localhost";
 }

--- a/src/presets/azure/runtime/_utils.ts
+++ b/src/presets/azure/runtime/_utils.ts
@@ -1,4 +1,4 @@
-import type { Cookie } from "@azure/functions";
+import type { Cookie, HttpRequest } from "@azure/functions";
 import { parse } from "cookie-es";
 
 export function getAzureParsedCookiesFromHeaders(headers: Headers): Cookie[] {
@@ -30,6 +30,24 @@ export function getAzureParsedCookiesFromHeaders(headers: Headers): Cookie[] {
     azureCookies.push(cookieObject);
   }
   return azureCookies;
+}
+
+export function resolveBaseUrl(req: HttpRequest) {
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  const forwardedHost = req.headers["x-forwarded-host"];
+  const host = forwardedHost || req.headers["host"];
+  if (host) {
+    return `${forwardedProto || "http"}://${host}`;
+  }
+  const originalUrl = req.headers["x-ms-original-url"];
+  if (originalUrl) {
+    try {
+      return new URL(originalUrl).origin;
+    } catch {
+      // ignore invalid original URL
+    }
+  }
+  return "http://localhost";
 }
 
 function parseNumberOrDate(expires: string) {

--- a/src/presets/azure/runtime/_utils.ts
+++ b/src/presets/azure/runtime/_utils.ts
@@ -55,8 +55,6 @@ export function resolveBaseUrl(req: HttpRequest) {
       // ignore invalid original URL
     }
   }
-}
-  }
   return "http://localhost";
 }
 

--- a/src/presets/azure/runtime/azure-swa.ts
+++ b/src/presets/azure/runtime/azure-swa.ts
@@ -1,7 +1,7 @@
 import "#nitro/virtual/polyfills";
 import { parseURL } from "ufo";
 import { useNitroApp } from "nitro/app";
-import { getAzureParsedCookiesFromHeaders } from "./_utils.ts";
+import { getAzureParsedCookiesFromHeaders, resolveBaseUrl } from "./_utils.ts";
 
 import type { HttpRequest, HttpResponse, HttpResponseSimple } from "@azure/functions";
 
@@ -19,8 +19,9 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
     url = "/api/" + (req.params.url || "");
   }
 
-  const request = new Request(url, {
+  const request = new Request(new URL(url, resolveBaseUrl(req)), {
     method: req.method || undefined,
+    headers: new Headers(req.headers),
     // https://github.com/Azure/azure-functions-nodejs-worker/issues/294
     // https://github.com/Azure/azure-functions-host/issues/293
     body: req.bufferBody ?? req.rawBody,
@@ -32,7 +33,7 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   // (v4) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status: response.status,
-    body: response.body,
+    body: response.body ? Buffer.from(await response.arrayBuffer()) : undefined,
     cookies: getAzureParsedCookiesFromHeaders(response.headers),
     headers: Object.fromEntries(
       [...response.headers.entries()].filter(([key]) => key !== "set-cookie")

--- a/test/unit/azure.utils.test.ts
+++ b/test/unit/azure.utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getAzureParsedCookiesFromHeaders } from "../../src/presets/azure/runtime/_utils.ts";
+import {
+  getAzureParsedCookiesFromHeaders,
+  resolveBaseUrl,
+} from "../../src/presets/azure/runtime/_utils.ts";
 
 describe("getAzureParsedCookiesFromHeaders", () => {
   it("returns empty array if no cookies", () => {
@@ -70,5 +73,35 @@ describe("getAzureParsedCookiesFromHeaders", () => {
         value: "qux",
       },
     ]);
+  });
+});
+
+describe("resolveBaseUrl", () => {
+  const req = (headers: Record<string, string>) => ({ headers }) as any;
+
+  it("uses the forwarded proto and host", () => {
+    expect(
+      resolveBaseUrl(req({ "x-forwarded-proto": "https", "x-forwarded-host": "example.com" }))
+    ).toBe("https://example.com");
+  });
+
+  it("falls back to the host header and http", () => {
+    expect(resolveBaseUrl(req({ host: "example.com:8080" }))).toBe("http://example.com:8080");
+  });
+
+  it("falls back to the origin of x-ms-original-url", () => {
+    expect(resolveBaseUrl(req({ "x-ms-original-url": "https://example.com/foo?bar=1" }))).toBe(
+      "https://example.com"
+    );
+  });
+
+  it("ignores an unusable host", () => {
+    expect(
+      resolveBaseUrl(req({ host: "not a host", "x-ms-original-url": "https://example.com/foo" }))
+    ).toBe("https://example.com");
+  });
+
+  it("falls back to localhost", () => {
+    expect(resolveBaseUrl(req({}))).toBe("http://localhost");
   });
 });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#2590

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR improves the azure-swa preset so Nitro runs reliably on Azure Static Web Apps

**What was failing**

- Some responses were returned as {} in Azure SWA instead of the expected payload. (#2590)
- Request is built with relative URL, causing runtime error

**How it is fixed**

- **Outgoing body**: Replace passing `response.body` (a stream) with `Buffer.from(await response.arrayBuffer())` when a body exists, so Azure Functions gets bytes instead of a stream object that could surface as `{} `or otherwise fail at runtime.
- **Incoming headers**: Pass `headers: new Headers(req.headers)` so the Fetch `Request` receives the same headers as the Azure HTTP trigger
- **Request URL**: Build the Request with an absolute URL via new `URL(url, resolveBaseUrl(req))` instead of a relative URL string. resolveBaseUrl prefers `x-forwarded-proto / x-forwarded-host` (or host), then falls back to the origin from x-ms-`original-url`, then `http://localhost`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
