### PR TITLE
presets(aws-amplify): support node.js 22 and 24 runtimes

### DIFF
--- a/docs/2.deploy/20.providers/aws-amplify.md
+++ b/docs/2.deploy/20.providers/aws-amplify.md
@@ -31,7 +31,7 @@ export default defineNitroConfig({
       // catchAllStaticFallback: true,
       // imageOptimization: { path: "/_image", cacheControl: "public, max-age=3600, immutable" },
       // imageSettings: { ... },
-      // runtime: "nodejs18.x", // default: "nodejs18.x" | "nodejs16.x" | "nodejs20.x"
+      // runtime: "nodejs24.x", // default: "nodejs20.x" | "nodejs22.x" | "nodejs24.x"
   }
 })
 ```
@@ -43,7 +43,7 @@ export default defineNuxtConfig({
       // catchAllStaticFallback: true,
       // imageOptimization: { "/_image", cacheControl: "public, max-age=3600, immutable" },
       // imageSettings: { ... },
-      // runtime: "nodejs18.x", // default: "nodejs18.x" | "nodejs16.x" | "nodejs20.x"
+      // runtime: "nodejs24.x", // default: "nodejs20.x" | "nodejs22.x" | "nodejs24.x"
     }
   }
 })
@@ -63,7 +63,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm use 18 && node --version
+        - nvm use 24 && node --version
         - corepack enable && npx --yes nypm install
     build:
       commands:
@@ -81,7 +81,7 @@ applications:
       phases:
         preBuild:
           commands:
-          - nvm use 18 && node --version
+          - nvm use 24 && node --version
           - corepack enable && npx --yes nypm install
         build:
           commands:

--- a/src/presets/aws-amplify/types.ts
+++ b/src/presets/aws-amplify/types.ts
@@ -8,7 +8,7 @@ export interface AmplifyComputeConfig {
    * The runtime property dictates the runtime of the provisioned compute resource.
    * Values are subset of https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
    */
-  runtime: "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
+  runtime: "nodejs20.x" | "nodejs22.x" | "nodejs24.x";
 
   /**
    * Specifies the starting file from which code will run for the given compute resource.
@@ -136,7 +136,7 @@ export interface AmplifyDeployManifest {
    * [
    *   {
    *     name: 'default',
-   *     runtime: 'nodejs16.x',
+   *     runtime: 'nodejs20.x',
    *     entrypoint: 'index.js',
    *   }
    * ]
@@ -158,5 +158,5 @@ export interface AWSAmplifyOptions {
     cacheControl?: string;
   };
   imageSettings?: AmplifyImageSettings;
-  runtime?: "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
+  runtime?: "nodejs20.x" | "nodejs22.x" | "nodejs24.x";
 }


### PR DESCRIPTION
AWS Amplify Hosting no longer supports Node.js 16 or 18 and [now supports](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-supported-features.html) Node.js 20, 22, and 24. Drop the obsolete `nodejs16.x`/`nodejs18.x` literals and add `nodejs22.x`/`nodejs24.x` to the runtime union.

Also refreshes the JSDoc example and the docs page, including the `amplify.yml` templates that still pinned `nvm use 18`.

Default runtime is unchanged (`nodejs20.x`, the minimum still supported by Amplify). Markdown examples use `nodejs24.x` / `nvm use 24` (current Node.js Active LTS).

Note: removing `nodejs16.x` and `nodejs18.x` from the union is a TypeScript-type breaking change, but those values are rejected at deploy time by Amplify, so leaving them in would be misleading. Happy to switch to a deprecation approach if preferred.