### PR TITLE
docs: use cleaner imports in examples and add read more links to config

### DIFF
--- a/docs/1.docs/2.quick-start.md
+++ b/docs/1.docs/2.quick-start.md
@@ -61,9 +61,9 @@ export default defineConfig({
 Create a `nitro.config.ts` to configure the server directory:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverDir: "./server",
 });
 ```
@@ -83,9 +83,9 @@ export default defineHandler(() => {
 });
 ```
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverDir: "./server",
 });
 ```

--- a/docs/1.docs/4.renderer.md
+++ b/docs/1.docs/4.renderer.md
@@ -15,9 +15,9 @@ The renderer is a special handler in Nitro that catches all routes that don't ma
 The renderer is configured using the `renderer` option in your Nitro config:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   renderer: {
     template: './index.html',  // Path to HTML template file
     handler: './renderer.ts',  // Path to custom renderer handler
@@ -80,9 +80,9 @@ You can specify a custom HTML template file using the `renderer.template` option
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   renderer: {
     template: './app.html'
   }
@@ -111,9 +111,9 @@ By default, Nitro auto-detects whether your HTML template contains [rendu](#hype
 You can override this behavior with the `static` option:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   renderer: {
     template: './index.html',
     static: true // Force static serving, skip template processing
@@ -248,9 +248,9 @@ export default function renderer({ req }: { req: Request }) {
 Then, specify the renderer entry in the Nitro config:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   renderer: {
     handler: './renderer.ts'
   }

--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -213,9 +213,9 @@ routes/
 You can use the `ignore` config option to exclude files from route scanning. It accepts an array of glob patterns relative to the server directory.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   ignore: [
     "routes/api/**/_*",   // Ignore files starting with _ in api/
     "middleware/_*.ts",    // Ignore middleware starting with _
@@ -233,9 +233,9 @@ In addition to filesystem routing, you can register route handlers programmatica
 The `routes` option allows you to map route patterns to handlers:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routes: {
     "/api/hello": "./server/routes/api/hello.ts",
     "/api/custom": {
@@ -265,9 +265,9 @@ Each route entry can be a simple string (handler path) or an object with the fol
 The `handlers` array is useful for registering middleware with control over route matching:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   handlers: [
     {
       route: "/api/**",
@@ -402,9 +402,9 @@ export default defineHandler((event) => {
 You can register middleware for specific route patterns using the [`handlers`](#handlers-config) config with the `middleware` option and a specific `route`:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   handlers: [
     {
       route: "/api/**",
@@ -437,7 +437,7 @@ Nitro allows you to add logic at the top-level for each route of your configurat
 
 It is a map from route pattern (following [rou3](https://github.com/h3js/rou3)) to route options.
 
-When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedEventHandler`. See the [cache guide](/docs/cache) to learn more about this function.
+When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedHandler`. See the [cache guide](/docs/cache) to learn more about this function.
 
 ::note
 `swr: true|number` is shortcut for `cache: { swr: true, maxAge: number }`
@@ -448,7 +448,7 @@ You can set route rules in the `nitro.routeRules` options.
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/blog/**': { swr: true },
     '/blog2/**': { swr: 600 },
@@ -472,9 +472,9 @@ Route rules are matched from least specific to most specific. When multiple rule
 You can use `false` to disable a rule that was set by a more general pattern:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/api/cached/**': { swr: true },
     '/api/cached/no-cache': { cache: false, swr: false },
@@ -489,9 +489,9 @@ export default defineNitroConfig({
 Set custom response headers for matching routes:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/api/**': { headers: { 'cache-control': 's-maxage=60' } },
     '**': { headers: { 'x-powered-by': 'Nitro' } },
@@ -506,9 +506,9 @@ Enable CORS headers with the `cors: true` shortcut. This sets `access-control-al
 You can override individual CORS headers using `headers`:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/api/v1/**': {
       cors: true,
@@ -523,9 +523,9 @@ export default defineNitroConfig({
 Redirect matching routes to another URL. Use a string for a simple redirect (defaults to `307` status), or an object for more control:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     // Simple redirect (307 status)
     '/old-page': { redirect: '/new-page' },
@@ -542,9 +542,9 @@ export default defineNitroConfig({
 Proxy requests to another URL. Supports both internal and external targets:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     // Proxy to exact URL
     '/api/proxy/example': { proxy: 'https://example.com' },
@@ -568,9 +568,9 @@ export default defineNitroConfig({
 Protect routes with HTTP Basic Authentication:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/admin/**': {
       basicAuth: {
@@ -590,9 +590,9 @@ export default defineNitroConfig({
 Control caching behavior with `cache`, `swr`, or `static` options:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     // Enable stale-while-revalidate caching
     '/blog/**': { swr: true },
@@ -621,9 +621,9 @@ export default defineNitroConfig({
 Mark routes for prerendering at build time:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/about': { prerender: true },
     '/dynamic/**': { prerender: false },
@@ -636,9 +636,9 @@ export default defineNitroConfig({
 Configure Incremental Static Regeneration for Vercel deployments:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/isr/**': { isr: true },
     '/isr-ttl/**': { isr: 60 },
@@ -673,9 +673,9 @@ export default defineNitroConfig({
 Route rules can be provided through `runtimeConfig`, allowing overrides via environment variables without rebuilding:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   runtimeConfig: {
     nitro: {
       routeRules: {

--- a/docs/1.docs/50.assets.md
+++ b/docs/1.docs/50.assets.md
@@ -65,9 +65,9 @@ You can configure additional public asset directories using the `publicAssets` c
 - `ignore` -- Pass `false` to disable ignore patterns, or an array of glob patterns to override the global `ignore` option.
 
 ```js [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   publicAssets: [
     {
       baseURL: "build",
@@ -87,9 +87,9 @@ Nitro can generate pre-compressed versions of your public assets during the buil
 Set `compressPublicAssets: true` to enable all encodings:
 
 ```js [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   compressPublicAssets: true,
 });
 ```
@@ -97,9 +97,9 @@ export default defineNitroConfig({
 Or pick specific encodings:
 
 ```js [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   compressPublicAssets: {
     gzip: true,
     brotli: true,
@@ -144,9 +144,9 @@ Each entry in `serverAssets` supports the following properties:
 - `ignore` -- Array of glob patterns to exclude files.
 
 ```js [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverAssets: [
     {
       baseName: "templates",

--- a/docs/1.docs/50.configuration.md
+++ b/docs/1.docs/50.configuration.md
@@ -15,9 +15,9 @@ See [config reference](/config) for available options.
 You can customize your Nitro builder with a configuration file.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   // Nitro options
 })
 ```
@@ -44,9 +44,9 @@ export default defineConfig({
 Using [c12](https://github.com/unjs/c12) conventions, you can provide environment-specific overrides using `$development` and `$production` keys:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   logLevel: 3,
   $development: {
     // Options applied only in development mode
@@ -66,9 +66,9 @@ The environment name is `"development"` during `nitro dev` and `"production"` du
 You can extend from other configs or presets using the `extends` key:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   extends: "./base.config",
 })
 ```
@@ -91,9 +91,9 @@ Nitro provides several options for controlling directory structure:
 | `output.publicDir` | `.output/public` | Public assets output directory. |
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverDir: "server",
   buildDir: "node_modules/.nitro",
   output: {
@@ -122,9 +122,9 @@ Nitro provides a runtime config API to expose configuration within your applicat
 First, you need to define the runtime config in your configuration file.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   runtimeConfig: {
     apiToken: "dev_token", // `dev_token` is the default value
   }
@@ -147,9 +147,9 @@ export default defineHandler((event) => {
 Runtime config supports nested objects. Keys at any depth are mapped to environment variables using the `NITRO_` prefix and `UPPER_SNAKE_CASE` conversion:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   runtimeConfig: {
     database: {
       host: "localhost",
@@ -219,9 +219,9 @@ NITRO_HELLO_WORLD="foo"
 You can configure a secondary environment variable prefix using the `nitro.envPrefix` runtime config key. This prefix is checked in addition to the default `NITRO_` prefix:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   runtimeConfig: {
     nitro: {
       envPrefix: "APP_",
@@ -238,9 +238,9 @@ With this configuration, both `NITRO_API_TOKEN` and `APP_API_TOKEN` will be chec
 When enabled, environment variable references using `{{VAR_NAME}}` syntax in runtime config string values are expanded at runtime:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   experimental: {
     envExpansion: true,
   },

--- a/docs/1.docs/50.database.md
+++ b/docs/1.docs/50.database.md
@@ -16,9 +16,9 @@ The default database connection is **preconfigured** with [SQLite](https://db0.u
 In order to enable database layer you need to enable experimental feature flag.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   experimental: {
     database: true
   }
@@ -126,9 +126,9 @@ const result = await stmt.bind("1001").all();
 You can configure database connections using `database` config:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   database: {
     default: {
       connector: "sqlite",
@@ -149,9 +149,9 @@ export default defineNitroConfig({
 Use the `devDatabase` config to override the database configuration **only for development mode**. This is useful for using a local SQLite database during development while targeting a different database in production.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   database: {
     default: {
       connector: "postgresql",

--- a/docs/1.docs/50.lifecycle.md
+++ b/docs/1.docs/50.lifecycle.md
@@ -43,9 +43,9 @@ Static assets also support content negotiation for pre-compressed files (gzip, b
 The matching route rules defined in the Nitro config will execute. Route rules run as middleware so most of them alter the response without terminating it (for instance, adding a header or setting a cache policy).
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     '/**': { headers: { 'x-nitro': 'first' } }
   }
@@ -158,9 +158,9 @@ Errors are also tracked per-request in `event.req.context.nitro.errors` for insp
 You can provide a custom error handler in the Nitro config to control error response formatting:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   errorHandler: "~/error",
 })
 ```

--- a/docs/1.docs/50.plugins.md
+++ b/docs/1.docs/50.plugins.md
@@ -24,9 +24,9 @@ export default definePlugin((nitroApp) => {
 If you have plugins in another directory, you can use the `plugins` option:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   plugins: ['my-plugins/hello.ts']
 })
 ```

--- a/docs/1.docs/50.tasks.md
+++ b/docs/1.docs/50.tasks.md
@@ -15,9 +15,9 @@ icon: codicon:run-all
 In order to use the tasks API you need to enable experimental feature flag.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   experimental: {
     tasks: true
   }
@@ -80,9 +80,9 @@ interface TaskEvent {
 In addition to file-based scanning, tasks can be registered directly in the Nitro config. This is useful for tasks provided by modules or pointing to custom handler paths.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   experimental: {
     tasks: true
   },
@@ -102,9 +102,9 @@ If a task is both scanned from the `tasks/` directory and defined in the config,
 You can define scheduled tasks using Nitro configuration to automatically run after each period of time.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   scheduledTasks: {
     // Run `cms:update` task every minute
     '* * * * *': ['cms:update'],

--- a/docs/1.docs/6.server-entry.md
+++ b/docs/1.docs/6.server-entry.md
@@ -138,9 +138,9 @@ For Node.js frameworks that use `(req, res)` style handlers (like [Express](http
 You can specify a custom server entry file using the `serverEntry` option in your Nitro configuration:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverEntry: "./nitro.server.ts"
 })
 ```
@@ -148,9 +148,9 @@ export default defineNitroConfig({
 You can also provide an object with `handler` and `format` options:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverEntry: {
     handler: "./server.ts",
     format: "node" // "web" (default) or "node"
@@ -172,9 +172,9 @@ When auto-detecting, the format is determined by the filename: `server.node.ts` 
 Set `serverEntry` to `false` to disable auto-detection and prevent Nitro from using any server entry:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverEntry: false
 })
 ```

--- a/docs/1.docs/7.cache.md
+++ b/docs/1.docs/7.cache.md
@@ -129,9 +129,9 @@ This feature enables you to add caching routes based on a glob pattern directly 
 Cache all the blog routes for 1 hour with `stale-while-revalidate` behavior:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     "/blog/**": { cache: { maxAge: 60 * 60 } },
   },
@@ -141,9 +141,9 @@ export default defineNitroConfig({
 If we want to use a [custom cache storage](#cache-storage) mount point, we can use the `base` option.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   storage: {
     redis: {
       driver: "redis",
@@ -161,9 +161,9 @@ export default defineNitroConfig({
 You can use the `swr` shortcut for enabling `stale-while-revalidate` caching on route rules. When set to `true`, SWR is enabled with the default `maxAge`. When set to a number, it is used as the `maxAge` value in seconds.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     "/blog/**": { swr: true },
     "/api/**": { swr: 3600 },
@@ -174,9 +174,9 @@ export default defineNitroConfig({
 To explicitly disable caching on a route, set `cache: false`:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     "/api/realtime/**": { cache: false },
   },
@@ -197,9 +197,9 @@ Nitro stores the data in the `cache` storage mount point.
 To overwrite the production storage, set the `cache` mount point using the `storage` option:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   storage: {
     cache: {
       driver: 'redis',
@@ -212,9 +212,9 @@ export default defineNitroConfig({
 In development, you can also overwrite the cache mount point using the `devStorage` option:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   storage: {
     cache: {
       // production cache storage

--- a/docs/1.docs/8.storage.md
+++ b/docs/1.docs/8.storage.md
@@ -83,9 +83,9 @@ You can mount one or multiple custom storage drivers using the `storage` option.
 The key is the mount point name, and the value is the driver name and configuration.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   storage: {
     redis: {
       driver: "redis",
@@ -108,9 +108,9 @@ You can use the `devStorage` option to override storage configuration during dev
 This is useful when your production driver is not available in development (e.g., a managed Redis instance).
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   storage: {
     db: {
       driver: "redis",
@@ -190,9 +190,9 @@ export default defineHandler(async () => {
 You can register additional asset directories using the `serverAssets` config option:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   serverAssets: [
     {
       baseName: "templates",

--- a/docs/1.docs/99.migration.md
+++ b/docs/1.docs/99.migration.md
@@ -36,7 +36,7 @@ The NPM package [nitropack](https://www.npmjs.com/package/nitropack) (v2) has be
 
 ```diff
 -- import { defineNitroConfig } from "nitropack/config"
-++ import { defineNitroConfig } from "nitro/config"
+++ import { defineConfig } from "nitro"
 ```
 
 ## nitro/runtime

--- a/docs/2.deploy/0.index.md
+++ b/docs/2.deploy/0.index.md
@@ -48,9 +48,9 @@ nitro build --preset cloudflare_pages
 **Example:** Updating the `nitro.config.ts` file
 
 ```ts
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   preset: 'cloudflare_pages'
 })
 ```

--- a/docs/2.deploy/20.providers/aws-amplify.md
+++ b/docs/2.deploy/20.providers/aws-amplify.md
@@ -24,9 +24,9 @@ Integration with this provider is possible with [zero configuration](/deploy/#ze
 You can configure advanced options of this preset using `awsAmplify` option.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   awsAmplify: {
       // catchAllStaticFallback: true,
       // imageOptimization: { path: "/_image", cacheControl: "public, max-age=3600, immutable" },

--- a/docs/2.deploy/20.providers/aws.md
+++ b/docs/2.deploy/20.providers/aws.md
@@ -23,9 +23,9 @@ const { statusCode, headers, body } = handler({ rawPath: '/' })
 Nitro output, by default uses dynamic chunks for lazy loading code only when needed. However this sometimes can not be ideal for performance. (See discussions in [nitrojs/nitro#650](https://github.com/nitrojs/nitro/pull/650)). You can enabling chunk inlining behavior using [`inlineDynamicImports`](/config#inlinedynamicimports) config.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   inlineDynamicImports: true
 });
 ```
@@ -38,9 +38,9 @@ export default defineNitroConfig({
 In order to enable response streaming, enable `awsLambda.streaming` flag:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   awsLambda: {
     streaming: true
   }

--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -19,9 +19,9 @@ To use Workers with Static Assets, you need a Nitro compatibility date set to `2
 The following shows an example `nitro.config.ts` file for deploying a Nitro app to Cloudflare Workers.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
     compatibilityDate: "2024-09-19",
     preset: "cloudflare_module",
     cloudflare: {
@@ -102,9 +102,9 @@ export default defineConfig({
 When using [Nitro tasks](/docs/tasks) with `scheduledTasks`, Nitro automatically generates [Cron Triggers](https://developers.cloudflare.com/workers/configuration/cron-triggers/) in the wrangler config at build time.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   preset: "cloudflare_module",
   experimental: {
     tasks: true,
@@ -138,9 +138,9 @@ Cloudflare [Workers Module](#cloudflare-workers) is the new recommended preset f
 The following shows an example `nitro.config.ts` file for deploying a Nitro app to Cloudflare Pages.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
     preset: "cloudflare_pages",
     cloudflare: {
       deployConfig: true,
@@ -350,9 +350,9 @@ you will be able to access the `MY_VARIABLE` and `MY_KV` from the request event 
 If you have multiple Wrangler environments, you can specify which Wrangler environment to use during Cloudflare dev emulation:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   preset: 'cloudflare_module',
   cloudflare: {
     dev: {

--- a/docs/2.deploy/20.providers/iis.md
+++ b/docs/2.deploy/20.providers/iis.md
@@ -25,9 +25,9 @@ You can use IIS http handler directly.
 ## IIS config options
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   // IIS options default
   iis: {
     // merges in a pre-existing web.config file to the nitro default file

--- a/docs/2.deploy/20.providers/vercel.md
+++ b/docs/2.deploy/20.providers/vercel.md
@@ -37,7 +37,7 @@ Nitro `/api` directory isn't compatible with Vercel. Instead, you should use:
 You can use [Bun](https://bun.com) instead of Node.js by specifying the runtime using the `vercel.functions` key inside `nitro.config`:
 
 ```ts [nitro.config.ts]
-export default defineNitroConfig({
+export default defineConfig({
   vercel: {
     functions: {
       runtime: "bun1.x"
@@ -62,9 +62,9 @@ Use `vercel.functionRules` to override [serverless function settings](https://ve
 This is useful when certain routes need different resource limits, regions, or features like [Vercel Queues triggers](https://vercel.com/docs/queues).
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   vercel: {
     functionRules: {
       "/api/heavy-computation": {
@@ -89,7 +89,7 @@ Route patterns support wildcards via [rou3](https://github.com/h3js/rou3) matchi
 Nitro automatically optimizes `proxy` route rules on Vercel by generating [CDN-level rewrites](https://vercel.com/docs/rewrites) at build time. This means matching requests are proxied at the edge without invoking a serverless function, reducing latency and cost.
 
 ```ts [nitro.config.ts]
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     // Proxied at CDN level — no function invocation
     "/api/**": {
@@ -127,9 +127,9 @@ Response headers defined on the route rule via the `headers` option are still ap
 Nitro automatically converts your [`scheduledTasks`](/docs/tasks#scheduled-tasks) configuration into [Vercel Cron Jobs](https://vercel.com/docs/cron-jobs) at build time. Define your schedules in your Nitro config and deploy - no manual `vercel.json` cron configuration required.
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   experimental: {
     tasks: true
   },
@@ -164,9 +164,9 @@ To revalidate a page on demand:
 2. Update your configuration:
 
     ```ts [nitro.config.ts]
-    import { defineNitroConfig } from "nitro/config";
+    import { defineConfig } from "nitro";
 
-    export default defineNitroConfig({
+    export default defineConfig({
       vercel: {
         config: {
           bypassToken: process.env.VERCEL_BYPASS_TOKEN
@@ -193,7 +193,7 @@ You can pass an options object to `isr` route rule to configure caching behavior
 - `exposeErrBody`: When `true`, expose the response body regardless of status code including error status codes. (default `false`
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   routeRules: {
     "/products/**": {
       isr: {

--- a/docs/2.deploy/20.providers/zephyr.md
+++ b/docs/2.deploy/20.providers/zephyr.md
@@ -37,9 +37,9 @@ Zephyr is a little different here from most Nitro providers: we recommend enabli
 If your CI pipeline already runs `nitro build`, enable deployment during the build step:
 
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   preset: "zephyr",
   zephyr: {
     deployOnBuild: true,

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -4,7 +4,7 @@ icon: ri:settings-3-line
 
 # Config
 
-:read-more{to="/guide/configuration"}
+:read-more{to="/docs/configuration"}
 
 ## General
 
@@ -17,7 +17,7 @@ Preset for development mode is always `nitro_dev` and default `node_server` for 
 The preset will automatically be detected when the `preset` option is not set and running in known environments.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   preset: "cloudflare_pages", // deploy to Cloudflare Pages
 });
 ```
@@ -29,7 +29,7 @@ export default defineNitroConfig({
 Enable debug mode for verbose logging and additional development information.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   debug: true,
 });
 ```
@@ -41,7 +41,7 @@ export default defineNitroConfig({
 Log verbosity level. See [consola](https://github.com/unjs/consola?tab=readme-ov-file#log-level) for more information.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   logLevel: 4, // verbose logging
 });
 ```
@@ -55,7 +55,7 @@ Server runtime configuration.
 **Note:** `nitro` namespace is reserved.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   runtimeConfig: {
     apiSecret: "default-secret", // override with NITRO_API_SECRET
   },
@@ -71,7 +71,7 @@ Set it to latest tested date in `YYYY-MM-DD` format to leverage latest preset fe
 If this configuration is not provided, Nitro will use `"latest"` behavior by default.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   compatibilityDate: "2025-01-01",
 });
 ```
@@ -83,7 +83,7 @@ export default defineNitroConfig({
 Enable static site generation mode.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   static: true, // prerender all routes
 });
 ```
@@ -109,7 +109,7 @@ Enable runtime hooks for request and response.
 Enable WebSocket support.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   features: {
     runtimeHooks: true,
     websocket: true, // enable WebSocket support
@@ -158,7 +158,7 @@ Enable experimental database support. See [Database](/docs/database).
 Enable experimental tasks support. See [Tasks](/docs/tasks).
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   experimental: {
     typescriptBundlerResolution: true,
     asyncContext: true,
@@ -234,7 +234,7 @@ New features pending for a major version to avoid breaking changes.
 Uses built-in SWR functionality (using caching layer and storage) for Netlify and Vercel presets instead of falling back to ISR behavior.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   future: {
     nativeSWR: true,
   },
@@ -248,7 +248,7 @@ export default defineNitroConfig({
 Storage configuration, read more in the [Storage Layer](/docs/storage) section.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   storage: {
     redis: {
       driver: "redis",
@@ -265,7 +265,7 @@ export default defineNitroConfig({
 Storage configuration overrides for development mode.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   devStorage: {
     redis: {
       driver: "fs",
@@ -277,7 +277,7 @@ export default defineNitroConfig({
 
 ### `database`
 
-Database connection configurations. Requires `experimental.database: true`.
+Database connection configurations. Requires `experimental.database: true`. [Read more](/docs/database).
 
 ```ts
 database: {
@@ -293,7 +293,7 @@ database: {
 Database connection configuration overrides for development mode.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   devDatabase: {
     default: {
       connector: "sqlite",
@@ -307,10 +307,10 @@ export default defineNitroConfig({
 
 - Type: `false`{lang=ts} | `{ handler?: string, static?: boolean, template?: string }`{lang=ts}
 
-Points to main render entry (file should export an event handler as default).
+Points to main render entry (file should export an event handler as default). [Read more](/docs/renderer).
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   renderer: {
     handler: "~/renderer", // path to the render handler
   },
@@ -327,7 +327,7 @@ Serve `public/` assets in production.
 **Note:** It is highly recommended that your edge CDN (Nginx, Apache, Cloud) serves the `.output/public/` directory instead to enable compression and higher level caching.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   serveStatic: "node", // serve static assets using Node.js
 });
 ```
@@ -339,14 +339,14 @@ export default defineNitroConfig({
 If enabled, disables `.output/public` directory creation. Skips copying `public/` dir and also disables pre-rendering.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   noPublicDir: true, // skip public directory output
 });
 ```
 
 ### `publicAssets`
 
-Public asset directories to serve in development and bundle in production.
+Public asset directories to serve in development and bundle in production. [Read more](/docs/assets).
 
 If a `public/` directory is detected, it will be added by default, but you can add more by yourself too!
 
@@ -375,7 +375,7 @@ If enabled, Nitro will generate a pre-compressed (gzip, brotli, and/or zstd) ver
 larger than 1024 bytes into the public directory. Default compression levels are used. Using this option you can support zero overhead asset compression without using a CDN.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   compressPublicAssets: {
     gzip: true,
     brotli: true, // enable gzip and brotli pre-compression
@@ -388,7 +388,7 @@ export default defineNitroConfig({
 Assets can be accessed in server logic and bundled in production. [Read more](/docs/assets#server-assets).
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   serverAssets: [
     {
       baseName: "templates",
@@ -405,7 +405,7 @@ export default defineNitroConfig({
 An array of Nitro modules. Modules can be a string (path), a module object with a `setup` function, or a function.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   modules: [
     "./modules/my-module.ts",
     (nitro) => {
@@ -424,7 +424,7 @@ An array of paths to nitro plugins. They will be executed by order on the first 
 Note that Nitro auto-registers the plugins in the `plugins/` directory, [learn more](/docs/plugins).
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   plugins: [
     "~/plugins/my-plugin.ts",
   ],
@@ -435,7 +435,7 @@ export default defineNitroConfig({
 
 - Default: `{}`
 
-Task definitions. Each key is a task name with a `handler` path and optional `description`.
+Task definitions. Each key is a task name with a `handler` path and optional `description`. [Read more](/docs/tasks).
 
 ```ts
 tasks: {
@@ -450,7 +450,7 @@ tasks: {
 
 - Default: `{}`
 
-Map of cron expressions to task name(s).
+Map of cron expressions to task name(s). [Read more](/docs/tasks).
 
 ```ts
 scheduledTasks: {
@@ -466,7 +466,7 @@ scheduledTasks: {
 Auto import options. Set to an object to enable. See [unimport](https://github.com/unjs/unimport) for more information.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   imports: {
     dirs: ["./utils"], // auto-import from utils/ directory
   },
@@ -480,7 +480,7 @@ export default defineNitroConfig({
 A map from dynamic virtual import names to their contents or an (async) function that returns it.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   virtual: {
     "#config": `export default { version: "1.0.0" }`,
   },
@@ -494,7 +494,7 @@ export default defineNitroConfig({
 Array of glob patterns to ignore when scanning directories.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   ignore: [
     "routes/_legacy/**", // skip legacy route handlers
   ],
@@ -509,7 +509,7 @@ export default defineNitroConfig({
 WASM support configuration. See [unwasm](https://github.com/unjs/unwasm) for options.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   wasm: {}, // enable WASM import support
 });
 ```
@@ -525,7 +525,7 @@ Dev server options. You can use `watch` to make the dev server reload if any fil
 Supports `port`, `hostname`, `watch`, and `runner` options.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   devServer: {
     port: 3001,
     watch: ["./server/plugins"],
@@ -538,7 +538,7 @@ export default defineNitroConfig({
 Watch options for development mode. See [chokidar](https://github.com/paulmillr/chokidar) for more information.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   watchOptions: {
     ignored: ["**/node_modules/**", "**/dist/**"],
   },
@@ -571,7 +571,7 @@ See [httpxy](https://github.com/unjs/httpxy) for all available target options.
 Control build logging behavior. Set `compressedSizes` to `false` to skip reporting compressed bundle sizes. Set `buildSuccess` to `false` to suppress the build success message.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   logging: {
     compressedSizes: false, // skip compressed size reporting
     buildSuccess: false,
@@ -588,7 +588,7 @@ Default: `/`{lang=ts} (or `NITRO_APP_BASE_URL` environment variable if provided)
 Server's main base URL.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   baseURL: "/app/", // serve app under /app/ prefix
 });
 ```
@@ -600,19 +600,19 @@ export default defineNitroConfig({
 Changes the default API base URL prefix.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   apiBaseURL: "/server/api", // api routes under /server/api/
 });
 ```
 
 ### `handlers`
 
-Server handlers and routes.
+Server handlers and routes. [Read more](/docs/routing).
 
 If `routes/`, `api/` or `middleware/` directories exist inside the server directory, they will be automatically added to the handlers array.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   handlers: [
     { route: "/health", handler: "./handlers/health.ts" },
     { route: "/admin/**", handler: "./handlers/admin.ts", method: "get" },
@@ -629,9 +629,9 @@ There are situations in that we directly want to provide a handler instance with
 We can use `devHandlers` but note that they are **only available in development mode** and **not in production build**.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   devHandlers: [
-    { route: "/__dev", handler: eventHandler(() => "dev-only route") },
+    { route: "/__dev", handler: defineHandler(() => "dev-only route") },
   ],
 });
 ```
@@ -643,7 +643,7 @@ export default defineNitroConfig({
 Inline route definitions. A map from route pattern to handler path or handler options.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   routes: {
     "/hello": "./routes/hello.ts",
     "/greet": { handler: "./routes/greet.ts", method: "post" },
@@ -660,15 +660,15 @@ Path(s) to custom runtime error handler(s). Replaces nitro's built-in error page
 **Example:**
 
 ```js [nitro.config]
-import { defineNitroConfig } from "nitro/config";
+import { defineConfig } from "nitro";
 
-export default defineNitroConfig({
+export default defineConfig({
   errorHandler: "~/error",
 });
 ```
 
 ```js [error.ts]
-export default defineNitroErrorHandler((error, event) => {
+export default defineErrorHandler((error, event) => {
   return new Response('[custom error handler] ' + error.stack, {
     headers: { 'Content-Type': 'text/plain' }
   });
@@ -679,9 +679,9 @@ export default defineNitroErrorHandler((error, event) => {
 
 **🧪 Experimental!**
 
-Route options. It is a map from route pattern (following [rou3](https://github.com/h3js/rou3)) to route options.
+Route options. It is a map from route pattern (following [rou3](https://github.com/h3js/rou3)) to route options. [Read more](/docs/routing#route-rules).
 
-When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedEventHandler`.
+When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedHandler`.
 
 See the [Cache API](/docs/cache) for all available cache options.
 
@@ -758,7 +758,7 @@ Project workspace root directory.
 The workspace (e.g. pnpm workspace)  directory is automatically detected when the `workspaceDir` option is not set.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   workspaceDir: "../", // monorepo root
 });
 ```
@@ -768,7 +768,7 @@ export default defineNitroConfig({
 Project main directory.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   rootDir: "./src/server",
 });
 ```
@@ -783,7 +783,7 @@ Server directory for scanning `api/`, `routes/`, `plugins/`, `utils/`, `middlewa
 When set to `false`, automatic directory scanning is disabled. Set to `"./"` to use the root directory, or `"./server"` to use a `server/` subdirectory.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   serverDir: "./server", // scan server/ subdirectory
 });
 ```
@@ -795,7 +795,7 @@ export default defineNitroConfig({
 List of directories to scan and auto-register files, such as API routes.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   scanDirs: ["./modules/auth/api", "./modules/billing/api"],
 });
 ```
@@ -807,7 +807,7 @@ export default defineNitroConfig({
 Defines a different directory to scan for api route handlers.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   apiDir: "endpoints", // scan endpoints/ instead of api/
 });
 ```
@@ -819,7 +819,7 @@ export default defineNitroConfig({
 Defines a different directory to scan for route handlers.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   routesDir: "pages", // scan pages/ instead of routes/
 });
 ```
@@ -831,7 +831,7 @@ export default defineNitroConfig({
 Nitro's temporary working directory for generating build-related files.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   buildDir: ".nitro", // use .nitro/ in project root
 });
 ```
@@ -843,7 +843,7 @@ export default defineNitroConfig({
 Output directories for production bundle.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   output: {
     dir: "dist",
     serverDir: "dist/server",
@@ -862,7 +862,7 @@ export default defineNitroConfig({
 Specify the bundler to use for building.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   builder: "vite",
 });
 ```
@@ -872,7 +872,7 @@ export default defineNitroConfig({
 Additional rollup configuration.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   rollupConfig: {
     output: { manualChunks: { vendor: ["lodash-es"] } },
   },
@@ -884,7 +884,7 @@ export default defineNitroConfig({
 Additional rolldown configuration.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   rolldownConfig: {
     output: { banner: "/* built with nitro */" },
   },
