### PR TITLE
feat(tracing): enable tracing channels for unstorage

### DIFF
--- a/src/build/virtual/storage.ts
+++ b/src/build/virtual/storage.ts
@@ -25,8 +25,7 @@ export default function storage(nitro: Nitro) {
       const driverImports = [...new Set(mounts.map((m) => m.driver))];
 
       const tracingEnabled = !!(
-        typeof nitro.options.tracingChannel === "object" &&
-        nitro.options.tracingChannel?.unstorage
+        typeof nitro.options.tracingChannel === "object" && nitro.options.tracingChannel?.unstorage
       );
 
       return /* js */ `

--- a/src/build/virtual/storage.ts
+++ b/src/build/virtual/storage.ts
@@ -24,8 +24,14 @@ export default function storage(nitro: Nitro) {
 
       const driverImports = [...new Set(mounts.map((m) => m.driver))];
 
+      const tracingEnabled = !!(
+        typeof nitro.options.tracingChannel === "object" &&
+        nitro.options.tracingChannel?.unstorage
+      );
+
       return /* js */ `
 import { createStorage } from 'unstorage'
+${tracingEnabled ? `import { withTracing } from 'unstorage/tracing'` : ""}
 import { assets } from '#nitro/virtual/server-assets'
 
 ${driverImports.map((i) => genImport(i, genSafeVariableName(i))).join("\n")}
@@ -39,7 +45,7 @@ export function initStorage() {
         `storage.mount('${m.path}', ${genSafeVariableName(m.driver)}(${JSON.stringify(m.opts)}))`
     )
     .join("\n")}
-  return storage
+  return ${tracingEnabled ? "withTracing(storage)" : "storage"}
 }
 `;
     },

--- a/src/config/resolvers/tracing.ts
+++ b/src/config/resolvers/tracing.ts
@@ -5,6 +5,7 @@ export async function resolveTracingOptions(options: NitroOptions) {
   options.tracingChannel = {
     srvx: true,
     h3: true,
+    unstorage: true,
     ...(typeof options.tracingChannel === "object" ? options.tracingChannel : {}),
   };
   options.plugins = options.plugins || [];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -363,6 +363,7 @@ export interface ServerAssetDir {
 export interface TracingOptions {
   srvx?: boolean;
   h3?: boolean;
+  unstorage?: boolean;
 }
 
 // Storage mounts

--- a/test/unit/virtual-storage.test.ts
+++ b/test/unit/virtual-storage.test.ts
@@ -31,12 +31,8 @@ describe("virtual/storage template", () => {
   });
 
   it("wraps storage with withTracing when tracingChannel.unstorage is true", () => {
-    const template = storage(
-      createNitroStub({ srvx: true, h3: true, unstorage: true })
-    ).template();
-    expect(template).toContain(
-      `import { withTracing } from 'unstorage/tracing'`
-    );
+    const template = storage(createNitroStub({ srvx: true, h3: true, unstorage: true })).template();
+    expect(template).toContain(`import { withTracing } from 'unstorage/tracing'`);
     expect(template).toContain("return withTracing(storage)");
   });
 });

--- a/test/unit/virtual-storage.test.ts
+++ b/test/unit/virtual-storage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { Nitro } from "nitro/types";
+
+import storage from "../../src/build/virtual/storage.ts";
+
+function createNitroStub(tracingChannel: Nitro["options"]["tracingChannel"]): Nitro {
+  return {
+    options: {
+      dev: true,
+      preset: "nitro-dev",
+      storage: {},
+      devStorage: {},
+      tracingChannel,
+    },
+  } as unknown as Nitro;
+}
+
+describe("virtual/storage template", () => {
+  it("does not wrap storage when tracingChannel is disabled", () => {
+    const template = storage(createNitroStub(undefined)).template();
+    expect(template).not.toContain("withTracing");
+    expect(template).not.toContain("unstorage/tracing");
+    expect(template).toContain("return storage");
+  });
+
+  it("does not wrap storage when tracingChannel.unstorage is false", () => {
+    const template = storage(
+      createNitroStub({ srvx: true, h3: true, unstorage: false })
+    ).template();
+    expect(template).not.toContain("withTracing");
+  });
+
+  it("wraps storage with withTracing when tracingChannel.unstorage is true", () => {
+    const template = storage(
+      createNitroStub({ srvx: true, h3: true, unstorage: true })
+    ).template();
+    expect(template).toContain(
+      `import { withTracing } from 'unstorage/tracing'`
+    );
+    expect(template).toContain("return withTracing(storage)");
+  });
+});


### PR DESCRIPTION
Enables tracing channels for `unstorage` calls when `tracingChannel` config option is enabled by wrapping the call with the `withTracing` helper which is available as of the current minimum `unstorage@2.0.0-alpha.7`.

We should do the same for `db0` when it gets released.