### PR TITLE
presets(vercel): enable `shouldAddSourcemapSupport` when sourcemap is enabled

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -54,6 +54,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
     launcherType: "Nodejs",
     shouldAddHelpers: false,
     supportsResponseStreaming: true,
+    ...(nitro.options.sourcemap ? { shouldAddSourcemapSupport: true } : {}),
     ...nitro.options.vercel?.functions,
   };
 

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -643,6 +643,7 @@ describe("nitro:preset:vercel:bun", async () => {
         "launcherType": "Nodejs",
         "runtime": "bun1.x",
         "shouldAddHelpers": false,
+        "shouldAddSourcemapSupport": true,
         "supportsResponseStreaming": true,
       }
     `);


### PR DESCRIPTION
related to #4232

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Enables runtime sourcemap support on Vercel when generation of sourcemap is enabled

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