@@ -896,7 +896,7 @@ export default defineNitroConfig({
 Bundler entry point.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   entry: "./server/entry.ts", // custom entry file
 });
 ```
@@ -906,7 +906,7 @@ export default defineNitroConfig({
 [unenv](https://github.com/unjs/unenv/) preset(s) for environment compatibility.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   unenv: {
     alias: { "my-module": "my-module/web" },
   },
@@ -918,7 +918,7 @@ export default defineNitroConfig({
 Path aliases for module resolution.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   alias: {
     "~utils": "./src/utils",
     "#shared": "./shared",
@@ -933,7 +933,7 @@ export default defineNitroConfig({
 Minify bundle.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   minify: true, // minify production bundle
 });
 ```
@@ -947,7 +947,7 @@ Bundle all code into a single file instead of creating separate chunks per route
 When `false`, each route handler becomes a separate chunk loaded on-demand. When `true`, everything is bundled together. Some presets enable this by default.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   inlineDynamicImports: true, // single output file
 });
 ```
@@ -959,7 +959,7 @@ export default defineNitroConfig({
 Enable source map generation. See [options](https://rollupjs.org/configuration-options/#output-sourcemap).
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   sourcemap: true, // generate .map files
 });
 ```
@@ -971,7 +971,7 @@ export default defineNitroConfig({
 Specify whether the build is used for Node.js or not. If set to `false`, nitro tries to mock Node.js dependencies using [unenv](https://github.com/unjs/unenv) and adjust its behavior.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   node: false, // target non-Node.js runtimes
 });
 ```
@@ -981,7 +981,7 @@ export default defineNitroConfig({
 Build-time string replacements.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   replace: {
     "process.env.APP_VERSION": JSON.stringify("1.0.0"),
   },
@@ -993,7 +993,7 @@ export default defineNitroConfig({
 Specifies additional configuration for the rollup CommonJS plugin.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   commonJS: {
     requireReturnsDefault: "auto",
   },
@@ -1005,7 +1005,7 @@ export default defineNitroConfig({
 Custom export conditions for module resolution.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   exportConditions: ["worker", "production"],
 });
 ```
@@ -1017,7 +1017,7 @@ export default defineNitroConfig({
 Prevent specific packages from being externalized. Set to `true` to bundle all dependencies, or pass an array of package names/patterns.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   noExternals: true, // bundle all dependencies
 });
 ```
@@ -1033,7 +1033,7 @@ Supports special prefixes:
 - `pkg*` — Full trace: copies all package files instead of only traced ones.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   traceDeps: [
     "sharp",
     "better-sqlite3",
@@ -1048,7 +1048,7 @@ export default defineNitroConfig({
 Advanced options passed to [nf3](https://github.com/nicolo-ribaudo/nf3) for dependency tracing.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   traceOpts: {
     // Options passed to @vercel/nft for file tracing
     nft: { /* ... */ },
@@ -1075,7 +1075,7 @@ export default defineNitroConfig({
 OXC options for rolldown builds. Includes `minify` and `transform` sub-options.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   oxc: {
     minify: { compress: true, mangle: true },
   },
@@ -1091,7 +1091,7 @@ export default defineNitroConfig({
 **⚠️ Caution! This is an advanced configuration. Things can go wrong if misconfigured.**
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   dev: true, // force development mode behavior
 });
 ```
@@ -1103,7 +1103,7 @@ Default: `{ strict: true, generateRuntimeConfigTypes: false, generateTsConfig: f
 TypeScript configuration options including `strict`, `generateRuntimeConfigTypes`, `generateTsConfig`, `tsConfig`, `generatedTypesDir`, and `tsconfigPath`.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   typescript: {
     strict: true,
     generateTsConfig: true,
@@ -1115,10 +1115,10 @@ export default defineNitroConfig({
 
 **⚠️ Caution! This is an advanced configuration. Things can go wrong if misconfigured.**
 
-nitro hooks. See [hookable](https://github.com/unjs/hookable) for more information.
+Nitro hooks. [Read more](/docs/lifecycle). See [hookable](https://github.com/unjs/hookable) for more information.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   hooks: {
     compiled(nitro) {
       console.log("Build compiled successfully!");
@@ -1134,7 +1134,7 @@ export default defineNitroConfig({
 Preview and deploy command hints are usually filled by deployment presets.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   commands: {
     preview: "node ./server/index.mjs",
   },
@@ -1148,7 +1148,7 @@ export default defineNitroConfig({
 A custom error handler function for development errors.
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   devErrorHandler: (error, event) => {
     return new Response(`Dev error: ${error.message}`, { status: 500 });
   },
@@ -1162,7 +1162,7 @@ export default defineNitroConfig({
 Framework information. Used by presets and build info. Typically set by higher-level frameworks (e.g. Nuxt).
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   framework: { name: "my-framework", version: "2.0.0" },
 });
 ```
@@ -1174,7 +1174,7 @@ export default defineNitroConfig({
 The options for the firebase functions preset. See [Preset Docs](/deploy/providers/firebase#options)
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   firebase: {
     gen: 2, // use Cloud Functions 2nd gen
     region: "us-central1",
@@ -1187,7 +1187,7 @@ export default defineNitroConfig({
 The options for the vercel preset. See [Preset Docs](/deploy/providers/vercel)
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   vercel: {
     config: { runtime: "nodejs20.x" },
   },
@@ -1199,7 +1199,7 @@ export default defineNitroConfig({
 The options for the cloudflare preset. See [Preset Docs](/deploy/providers/cloudflare)
 
 ```ts
-export default defineNitroConfig({
+export default defineConfig({
   cloudflare: {
     wrangler: { compatibility_date: "2025-01-01" },
   },

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -245,7 +245,7 @@ export default defineConfig({
 
 - Default: `{}`
 
-Storage configuration, read more in the [Storage Layer](/docs/storage) section.
+Storage configuration.
 
 ```ts
 export default defineConfig({
@@ -257,6 +257,8 @@ export default defineConfig({
   },
 });
 ```
+
+:read-more{to="/docs/storage"}
 
 ### `devStorage`
 
@@ -277,7 +279,7 @@ export default defineConfig({
 
 ### `database`
 
-Database connection configurations. Requires `experimental.database: true`. [Read more](/docs/database).
+Database connection configurations. Requires `experimental.database: true`.
 
 ```ts
 database: {
@@ -287,6 +289,8 @@ database: {
   }
 }
 ```
+
+:read-more{to="/docs/database"}
 
 ### `devDatabase`
 
@@ -307,7 +311,7 @@ export default defineConfig({
 
 - Type: `false`{lang=ts} | `{ handler?: string, static?: boolean, template?: string }`{lang=ts}
 
-Points to main render entry (file should export an event handler as default). [Read more](/docs/renderer).
+Points to main render entry (file should export an event handler as default).
 
 ```ts
 export default defineConfig({
@@ -316,6 +320,8 @@ export default defineConfig({
   },
 });
 ```
+
+:read-more{to="/docs/renderer"}
 
 ### `serveStatic`
 
@@ -346,7 +352,7 @@ export default defineConfig({
 
 ### `publicAssets`
 
-Public asset directories to serve in development and bundle in production. [Read more](/docs/assets).
+Public asset directories to serve in development and bundle in production.
 
 If a `public/` directory is detected, it will be added by default, but you can add more by yourself too!
 
@@ -367,6 +373,8 @@ The config above generates the following header in the assets under `public/imag
 
 The `dir` option is where your files live on your file system; the `baseURL` option is the folder they will be accessible from when served/bundled.
 
+:read-more{to="/docs/assets"}
+
 ### `compressPublicAssets`
 
 - Default: `{ gzip: false, brotli: false, zstd: false }`{lang=ts}
@@ -385,7 +393,7 @@ export default defineConfig({
 
 ### `serverAssets`
 
-Assets can be accessed in server logic and bundled in production. [Read more](/docs/assets#server-assets).
+Assets can be accessed in server logic and bundled in production.
 
 ```ts
 export default defineConfig({
@@ -397,6 +405,8 @@ export default defineConfig({
   ],
 });
 ```
+
+:read-more{to="/docs/assets#server-assets"}
 
 ### `modules`
 
@@ -421,7 +431,7 @@ export default defineConfig({
 
 An array of paths to nitro plugins. They will be executed by order on the first initialization.
 
-Note that Nitro auto-registers the plugins in the `plugins/` directory, [learn more](/docs/plugins).
+Note that Nitro auto-registers the plugins in the `plugins/` directory.
 
 ```ts
 export default defineConfig({
@@ -431,11 +441,13 @@ export default defineConfig({
 });
 ```
 
+:read-more{to="/docs/plugins"}
+
 ### `tasks`
 
 - Default: `{}`
 
-Task definitions. Each key is a task name with a `handler` path and optional `description`. [Read more](/docs/tasks).
+Task definitions. Each key is a task name with a `handler` path and optional `description`.
 
 ```ts
 tasks: {
@@ -446,11 +458,13 @@ tasks: {
 }
 ```
 
+:read-more{to="/docs/tasks"}
+
 ### `scheduledTasks`
 
 - Default: `{}`
 
-Map of cron expressions to task name(s). [Read more](/docs/tasks).
+Map of cron expressions to task name(s).
 
 ```ts
 scheduledTasks: {
@@ -458,6 +472,8 @@ scheduledTasks: {
   '*/5 * * * *': ['health:check', 'metrics:collect']
 }
 ```
+
+:read-more{to="/docs/tasks"}
 
 ### `imports`
 
@@ -607,7 +623,7 @@ export default defineConfig({
 
 ### `handlers`
 
-Server handlers and routes. [Read more](/docs/routing).
+Server handlers and routes.
 
 If `routes/`, `api/` or `middleware/` directories exist inside the server directory, they will be automatically added to the handlers array.
 
@@ -619,6 +635,8 @@ export default defineConfig({
   ],
 });
 ```
+
+:read-more{to="/docs/routing"}
 
 ### `devHandlers`
 
@@ -679,7 +697,7 @@ export default defineErrorHandler((error, event) => {
 
 **🧪 Experimental!**
 
-Route options. It is a map from route pattern (following [rou3](https://github.com/h3js/rou3)) to route options. [Read more](/docs/routing#route-rules).
+Route options. It is a map from route pattern (following [rou3](https://github.com/h3js/rou3)) to route options.
 
 When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedHandler`.
 
@@ -707,6 +725,8 @@ routeRules: {
   '/admin/**': { basicAuth: { username: 'admin', password: 'secret' } },
 }
 ```
+
+:read-more{to="/docs/routing#route-rules"}
 
 ### `prerender`
 
@@ -1115,7 +1135,7 @@ export default defineConfig({
 
 **⚠️ Caution! This is an advanced configuration. Things can go wrong if misconfigured.**
 
-Nitro hooks. [Read more](/docs/lifecycle). See [hookable](https://github.com/unjs/hookable) for more information.
+Nitro hooks. See [hookable](https://github.com/unjs/hookable) for more information.
 
 ```ts
 export default defineConfig({
@@ -1126,6 +1146,8 @@ export default defineConfig({
   },
 });
 ```
+
+:read-more{to="/docs/lifecycle"}
 
 ### `commands`
 

--- a/docs/4.examples/plugins.md
+++ b/docs/4.examples/plugins.md
@@ -33,9 +33,9 @@ export default defineConfig({
 ```
 
 ```ts [server.ts]
-import { eventHandler } from "h3";
+import { defineHandler } from "nitro";
 
-export default eventHandler(() => "<h1>Hello Nitro!</h1>");
+export default defineHandler(() => "<h1>Hello Nitro!</h1>");
 ```
 
 ```json [tsconfig.json]
@@ -90,9 +90,9 @@ The plugin uses `useNitroHooks()` to access the hooks system, then registers a `
 ## Main Handler
 
 ```ts [server.ts]
-import { eventHandler } from "h3";
+import { defineHandler } from "nitro";
 
-export default eventHandler(() => "<h1>Hello Nitro!</h1>");
+export default defineHandler(() => "<h1>Hello Nitro!</h1>");
 ```
 
 The handler returns HTML without setting a content type. The plugin automatically adds the correct `Content-Type: html; charset=utf-8` header to the response.

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -19,9 +19,9 @@ The plugin uses `useNitroHooks()` to access the hooks system, then registers a `
 ## Main Handler
 
 ```ts [server.ts]
-import { eventHandler } from "h3";
+import { defineHandler } from "nitro";
 
-export default eventHandler(() => "<h1>Hello Nitro!</h1>");
+export default defineHandler(() => "<h1>Hello Nitro!</h1>");
 ```
 
 The handler returns HTML without setting a content type. The plugin automatically adds the correct `Content-Type: html; charset=utf-8` header to the response.

--- a/examples/plugins/server.ts
+++ b/examples/plugins/server.ts
@@ -1,3 +1,3 @@
-import { eventHandler } from "h3";
+import { defineHandler } from "nitro";
 
-export default eventHandler(() => "<h1>Hello Nitro!</h1>");
+export default defineHandler(() => "<h1>Hello Nitro!</h1>");


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Switches imports to `import { defineConfig } from 'nitro'` rather than `import { defineNitroConfig } from 'nitro/config'`, and adds read more links in the config page to link to the dedicated docs pages.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
