### PR TITLE
build: shim `oxc-parser` via `rolldown/utils`

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -89,15 +89,13 @@ export default defineBuildConfig({
         if (chunk.name === "rolldown-runtime") {
           return `_common.mjs`;
         }
-        if (chunk.moduleIds.every((id) => id.includes("node_modules"))) {
+        const pkgRe =
+          /.*[/\\](?:node_modules|shims)[/\\](?<package>@[^/\\]+[/\\][^/\\]+|[^/\\]+)/;
+        if (chunk.moduleIds.every((id) => pkgRe.test(id))) {
           const pkgNames = [
             ...new Set(
               chunk.moduleIds
-                .map(
-                  (id) =>
-                    id.match(/.*[/\\]node_modules[/\\](?<package>@[^/\\]+[/\\][^/\\]+|[^/\\]+)/)
-                      ?.groups?.package
-                )
+                .map((id) => id.match(pkgRe)?.groups?.package)
                 .filter(Boolean)
                 .map((name) => name!.split(/[/\\]/).pop()!)
                 .filter(Boolean)

--- a/build.config.ts
+++ b/build.config.ts
@@ -89,8 +89,7 @@ export default defineBuildConfig({
         if (chunk.name === "rolldown-runtime") {
           return `_common.mjs`;
         }
-        const pkgRe =
-          /.*[/\\](?:node_modules|shims)[/\\](?<package>@[^/\\]+[/\\][^/\\]+|[^/\\]+)/;
+        const pkgRe = /.*[/\\](?:node_modules|shims)[/\\](?<package>@[^/\\]+[/\\][^/\\]+|[^/\\]+)/;
         if (chunk.moduleIds.every((id) => pkgRe.test(id))) {
           const pkgNames = [
             ...new Set(

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "mlly": "^1.8.2",
     "nypm": "^0.6.6",
     "obuild": "^0.4.33",
+    "oxc-parser": "*",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.62.0",
     "pathe": "^2.0.3",
@@ -211,7 +212,8 @@
   },
   "resolutions": {
     "cookie-es": "^3.1.1",
-    "nitro": "link:."
+    "nitro": "link:.",
+    "oxc-parser": "link:./shims/oxc-parser"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ settings:
 overrides:
   cookie-es: ^3.1.1
   nitro: link:.
+  oxc-parser: link:./shims/oxc-parser
 
 importers:
 
@@ -227,6 +228,9 @@ importers:
       obuild:
         specifier: ^0.4.33
         version: 0.4.33(@typescript/native-preview@7.0.0-dev.20260429.1)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.6.1)(magicast@0.5.2)(picomatch@4.0.4)(rollup@4.60.2)(typescript@6.0.3)
+      oxc-parser:
+        specifier: link:shims/oxc-parser
+        version: link:shims/oxc-parser
       oxfmt:
         specifier: ^0.47.0
         version: 0.47.0
@@ -295,7 +299,7 @@ importers:
         version: 2.5.0
       unimport:
         specifier: ^6.2.0
-        version: 6.2.0
+        version: 6.2.0(oxc-parser@shims+oxc-parser)
       untyped:
         specifier: ^2.0.0
         version: 2.0.0
@@ -12968,7 +12972,7 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unimport@6.2.0:
+  unimport@6.2.0(oxc-parser@shims+oxc-parser):
     dependencies:
       acorn: 8.16.0
       escape-string-regexp: 5.0.0
@@ -12984,6 +12988,8 @@ snapshots:
       tinyglobby: 0.2.16
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
+    optionalDependencies:
+      oxc-parser: link:shims/oxc-parser
 
   unist-util-find-after@5.0.0:
     dependencies:

--- a/shims/oxc-parser/index.mjs
+++ b/shims/oxc-parser/index.mjs
@@ -1,0 +1,1 @@
+export { parse, parseSync } from "rolldown/utils";

--- a/shims/oxc-parser/package.json
+++ b/shims/oxc-parser/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "oxc-parser",
+  "version": "0.127.0",
+  "private": true,
+  "description": "Local shim that re-exports parseSync from rolldown/utils.",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs",
+    "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "rolldown": "*"
+  }
+}


### PR DESCRIPTION
Shim the optional `oxc-parser` peer dependency of unimport via a local package that re-exports `parseSync` from `rolldown/utils`.