### PR TITLE
fix(config): prepend bun export condition under bun runtime

### DIFF
--- a/src/config/resolvers/export-conditions.ts
+++ b/src/config/resolvers/export-conditions.ts
@@ -21,6 +21,9 @@ function _resolveExportConditions(
   }
 
   if (opts.node) {
+    if ("Bun" in globalThis) {
+      conditions.push("bun");
+    }
     conditions.push("node");
   }
 


### PR DESCRIPTION
### Linked Issue

Closes #4228

### Description

`_resolveExportConditions` only pushed `"node"` to Vite's resolve conditions, regardless of the actual dev runtime. Under `bun --bun vite dev`, this caused Vite's `ModuleRunner` (inside the dev worker) to load `srvx/dist/adapters/node.mjs` and `h3/dist/_entries/node.mjs`. The Node adapter's `NodeResponse` wrapper class is then returned from h3's response pipeline to `Bun.serve` — which rejects it (`error: Expected a Response object, but received 'NodeResponse {...}'`) and falls back to its default response, breaking every `/_nitro/*` request with a `Parse Error` from `node:_http_client:230`.

### Change

Detect Bun via `"Bun" in globalThis` and prepend `"bun"` to the conditions list when running under Bun. `"node"` is still pushed unconditionally, so packages that only declare a `"node"` export condition still resolve correctly. For packages declaring both (srvx, h3) the order of the resolve conditions causes `"bun"` to win — picking the Bun adapter as intended.

Pattern matches the existing `"Bun" in globalThis` check in `src/presets/vercel/utils.ts:438`.

### Verified

- Patched the bundled `dist/_chunks/nitro.mjs` in a real Nitro + Vite app — `GET /_nitro/tasks`, `GET/POST /_nitro/tasks/:name`, and the main `GET /` route all return 200 under `bun --bun vite dev`. Scheduled tasks continue to fire.
- `pnpm lint` passes.
- `pnpm typecheck` passes for the modified file (other unrelated type errors are pre-existing on `main`).
- `pnpm build` produces a clean bundle with the expected logic.
- Pure Node setups: behavior is identical to before (the `"Bun" in globalThis` check is false, so the only conditions pushed are the same as `main`).