### PR TITLE
types(vite): make `experimental.vite` optional

### DIFF
--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -24,7 +24,7 @@ export interface NitroPluginConfig extends NitroConfig {
   _nitro?: Nitro;
 
   experimental?: NitroConfig["experimental"] & {
-    vite: {
+    vite?: {
       /**
        * @experimental Enable `?assets` import proposed by https://github.com/vitejs/vite/discussions/20913
        * @default true


### PR DESCRIPTION
### 🔍 Linked Issue

None — trivial type fix.

### 📚 Description

`NitroPluginConfig.experimental.vite` is currently typed as required, even though every field inside it is optional and every call site in `src/build/vite/plugin.ts` already reads it via optional chaining (`pluginConfig.experimental?.vite?.…`).

This makes any `experimental` override that doesn't include `vite` fail to typecheck. For example:

```ts
nitro({
  experimental: {
    tasks: true,
  },
})
```

…produces:

```
Property 'vite' is missing in type '{ tasks: true; }' but required in type '{ vite: { assetsImport?: boolean; serverReload?: boolean; services?: Record<string, ServiceConfig>; }; }'.
```

The workaround is `experimental: { tasks: true, vite: {} }`, but the empty object is meaningless — all three `vite` sub-options have defaults.

### Change

One-character fix: `vite:` → `vite?:` in `src/build/vite/types.ts`. Aligns the declared type with actual runtime behavior.

No behavior change; no call site updates needed (they already optional-chain).

### Checks

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm test` — passes except one pre-existing flake in `test/vite/hmr.test.ts > editing SSR entry (no full-reload)`, which fails on clean `main` without this patch as well