### PR TITLE
presets(cloudflare): prefer source path rather than `#imports`

### DIFF
--- a/src/presets/cloudflare/runtime/plugin.dev.ts
+++ b/src/presets/cloudflare/runtime/plugin.dev.ts
@@ -58,13 +58,13 @@ async function _getPlatformProxy() {
     );
   })) as typeof import("wrangler");
 
-  const runtimeConfig: {
+  const runtimeConfig = useRuntimeConfig() as unknown as {
     wrangler: {
       configPath: string;
       persistDir: string;
       environment?: string;
     };
-  } = useRuntimeConfig();
+  };
 
   const proxyOptions: GetPlatformProxyOptions = {
     configPath: runtimeConfig.wrangler.configPath,

--- a/src/presets/cloudflare/runtime/plugin.dev.ts
+++ b/src/presets/cloudflare/runtime/plugin.dev.ts
@@ -1,8 +1,8 @@
 import type { NitroAppPlugin } from "nitropack";
 import type { GetPlatformProxyOptions, PlatformProxy } from "wrangler";
 
-// @ts-ignore
-import { useRuntimeConfig, getRequestURL } from "#imports";
+import { useRuntimeConfig } from "nitropack/runtime";
+import { getRequestURL } from "h3";
 
 const proxy = await _getPlatformProxy().catch((error) => {
   console.error("Failed to initialize wrangler bindings proxy", error);


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/34282

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

when auto-imports are fully turned off, imports from `#imports` stop working, and I'm not aware of a reason to keep them rather than just importing from `nitropack/runtime` 🤔 

related commit to v3 branch:  a85ebaa9

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
