### PR TITLE
fix(route-rules): prevent open redirect via protocol-relative url bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "tinyglobby": "^0.2.16",
     "tsconfck": "^3.1.6",
     "typescript": "^6.0.3",
-    "ufo": "^1.6.3",
+    "ufo": "^1.6.4",
     "ultrahtml": "^1.6.0",
     "uncrypto": "^0.1.3",
     "unctx": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,8 +282,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       ufo:
-        specifier: ^1.6.3
-        version: 1.6.3
+        specifier: ^1.6.4
+        version: 1.6.4
       ultrahtml:
         specifier: ^1.6.0
         version: 1.6.0
@@ -6299,8 +6299,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
@@ -8993,7 +8993,7 @@ snapshots:
       source-map: 0.7.6
       srvx: 0.11.15
       tinyglobby: 0.2.16
-      ufo: 1.6.3
+      ufo: 1.6.4
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitefu: 1.1.3(vite@8.0.10)
       xmlbuilder2: 4.0.3
@@ -11644,7 +11644,7 @@ snapshots:
       acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   moment@2.30.1: {}
 
@@ -11808,7 +11808,7 @@ snapshots:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ofetch@2.0.0-alpha.3: {}
 
@@ -12919,7 +12919,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
   uint8array-extras@1.5.0: {}
 

--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -32,7 +32,7 @@ export const redirect: RouteRuleCtor<"redirect"> = ((m) =>
         if (!isPathInScope(event.url.pathname, strpBase)) {
           throw new HTTPError({ status: 400 });
         }
-        targetPath = withoutBase(targetPath, strpBase);
+        targetPath = collapseLeadingSlashes(withoutBase(targetPath, strpBase));
       }
       target = joinURL(target.slice(0, -3), targetPath);
     } else if (event.url.search) {
@@ -55,7 +55,7 @@ export const proxy: RouteRuleCtor<"proxy"> = ((m) =>
         if (!isPathInScope(event.url.pathname, strpBase)) {
           throw new HTTPError({ status: 400 });
         }
-        targetPath = withoutBase(targetPath, strpBase);
+        targetPath = collapseLeadingSlashes(withoutBase(targetPath, strpBase));
       }
       target = joinURL(target.slice(0, -3), targetPath);
     } else if (event.url.search) {
@@ -120,4 +120,13 @@ export function isPathInScope(pathname: string, base: string): boolean {
     return false;
   }
   return !base || canonical === base || canonical.startsWith(base + "/");
+}
+
+// Collapse any leading run of slashes to a single slash. After `withoutBase`
+// strips the wildcard prefix, a request like `/legacy//evil.com` leaves
+// `//evil.com`, which `joinURL("", "//evil.com")` would emit verbatim and the
+// browser would interpret as a protocol-relative URL pointing at an external
+// host (GHSA-9phm-9p8f-hw5m).
+function collapseLeadingSlashes(path: string): string {
+  return path.startsWith("//") ? path.replace(/^\/+/, "/") : path;
 }

