### PR TITLE
perf(rollup): skip URI-scheme ids before `this.resolve()`

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -17,6 +17,8 @@ import { readPackageJSON, writePackageJSON } from "pkg-types";
 import type { Plugin } from "rollup";
 import semver from "semver";
 
+const URI_SCHEME_RE = /^[a-z0-9]{2,}:/;
+
 export function externals(opts: NodeExternalsOptions): Plugin {
   const trackedExternals = new Set<string>();
 
@@ -80,6 +82,16 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Skip relative paths
       if (originalId.startsWith(".")) {
+        return null;
+      }
+
+      if (URI_SCHEME_RE.test(originalId)) {
+        if (
+          originalId.startsWith("node:") &&
+          !isExplicitInline(originalId, importer)
+        ) {
+          return { id: originalId, external: true };
+        }
         return null;
       }
 


### PR DESCRIPTION

### 🔗 Linked issue

spotted this while investigating nuxt/nuxt#27106.

related: https://github.com/nuxt/nuxt/issues/34753

this makes a measureable difference in terms of nuxt build performance

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this is a perf improvement porting some changes that have already been made in `main` branch (but which I discovered somewhat differently via nuxt/nuxt#27106):

- fast return for `node:` builtins
- fast return for `data:`, `http(s):`, `virtual:`, `bun:`, `deno:`, etc.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
