### PR TITLE
fix(dev): accept ipv4-mapped ipv6 loopback in vfs handler

### DIFF
--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -15,8 +15,9 @@ export function createVFSHandler(nitro: Nitro) {
       socket?.readable && socket?.writable && !socket?.remotePort;
 
     const ip = getRequestIP(event, { xForwardedFor: isUnixSocket });
+    const v4 = ip?.toLowerCase().startsWith("::ffff:") ? ip.slice(7) : ip;
 
-    const isLocalRequest = ip && /^::1$|^127\.\d+\.\d+\.\d+$/.test(ip);
+    const isLocalRequest = v4 && /^(?:::1|127\.\d+\.\d+\.\d+)$/.test(v4);
     if (!isLocalRequest) {
       throw new HTTPError({
         statusText: `Forbidden IP: "${ip || "?"}"`,


### PR DESCRIPTION
### 🔗 Linked issue

Closes #4205 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Dual-stack Node sockets report loopback connections as `::ffff:127.0.0.1` RFC 4291), which caused the VFS handler to return 403 on platforms like. Strip the `::ffff:` prefix before the loopback check.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
