### PR TITLE
fix: always run basicAuth route rule first

### DIFF
--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -10,7 +10,6 @@ import type { H3Config, H3EventContext, Middleware, WebSocketHooks } from "h3";
 import { H3Core, toRequest } from "h3";
 import { HookableCore } from "hookable";
 import { nitroAsyncContext } from "./context.ts";
-import { RouteRuleOrder } from "./route-rules.ts";
 
 // IMPORTANT: virtual imports and user code should be imported last to avoid initialization order issues
 import errorHandler from "#nitro/virtual/error-handler";
@@ -244,7 +243,7 @@ export function getRouteRules(
   }
   const middleware = [];
   const orderedRules = Object.values(routeRules).sort(
-    (a, b) => (RouteRuleOrder[a.name] || 0) - (RouteRuleOrder[b.name] || 0)
+    (a, b) => (a.handler?.order || 0) - (b.handler?.order || 0)
   );
   for (const rule of orderedRules) {
     if (rule.options === false || !rule.handler) {

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -10,6 +10,7 @@ import type { H3Config, H3EventContext, Middleware, WebSocketHooks } from "h3";
 import { H3Core, toRequest } from "h3";
 import { HookableCore } from "hookable";
 import { nitroAsyncContext } from "./context.ts";
+import { RouteRuleOrder } from "./route-rules.ts";
 
 // IMPORTANT: virtual imports and user code should be imported last to avoid initialization order issues
 import errorHandler from "#nitro/virtual/error-handler";
@@ -242,7 +243,10 @@ export function getRouteRules(
     }
   }
   const middleware = [];
-  for (const rule of Object.values(routeRules)) {
+  const orderedRules = Object.values(routeRules).sort(
+    (a, b) => (RouteRuleOrder[a.name] || 0) - (RouteRuleOrder[b.name] || 0)
+  );
+  for (const rule of orderedRules) {
     if (rule.options === false || !rule.handler) {
       continue;
     }

--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -89,3 +89,11 @@ export const basicAuth: RouteRuleCtor<"auth"> = ((m) =>
     await requireBasicAuth(event, m.options as BasicAuthOptions);
     return next();
   }) satisfies RouteRuleCtor<"auth">;
+
+// Execution order for route rule middleware (lower runs first).
+// Rules not listed default to `0`.
+// `basicAuth` must run before `redirect`/`proxy`/`cache` so that unauthorized
+// requests are not redirected or proxied.
+export const RouteRuleOrder: Record<string, number> = {
+  basicAuth: -1,
+};

--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -85,12 +85,14 @@ export const cache: RouteRuleCtor<"cache"> = ((m) =>
 // basicAuth auth route rule
 // Must run before `redirect`/`proxy`/`cache` so unauthorized requests are
 // neither redirected nor proxied.
-export const basicAuth: RouteRuleCtor<"auth"> = ((m) =>
-  async function authRouteRule(event, next) {
-    if (!m.options) {
-      return;
-    }
-    await requireBasicAuth(event, m.options as BasicAuthOptions);
-    return next();
-  }) satisfies RouteRuleCtor<"auth">;
-basicAuth.order = -1;
+export const basicAuth: RouteRuleCtor<"auth"> = /* @__PURE__ */ Object.assign(
+  ((m) =>
+    async function authRouteRule(event, next) {
+      if (!m.options) {
+        return;
+      }
+      await requireBasicAuth(event, m.options as BasicAuthOptions);
+      return next();
+    }) satisfies RouteRuleCtor<"auth">,
+  { order: -1 }
+);

--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -6,7 +6,9 @@ import { defineCachedHandler } from "./cache.ts";
 
 // Note: Remember to update RuntimeRouteRules in src/build/virtual/routing.ts when adding new route rules
 
-type RouteRuleCtor<T extends keyof NitroRouteRules> = (m: MatchedRouteRule<T>) => Middleware;
+type RouteRuleCtor<T extends keyof NitroRouteRules> = ((m: MatchedRouteRule<T>) => Middleware) & {
+  order?: number;
+};
 
 // Headers route rule
 export const headers: RouteRuleCtor<"headers"> = ((m) =>
@@ -81,6 +83,8 @@ export const cache: RouteRuleCtor<"cache"> = ((m) =>
   }) satisfies RouteRuleCtor<"cache">;
 
 // basicAuth auth route rule
+// Must run before `redirect`/`proxy`/`cache` so unauthorized requests are
+// neither redirected nor proxied.
 export const basicAuth: RouteRuleCtor<"auth"> = ((m) =>
   async function authRouteRule(event, next) {
     if (!m.options) {
@@ -89,11 +93,4 @@ export const basicAuth: RouteRuleCtor<"auth"> = ((m) =>
     await requireBasicAuth(event, m.options as BasicAuthOptions);
     return next();
   }) satisfies RouteRuleCtor<"auth">;
-
-// Execution order for route rule middleware (lower runs first).
-// Rules not listed default to `0`.
-// `basicAuth` must run before `redirect`/`proxy`/`cache` so that unauthorized
-// requests are not redirected or proxied.
-export const RouteRuleOrder: Record<string, number> = {
-  basicAuth: -1,
-};
+basicAuth.order = -1;

--- a/src/types/route-rules.ts
+++ b/src/types/route-rules.ts
@@ -33,11 +33,11 @@ export type MatchedRouteRule<K extends keyof NitroRouteRules = "custom"> = {
   options: Exclude<NitroRouteRules[K], false>;
   route: string;
   params?: Record<string, string>;
-  handler?: (opts: unknown) => Middleware;
   /**
-   * Execution order of route rule middleware (lower runs first, default `0`).
+   * Middleware constructor. May expose an `order` property — lower runs first
+   * (default `0`).
    */
-  order?: number;
+  handler?: ((opts: unknown) => Middleware) & { order?: number };
 };
 
 export type MatchedRouteRules = {

--- a/src/types/route-rules.ts
+++ b/src/types/route-rules.ts
@@ -34,6 +34,10 @@ export type MatchedRouteRule<K extends keyof NitroRouteRules = "custom"> = {
   route: string;
   params?: Record<string, string>;
   handler?: (opts: unknown) => Middleware;
+  /**
+   * Execution order of route rule middleware (lower runs first, default `0`).
+   */
+  order?: number;
 };
 
 export type MatchedRouteRules = {

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -123,6 +123,14 @@ export default defineConfig({
       basicAuth: { username: "admin", password: "secret", realm: "Secure Area" },
     },
     "/rules/basic-auth/no-auth/**": { basicAuth: false },
+    "/rules/ba-redirect/**": { redirect: "/base" },
+    "/rules/ba-redirect/secure/**": {
+      basicAuth: { username: "admin", password: "secret", realm: "Secure Area" },
+    },
+    "/rules/ba-proxy/**": { proxy: "/api/echo" },
+    "/rules/ba-proxy/secure/**": {
+      basicAuth: { username: "admin", password: "secret", realm: "Secure Area" },
+    },
     "**": { headers: { "x-test": "test" } },
   },
   prerender: {

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -41,12 +41,13 @@ describe("nitro:preset:netlify", async () => {
         const redirects = await fsp.readFile(resolve(ctx.outDir, "../dist/_redirects"), "utf8");
 
         expect(redirects).toMatchInlineSnapshot(`
-        "/rules/nested/override	/other	302
-        /rules/redirect/wildcard/*	https://nitro.build/:splat	302
-        /rules/redirect/obj	https://nitro.build/	301
-        /rules/nested/*	/base	302
-        /rules/redirect	/base	302
-        "
+          "/rules/nested/override	/other	302
+          /rules/redirect/wildcard/*	https://nitro.build/:splat	302
+          /rules/redirect/obj	https://nitro.build/	301
+          /rules/ba-redirect/*	/base	302
+          /rules/nested/*	/base	302
+          /rules/redirect	/base	302
+          "
         `);
       });
 

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -120,6 +120,13 @@ describe("nitro:preset:vercel:web", async () => {
               },
               {
                 "headers": {
+                  "Location": "/base",
+                },
+                "src": "/rules/ba-redirect/(.*)",
+                "status": 307,
+              },
+              {
+                "headers": {
                   "cache-control": "public, max-age=3600, immutable",
                 },
                 "src": "/build/(.*)",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -417,6 +417,24 @@ export function testNitro(
       const { status } = await callHandler({ url: "/rules/basic-auth/no-auth" });
       expect(status).toBe(200);
     });
+
+    it("runs before redirect rule from a less specific layer", async () => {
+      const { status, headers } = await callHandler({
+        url: "/rules/ba-redirect/secure/page",
+        headers: { Authorization: "Basic " + btoa("user:wrongpass") },
+      });
+      expect(status).toBe(401);
+      expect(headers["www-authenticate"]).toBe('Basic realm="Secure Area"');
+    });
+
+    it("runs before proxy rule from a less specific layer", async () => {
+      const { status, headers } = await callHandler({
+        url: "/rules/ba-proxy/secure/page",
+        headers: { Authorization: "Basic " + btoa("user:wrongpass") },
+      });
+      expect(status).toBe(401);
+      expect(headers["www-authenticate"]).toBe('Basic realm="Secure Area"');
+    });
   });
 
   it("handles route rules - allowing overriding", async () => {


### PR DESCRIPTION
This PR makes sure `basicAuth` route rule (first introduced via #4049 in v3.0.260311-beta) always runs first before others like proxy, etc.