### PR TITLE
fix(cloudflare): auto-add .wrangler/state/v3 to .gitignore on default persistDir

### DIFF
--- a/src/presets/cloudflare/dev.ts
+++ b/src/presets/cloudflare/dev.ts
@@ -53,12 +53,10 @@ export async function cloudflareDevModule(nitro: Nitro) {
     startingFrom: nitro.options.rootDir,
   }).catch(() => undefined);
 
-  // let addedToGitIgnore = false;
-  if (gitIgnorePath && persistDir === ".wrangler/state/v3") {
+  if (gitIgnorePath && !config.persistDir) {
     const gitIgnore = await fs.readFile(gitIgnorePath, "utf8");
     if (!gitIgnore.includes(".wrangler/state/v3")) {
       await fs.writeFile(gitIgnorePath, gitIgnore + "\n.wrangler/state/v3\n").catch(() => {});
-      // addedToGitIgnore = true;
     }
   }
 


### PR DESCRIPTION
In Cloudflare dev emulation, Nitro tries to auto-append `.wrangler/state/v3` to the project `.gitignore` so Wrangler emulator state doesn't get committed.

The guard compares a resolved absolute path against the relative literal `".wrangler/state/v3"`, so it never matches and the entry is never added. Switching to `!config.persistDir` makes the check fire when the user is on the default location.

(Also removed dead commented code but can keep that if preffered.)