--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -32,7 +32,9 @@ export const redirect: RouteRuleCtor<"redirect"> = ((m) =>
         if (!isPathInScope(event.url.pathname, strpBase)) {
           throw new HTTPError({ status: 400 });
         }
-        targetPath = collapseLeadingSlashes(withoutBase(targetPath, strpBase));
+        targetPath = withoutBase(targetPath, strpBase);
+      } else if (targetPath.startsWith("//")) {
+        targetPath = targetPath.replace(/^\/+/, "/");
       }
       target = joinURL(target.slice(0, -3), targetPath);
     } else if (event.url.search) {
@@ -55,7 +57,9 @@ export const proxy: RouteRuleCtor<"proxy"> = ((m) =>
         if (!isPathInScope(event.url.pathname, strpBase)) {
           throw new HTTPError({ status: 400 });
         }
-        targetPath = collapseLeadingSlashes(withoutBase(targetPath, strpBase));
+        targetPath = withoutBase(targetPath, strpBase);
+      } else if (targetPath.startsWith("//")) {
+        targetPath = targetPath.replace(/^\/+/, "/");
       }
       target = joinURL(target.slice(0, -3), targetPath);
     } else if (event.url.search) {
@@ -120,13 +124,4 @@ export function isPathInScope(pathname: string, base: string): boolean {
     return false;
   }
   return !base || canonical === base || canonical.startsWith(base + "/");
-}
-
-// Collapse any leading run of slashes to a single slash. After `withoutBase`
-// strips the wildcard prefix, a request like `/legacy//evil.com` leaves
-// `//evil.com`, which `joinURL("", "//evil.com")` would emit verbatim and the
-// browser would interpret as a protocol-relative URL pointing at an external
-// host (GHSA-9phm-9p8f-hw5m).
-function collapseLeadingSlashes(path: string): string {
-  return path.startsWith("//") ? path.replace(/^\/+/, "/") : path;
 }

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -111,6 +111,7 @@ export default defineConfig({
       redirect: { to: "https://nitro.build/", status: 308 },
     },
     "/rules/redirect/wildcard/**": { redirect: "https://nitro.build/**" },
+    "/rules/redirect/legacy/**": { redirect: "/**" },
     "/rules/nested/**": { redirect: "/base", headers: { "x-test": "test" } },
     "/rules/nested/override": { redirect: { to: "/other" } },
     "/rules/_/noncached/cached": { swr: true },

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -119,6 +119,7 @@ export default defineConfig({
     "/rules/_/cached/noncached": { cache: false, swr: false, isr: false },
     "/rules/_/cached/**": { swr: true },
     "/api/proxy/**": { proxy: "/api/echo" },
+    "/rules/proxy/legacy/**": { proxy: "/api/wildcard/**" },
     "/cdn/**": { proxy: "https://cdn.jsdelivr.net/**" },
     "/rules/basic-auth/**": {
       basicAuth: { username: "admin", password: "secret", realm: "Secure Area" },

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -42,6 +42,7 @@ describe("nitro:preset:netlify", async () => {
 
         expect(redirects).toMatchInlineSnapshot(`
           "/rules/nested/override	/other	302
+          /rules/redirect/legacy/*	/:splat	302
           /rules/redirect/wildcard/*	https://nitro.build/:splat	302
           /rules/redirect/obj	https://nitro.build/	301
           /rules/ba-redirect/*	/base	302

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -83,6 +83,13 @@ describe("nitro:preset:vercel:web", async () => {
               },
               {
                 "headers": {
+                  "Location": "/$1",
+                },
+                "src": "/rules/redirect/legacy/(.*)",
+                "status": 307,
+              },
+              {
+                "headers": {
                   "Location": "/other",
                 },
                 "src": "/rules/nested/override",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -317,6 +317,15 @@ export function testNitro(
     });
     expect(wildcard.status).toBe(307);
     expect(wildcard.headers.location).toBe("https://nitro.build/nuxt");
+
+    // Regression test for GHSA-9phm-9p8f-hw5m: a leading `//` after the
+    // wildcard prefix must not be forwarded as a protocol-relative URL.
+    const legacy = await callHandler({
+      url: "/rules/redirect/legacy//evil.com",
+    });
+    expect(legacy.status).toBe(307);
+    expect(legacy.headers.location).not.toMatch(/^\/\//);
+    expect(legacy.headers.location).toBe("/evil.com");
   });
 
   it("binary response", async () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -578,6 +578,15 @@ export function testNitro(
     }
   });
 
+  it("runtime proxy collapses leading slashes after wildcard prefix", async () => {
+    // Regression test for GHSA-9phm-9p8f-hw5m: a leading `//` after the
+    // wildcard prefix must not be forwarded verbatim to the upstream.
+    const { data } = await callHandler({
+      url: "/rules/proxy/legacy//evil.com",
+    });
+    expect(data).toBe("evil.com");
+  });
+
   it("external proxy", async () => {
     const { data, headers, status } = await callHandler({
       url: "/cdn/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js",


### PR DESCRIPTION
A `redirect` or `proxy` route rule with a `/**` wildcard target was vulnerable to an open redirect via protocol-relative URLs (GHSA-9phm-9p8f-hw5m).

Given:

```ts
"/legacy/**": { redirect: "/**" }
```

A request to `/legacy//evil.com` produced `Location: //evil.com` — a protocol-relative URL the browser resolves against the current scheme, redirecting to an attacker-controlled host. The `proxy` rule has the symmetric problem (forwarding to an unintended internal path).

Internally, `withoutBase("/legacy//evil.com", "/legacy")` returned `"//evil.com"`, and `joinURL("", "//evil.com")` emitted it verbatim.

## Fix

Two parts:

1. **Bump `ufo` to `^1.6.4`** — [unjs/ufo@5cd9e67](https://github.com/unjs/ufo/commit/5cd9e676711af3f4e4b5398ddf6ca8d52c1c7e1f) collapses any run of leading slashes to a single `/` inside `withoutBase`, so the typical `/scope/**` case now yields `Location: /evil.com`.

2. **Inline collapse in the runtime** for the edge case where the rule path itself is `/**` (`_redirectStripBase` / `_proxyStripBase` is `""`, so `withoutBase` is never called and the raw pathname flows into `joinURL("", …)`). Leading `//` is stripped before joining.

Includes regression tests for both the redirect and proxy paths.