### PR TITLE
perf: use vfs for nitro app dynamic code

### DIFF
--- a/src/build/virtual/_all.ts
+++ b/src/build/virtual/_all.ts
@@ -1,5 +1,6 @@
 import type { Nitro } from "nitro/types";
 
+import app from "./app.ts";
 import database from "./database.ts";
 import errorHandler from "./error-handler.ts";
 import featureFlags from "./feature-flags.ts";
@@ -22,6 +23,7 @@ type VirtualTemplate = {
 
 export function virtualTemplates(nitro: Nitro, _polyfills: string[]): VirtualTemplate[] {
   const nitroTemplates = [
+    app,
     database,
     errorHandler,
     featureFlags,

--- a/src/build/virtual/app.ts
+++ b/src/build/virtual/app.ts
@@ -23,13 +23,13 @@ export default function app(nitro: Nitro) {
       const code: string[] = [];
 
       imports.push(
-        /* js */ `import { H3Core } from "h3";`,
-        /* js */ `import errorHandler from "#nitro/virtual/error-handler";`
+        `import { H3Core } from "h3";`,
+        `import errorHandler from "#nitro/virtual/error-handler";`
       );
 
       // --- createNitroApp() ---
 
-      code.push(``, /* js */ `export function createNitroApp() {`);
+      code.push(``, `export function createNitroApp() {`);
 
       if (hasHooks) {
         imports.push(`import { HookableCore } from "hookable";`);

--- a/src/build/virtual/app.ts
+++ b/src/build/virtual/app.ts
@@ -10,6 +10,8 @@ export default function app(nitro: Nitro) {
       const hasGlobalMiddleware = nitro.routing.globalMiddleware.length > 0;
       const hasPlugins = nitro.options.plugins.length > 0;
       const hasHooks = nitro.options.features?.runtimeHooks ?? hasPlugins;
+      const hasGetMiddleware = hasRouteRules || hasRoutedMiddleware;
+      const hasAsyncContext = !!nitro.options.experimental.asyncContext;
 
       const routingImports = [
         hasRoutes && "findRoute",
@@ -17,135 +19,170 @@ export default function app(nitro: Nitro) {
         hasGlobalMiddleware && "globalMiddleware",
       ].filter(Boolean);
 
-      return /* js */ `
-import { H3Core } from "h3";
-${hasHooks ? `import { HookableCore } from "hookable";` : ""}
-import errorHandler from "#nitro/virtual/error-handler";
-${hasPlugins ? `import { plugins } from "#nitro/virtual/plugins";` : ""}
-${routingImports.length ? `import { ${routingImports.join(", ")} } from "#nitro/virtual/routing";` : ""}
-${hasRouteRules ? `import { getRouteRules } from "#nitro/runtime/app";` : ""}
-import { nitroAsyncContext } from "#nitro/runtime/context";
+      const imports: string[] = [];
+      const code: string[] = [];
 
-export function createNitroApp() {
-  ${hasHooks ? `const hooks = new HookableCore();` : ""}
+      imports.push(
+        /* js */ `import { H3Core } from "h3";`,
+        /* js */ `import errorHandler from "#nitro/virtual/error-handler";`
+      );
 
-  const captureError = (error, errorCtx) => {
-    ${
-      hasHooks
-        ? `const promise = hooks.callHook("error", error, errorCtx)?.catch?.((hookError) => {
-      console.error("Error while capturing another error", hookError);
-    });`
-        : ""
-    }
-    if (errorCtx?.event) {
-      const errors = errorCtx.event.req.context?.nitro?.errors;
-      if (errors) {
-        errors.push({ error, context: errorCtx });
+      // --- createNitroApp() ---
+
+      code.push(``, /* js */ `export function createNitroApp() {`);
+
+      if (hasHooks) {
+        imports.push(`import { HookableCore } from "hookable";`);
+        code.push(`  const hooks = new HookableCore();`);
       }
-      ${
-        hasHooks
-          ? `if (promise && typeof errorCtx.event.req.waitUntil === "function") {
-        errorCtx.event.req.waitUntil(promise);
-      }`
-          : ""
+
+      code.push(``, `const captureError = (error, errorCtx) => {`);
+      if (hasHooks) {
+        code.push(
+          `    const promise = hooks.callHook("error", error, errorCtx)?.catch?.((hookError) => {`,
+          `      console.error("Error while capturing another error", hookError);`,
+          `    });`
+        );
       }
-    }
-  };
+      code.push(
+        `    if (errorCtx?.event) {`,
+        `      const errors = errorCtx.event.req.context?.nitro?.errors;`,
+        `      if (errors) {`,
+        `        errors.push({ error, context: errorCtx });`,
+        `      }`
+      );
+      if (hasHooks) {
+        code.push(
+          `      if (promise && typeof errorCtx.event.req.waitUntil === "function") {`,
+          `        errorCtx.event.req.waitUntil(promise);`,
+          `      }`
+        );
+      }
+      code.push(`    }`, `  };`);
 
-  const h3App = createH3App({
-    onError(error, event) {
-      ${hasHooks ? `captureError(error, { event });` : ""}
-      return errorHandler(error, event);
-    },
-  });
+      code.push(``, `  const h3App = createH3App({`, `    onError(error, event) {`);
+      if (hasHooks) {
+        code.push(`      captureError(error, { event });`);
+      }
+      code.push(`      return errorHandler(error, event);`, `    },`, `  });`);
 
-  ${
-    hasHooks
-      ? `h3App.config.onRequest = (event) => {
-    return hooks.callHook("request", event)?.catch?.((error) => {
-      captureError(error, { event, tags: ["request"] });
-    });
-  };
-  h3App.config.onResponse = (res, event) => {
-    return hooks.callHook("response", res, event)?.catch?.((error) => {
-      captureError(error, { event, tags: ["response"] });
-    });
-  };`
-      : ""
-  }
+      if (hasHooks) {
+        code.push(
+          ``,
+          `  h3App.config.onRequest = (event) => {`,
+          `    return hooks.callHook("request", event)?.catch?.((error) => {`,
+          `      captureError(error, { event, tags: ["request"] });`,
+          `    });`,
+          `  };`,
+          `  h3App.config.onResponse = (res, event) => {`,
+          `    return hooks.callHook("response", res, event)?.catch?.((error) => {`,
+          `      captureError(error, { event, tags: ["response"] });`,
+          `    });`,
+          `  };`
+        );
+      }
 
-  let appHandler = (req) => {
-    req.context ||= {};
-    req.context.nitro = req.context.nitro || { errors: [] };
-    return h3App.fetch(req);
-  };
+      code.push(
+        ``,
+        `  let appHandler = (req) => {`,
+        `    req.context ||= {};`,
+        `    req.context.nitro = req.context.nitro || { errors: [] };`,
+        `    return h3App.fetch(req);`,
+        `  };`
+      );
 
-  if (import.meta._asyncContext) {
-    const originalHandler = appHandler;
-    appHandler = (req) => {
-      return nitroAsyncContext.callAsync({ request: req }, () => originalHandler(req));
-    };
-  }
+      if (hasAsyncContext) {
+        imports.push(`import { nitroAsyncContext } from "#nitro/runtime/context";`);
+        code.push(
+          ``,
+          `  const originalHandler = appHandler;`,
+          `  appHandler = (req) => {`,
+          `    return nitroAsyncContext.callAsync({ request: req }, () => originalHandler(req));`,
+          `  };`
+        );
+      }
 
-  return {
-    fetch: appHandler,
-    h3: h3App,
-    hooks: ${hasHooks ? `hooks` : `undefined`},
-    captureError,
-  };
-}
+      code.push(
+        ``,
+        `  return {`,
+        `    fetch: appHandler,`,
+        `    h3: h3App,`,
+        `    hooks: ${hasHooks ? "hooks" : "undefined"},`,
+        `    captureError,`,
+        `  };`,
+        `}`
+      );
 
-export function initNitroPlugins(app) {
-  ${
-    hasPlugins
-      ? `for (const plugin of plugins) {
-    try {
-      plugin(app);
-    } catch (error) {
-      app.captureError?.(error, { tags: ["plugin"] });
-      throw error;
-    }
-  }`
-      : ""
-  }
-  return app;
-}
+      // --- initNitroPlugins() ---
 
-function createH3App(config) {
-  const h3App = new H3Core(config);
-  ${hasRoutes ? `h3App["~findRoute"] = (event) => findRoute(event.req.method, event.url.pathname);` : ""}
-  ${hasGlobalMiddleware ? `h3App["~middleware"].push(...globalMiddleware);` : ""}
-  ${
-    hasRouteRules || hasRoutedMiddleware
-      ? `h3App["~getMiddleware"] = (event, route) => {
-    const pathname = event.url.pathname;
-    const method = event.req.method;
-    const middleware = [];
-    ${
-      hasRouteRules
-        ? `const routeRules = getRouteRules(method, pathname);
-    event.context.routeRules = routeRules?.routeRules;
-    if (routeRules?.routeRuleMiddleware.length) {
-      middleware.push(...routeRules.routeRuleMiddleware);
-    }`
-        : ""
-    }
-    ${hasGlobalMiddleware ? `middleware.push(...h3App["~middleware"]);` : ""}
-    ${hasRoutedMiddleware ? `middleware.push(...findRoutedMiddleware(method, pathname).map((r) => r.data));` : ""}
-    ${
-      hasRoutes
-        ? `if (route?.data?.middleware?.length) {
-      middleware.push(...route.data.middleware);
-    }`
-        : ""
-    }
-    return middleware;
-  };`
-      : ""
-  }
-  return h3App;
-}
-`;
+      code.push(``, `export function initNitroPlugins(app) {`);
+      if (hasPlugins) {
+        imports.push(`import { plugins } from "#nitro/virtual/plugins";`);
+        code.push(
+          `  for (const plugin of plugins) {`,
+          `    try {`,
+          `      plugin(app);`,
+          `    } catch (error) {`,
+          `      app.captureError?.(error, { tags: ["plugin"] });`,
+          `      throw error;`,
+          `    }`,
+          `  }`
+        );
+      }
+      code.push(`  return app;`, `}`);
+
+      // --- createH3App() ---
+
+      if (routingImports.length) {
+        imports.push(`import { ${routingImports.join(", ")} } from "#nitro/virtual/routing";`);
+      }
+
+      code.push(``, `function createH3App(config) {`, `  const h3App = new H3Core(config);`);
+      if (hasRoutes) {
+        code.push(
+          `  h3App["~findRoute"] = (event) => findRoute(event.req.method, event.url.pathname);`
+        );
+      }
+      if (hasGlobalMiddleware) {
+        code.push(`  h3App["~middleware"].push(...globalMiddleware);`);
+      }
+      if (hasGetMiddleware) {
+        code.push(
+          `  h3App["~getMiddleware"] = (event, route) => {`,
+          `    const pathname = event.url.pathname;`,
+          `    const method = event.req.method;`,
+          `    const middleware = [];`
+        );
+        if (hasRouteRules) {
+          imports.push(`import { getRouteRules } from "#nitro/runtime/app";`);
+          code.push(
+            `    const routeRules = getRouteRules(method, pathname);`,
+            `    event.context.routeRules = routeRules?.routeRules;`,
+            `    if (routeRules?.routeRuleMiddleware.length) {`,
+            `      middleware.push(...routeRules.routeRuleMiddleware);`,
+            `    }`
+          );
+        }
+        if (hasGlobalMiddleware) {
+          code.push(`    middleware.push(...h3App["~middleware"]);`);
+        }
+        if (hasRoutedMiddleware) {
+          code.push(
+            `    middleware.push(...findRoutedMiddleware(method, pathname).map((r) => r.data));`
+          );
+        }
+        if (hasRoutes) {
+          code.push(
+            `    if (route?.data?.middleware?.length) {`,
+            `      middleware.push(...route.data.middleware);`,
+            `    }`
+          );
+        }
+        code.push(`    return middleware;`, `  };`);
+      }
+      code.push(`  return h3App;`, `}`);
+
+      return [...imports, ...code].join("\n");
     },
   };
 }

--- a/src/build/virtual/app.ts
+++ b/src/build/virtual/app.ts
@@ -1,0 +1,151 @@
+import type { Nitro } from "nitro/types";
+
+export default function app(nitro: Nitro) {
+  return {
+    id: "#nitro/virtual/app",
+    template: () => {
+      const hasRoutes = nitro.routing.routes.hasRoutes();
+      const hasRouteRules = nitro.routing.routeRules.hasRoutes();
+      const hasRoutedMiddleware = nitro.routing.routedMiddleware.hasRoutes();
+      const hasGlobalMiddleware = nitro.routing.globalMiddleware.length > 0;
+      const hasPlugins = nitro.options.plugins.length > 0;
+      const hasHooks = nitro.options.features?.runtimeHooks ?? hasPlugins;
+
+      const routingImports = [
+        hasRoutes && "findRoute",
+        hasRoutedMiddleware && "findRoutedMiddleware",
+        hasGlobalMiddleware && "globalMiddleware",
+      ].filter(Boolean);
+
+      return /* js */ `
+import { H3Core } from "h3";
+${hasHooks ? `import { HookableCore } from "hookable";` : ""}
+import errorHandler from "#nitro/virtual/error-handler";
+${hasPlugins ? `import { plugins } from "#nitro/virtual/plugins";` : ""}
+${routingImports.length ? `import { ${routingImports.join(", ")} } from "#nitro/virtual/routing";` : ""}
+${hasRouteRules ? `import { getRouteRules } from "#nitro/runtime/app";` : ""}
+import { nitroAsyncContext } from "#nitro/runtime/context";
+
+export function createNitroApp() {
+  ${hasHooks ? `const hooks = new HookableCore();` : ""}
+
+  const captureError = (error, errorCtx) => {
+    ${
+      hasHooks
+        ? `const promise = hooks.callHook("error", error, errorCtx)?.catch?.((hookError) => {
+      console.error("Error while capturing another error", hookError);
+    });`
+        : ""
+    }
+    if (errorCtx?.event) {
+      const errors = errorCtx.event.req.context?.nitro?.errors;
+      if (errors) {
+        errors.push({ error, context: errorCtx });
+      }
+      ${
+        hasHooks
+          ? `if (promise && typeof errorCtx.event.req.waitUntil === "function") {
+        errorCtx.event.req.waitUntil(promise);
+      }`
+          : ""
+      }
+    }
+  };
+
+  const h3App = createH3App({
+    onError(error, event) {
+      ${hasHooks ? `captureError(error, { event });` : ""}
+      return errorHandler(error, event);
+    },
+  });
+
+  ${
+    hasHooks
+      ? `h3App.config.onRequest = (event) => {
+    return hooks.callHook("request", event)?.catch?.((error) => {
+      captureError(error, { event, tags: ["request"] });
+    });
+  };
+  h3App.config.onResponse = (res, event) => {
+    return hooks.callHook("response", res, event)?.catch?.((error) => {
+      captureError(error, { event, tags: ["response"] });
+    });
+  };`
+      : ""
+  }
+
+  let appHandler = (req) => {
+    req.context ||= {};
+    req.context.nitro = req.context.nitro || { errors: [] };
+    return h3App.fetch(req);
+  };
+
+  if (import.meta._asyncContext) {
+    const originalHandler = appHandler;
+    appHandler = (req) => {
+      return nitroAsyncContext.callAsync({ request: req }, () => originalHandler(req));
+    };
+  }
+
+  return {
+    fetch: appHandler,
+    h3: h3App,
+    hooks: ${hasHooks ? `hooks` : `undefined`},
+    captureError,
+  };
+}
+
+export function initNitroPlugins(app) {
+  ${
+    hasPlugins
+      ? `for (const plugin of plugins) {
+    try {
+      plugin(app);
+    } catch (error) {
+      app.captureError?.(error, { tags: ["plugin"] });
+      throw error;
+    }
+  }`
+      : ""
+  }
+  return app;
+}
+
+function createH3App(config) {
+  const h3App = new H3Core(config);
+  ${hasRoutes ? `h3App["~findRoute"] = (event) => findRoute(event.req.method, event.url.pathname);` : ""}
+  ${hasGlobalMiddleware ? `h3App["~middleware"].push(...globalMiddleware);` : ""}
+  ${
+    hasRouteRules || hasRoutedMiddleware
+      ? `h3App["~getMiddleware"] = (event, route) => {
+    const pathname = event.url.pathname;
+    const method = event.req.method;
+    const middleware = [];
+    ${
+      hasRouteRules
+        ? `const routeRules = getRouteRules(method, pathname);
+    event.context.routeRules = routeRules?.routeRules;
+    if (routeRules?.routeRuleMiddleware.length) {
+      middleware.push(...routeRules.routeRuleMiddleware);
+    }`
+        : ""
+    }
+    ${hasGlobalMiddleware ? `middleware.push(...h3App["~middleware"]);` : ""}
+    ${hasRoutedMiddleware ? `middleware.push(...findRoutedMiddleware(method, pathname).map((r) => r.data));` : ""}
+    ${
+      hasRoutes
+        ? `if (route?.data?.middleware?.length) {
+      middleware.push(...route.data.middleware);
+    }`
+        : ""
+    }
+    return middleware;
+  };`
+      : ""
+  }
+  return h3App;
+}
+`;
+    },
+  };
+}

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -1,33 +1,12 @@
-import type {
-  CaptureError,
-  MatchedRouteRules,
-  NitroApp,
-  NitroAsyncContext,
-  NitroRuntimeHooks,
-} from "nitro/types";
+import type { MatchedRouteRules, NitroApp, NitroRuntimeHooks } from "nitro/types";
 import type { ServerRequest, ServerRequestContext } from "srvx";
-import type { H3Config, H3EventContext, Middleware, WebSocketHooks } from "h3";
-import { H3Core, toRequest } from "h3";
+import type { H3EventContext, Middleware, WebSocketHooks } from "h3";
+import { toRequest } from "h3";
 import { HookableCore } from "hookable";
-import { nitroAsyncContext } from "./context.ts";
 
 // IMPORTANT: virtual imports and user code should be imported last to avoid initialization order issues
-import errorHandler from "#nitro/virtual/error-handler";
-import { plugins } from "#nitro/virtual/plugins";
-import {
-  findRoute,
-  findRouteRules,
-  globalMiddleware,
-  findRoutedMiddleware,
-} from "#nitro/virtual/routing";
-import {
-  hasRouteRules,
-  hasRoutedMiddleware,
-  hasGlobalMiddleware,
-  hasRoutes,
-  hasHooks,
-  hasPlugins,
-} from "#nitro/virtual/feature-flags";
+import { findRouteRules } from "#nitro/virtual/routing";
+import { createNitroApp, initNitroPlugins } from "#nitro/virtual/app";
 
 declare global {
   var __nitro__:
@@ -45,9 +24,7 @@ export function useNitroApp(): NitroApp {
   instance = (useNitroApp as any)._instance = createNitroApp();
   globalThis.__nitro__ = globalThis.__nitro__ || {};
   globalThis.__nitro__[APP_ID] = instance;
-  if (hasPlugins) {
-    initNitroPlugins(instance);
-  }
+  initNitroPlugins(instance);
   return instance;
 }
 
@@ -91,118 +68,6 @@ export function fetch(
   }
   resource = (resource as any)._request || resource; // unwrap srvx request
   return globalThis.fetch(resource, init);
-}
-
-function createNitroApp(): NitroApp {
-  const hooks = hasHooks ? new HookableCore<NitroRuntimeHooks>() : undefined;
-
-  const captureError: CaptureError = (error, errorCtx) => {
-    const promise =
-      hasHooks &&
-      hooks!.callHook("error", error, errorCtx)?.catch?.((hookError: any) => {
-        console.error("Error while capturing another error", hookError);
-      });
-    if (errorCtx?.event) {
-      const errors = errorCtx.event.req.context?.nitro?.errors;
-      if (errors) {
-        errors.push({ error, context: errorCtx });
-      }
-      if (hasHooks && promise && typeof errorCtx.event.req.waitUntil === "function") {
-        errorCtx.event.req.waitUntil(promise);
-      }
-    }
-  };
-
-  const h3App = createH3App({
-    onError(error, event) {
-      hasHooks && captureError(error, { event });
-      return errorHandler(error, event);
-    },
-  });
-
-  if (hasHooks) {
-    h3App.config.onRequest = (event) => {
-      return hooks!.callHook("request", event)?.catch?.((error: any) => {
-        captureError(error, { event, tags: ["request"] });
-      });
-    };
-    h3App.config.onResponse = (res, event) => {
-      return hooks!.callHook("response", res, event)?.catch?.((error: any) => {
-        captureError(error, { event, tags: ["response"] });
-      });
-    };
-  }
-
-  let appHandler = (req: ServerRequest): Response | Promise<Response> => {
-    req.context ||= {};
-    req.context.nitro = req.context.nitro || { errors: [] };
-    return h3App.fetch(req);
-  };
-
-  // Experimental async context support
-  if (import.meta._asyncContext) {
-    const originalHandler = appHandler;
-    appHandler = (req: ServerRequest): Promise<Response> => {
-      const asyncCtx: NitroAsyncContext = { request: req as Request };
-      return nitroAsyncContext.callAsync(asyncCtx, () => originalHandler(req));
-    };
-  }
-
-  const app: NitroApp = {
-    fetch: appHandler,
-    h3: h3App,
-    hooks,
-    captureError,
-  };
-
-  return app;
-}
-
-function initNitroPlugins(app: NitroApp) {
-  for (const plugin of plugins) {
-    try {
-      plugin(app as NitroApp & { hooks: NonNullable<NitroApp["hooks"]> });
-    } catch (error: any) {
-      app.captureError?.(error, { tags: ["plugin"] });
-      throw error;
-    }
-  }
-  return app;
-}
-
-function createH3App(config: H3Config) {
-  // Create H3 app
-  const h3App = new H3Core(config);
-
-  // Compiled route matching
-  hasRoutes && (h3App["~findRoute"] = (event) => findRoute(event.req.method, event.url.pathname));
-
-  hasGlobalMiddleware && h3App["~middleware"].push(...globalMiddleware);
-
-  if (hasRouteRules || hasRoutedMiddleware) {
-    h3App["~getMiddleware"] = (event, route) => {
-      const needsRouting = hasRouteRules || hasRoutedMiddleware;
-      const pathname = needsRouting ? event.url.pathname : undefined;
-      const method = needsRouting ? event.req.method : undefined;
-      const middleware: Middleware[] = [];
-      if (hasRouteRules) {
-        const routeRules = getRouteRules(method!, pathname!);
-        event.context.routeRules = routeRules?.routeRules;
-        if (routeRules?.routeRuleMiddleware.length) {
-          middleware.push(...routeRules.routeRuleMiddleware);
-        }
-      }
-      hasGlobalMiddleware && middleware.push(...h3App["~middleware"]);
-      hasRoutedMiddleware &&
-        middleware.push(...findRoutedMiddleware(method!, pathname!).map((r) => r.data));
-      if (hasRoutes && route?.data?.middleware?.length) {
-        middleware.push(...route.data.middleware);
-      }
-      return middleware;
-    };
-  }
-
-  return h3App;
 }
 
 export function getRouteRules(

--- a/src/runtime/virtual/app.ts
+++ b/src/runtime/virtual/app.ts
@@ -1,0 +1,35 @@
+import "./_runtime_warn.ts";
+import type { NitroApp } from "nitro/types";
+import type { ServerRequest } from "srvx";
+import { H3Core } from "h3";
+import errorHandler from "#nitro/virtual/error-handler";
+
+export function createNitroApp(): NitroApp {
+  const h3App = new H3Core({
+    onError(error, event) {
+      return errorHandler(error, event);
+    },
+  });
+  const captureError: NonNullable<NitroApp["captureError"]> = (error, errorCtx) => {
+    if (errorCtx?.event) {
+      const errors = errorCtx.event.req.context?.nitro?.errors;
+      if (errors) {
+        errors.push({ error, context: errorCtx });
+      }
+    }
+  };
+  return {
+    fetch: (req: ServerRequest) => {
+      req.context ||= {};
+      req.context.nitro = req.context.nitro || { errors: [] };
+      return h3App.fetch(req);
+    },
+    h3: h3App,
+    hooks: undefined,
+    captureError,
+  };
+}
+
+export function initNitroPlugins(app: NitroApp): NitroApp {
+  return app;
+}

--- a/test/minimal/minimal.test.ts
+++ b/test/minimal/minimal.test.ts
@@ -11,8 +11,8 @@ const tmpDir = fileURLToPath(new URL(".tmp", import.meta.url));
 // Rounded up
 const bundleSizes: Record<string, [kb: number, minKB: number]> = {
   rollup: [16, 8],
-  rolldown: [19, 10],
-  vite: [19, 10],
+  rolldown: [17, 8],
+  vite: [17, 8],
   vite7: [16, 8],
 };
 

--- a/test/minimal/minimal.test.ts
+++ b/test/minimal/minimal.test.ts
@@ -10,9 +10,9 @@ const tmpDir = fileURLToPath(new URL(".tmp", import.meta.url));
 
 // Rounded up
 const bundleSizes: Record<string, [kb: number, minKB: number]> = {
-  rollup: [16, 8],
-  rolldown: [17, 8],
-  vite: [17, 8],
+  rollup: [15, 8],
+  rolldown: [15, 8],
+  vite: [15, 8],
   vite7: [16, 8],
 };
 


### PR DESCRIPTION
Rolldown is sadly less efficient for treeshaking statically analyzable logic from feature flags and pulls in unneded depencies.

This PR refactors dynamic part of app.ts into a virtual entry to reduce bundle size.