### PR TITLE
fix(vite): allow global prod builds with npx

### DIFF
--- a/patches/@hiogawa__vite-plugin-fullstack.patch
+++ b/patches/@hiogawa__vite-plugin-fullstack.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/plugin-B4MlD0Bd.js b/dist/plugin-B4MlD0Bd.js
-index 7ddbbcf1630129b133dbf3e8621942478b5348b8..644f2ffece292a0f5631def23f0b6dae01826b7e 100644
+index 7ddbbcf1630129b133dbf3e8621942478b5348b8..d73f971411782d1952391aefbf1bb5ed7c35b0dc 100644
 --- a/dist/plugin-B4MlD0Bd.js
 +++ b/dist/plugin-B4MlD0Bd.js
 @@ -1,5 +1,4 @@
@@ -22,3 +22,13 @@ index 7ddbbcf1630129b133dbf3e8621942478b5348b8..644f2ffece292a0f5631def23f0b6dae
  function injectQuery(url, queryToInject) {
  	const { file, postfix } = splitFileAndPostfix(url);
  	return `${isWindows ? slash(file) : file}?${queryToInject}${postfix[0] === "?" ? `&${postfix.slice(1)}` : postfix}`;
+@@ -502,7 +508,8 @@ function collectAssetDepsInner(fileName, bundle) {
+ 	};
+ }
+ function patchViteClientPlugin() {
+-	const viteClientPath = normalizePath(fileURLToPath(import.meta.resolve("vite/dist/client/client.mjs")));
++	let viteClientPath
++	try { viteClientPath = normalizePath(fileURLToPath(import.meta.resolve("vite/dist/client/client.mjs"))); } catch {}
+ 	function endIndexOf(code, searchValue) {
+ 		const i = code.lastIndexOf(searchValue);
+ 		return i === -1 ? i : i + searchValue.length;

--- a/patches/@hiogawa__vite-plugin-fullstack.patch
+++ b/patches/@hiogawa__vite-plugin-fullstack.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/plugin-B4MlD0Bd.js b/dist/plugin-B4MlD0Bd.js
+index 7ddbbcf1630129b133dbf3e8621942478b5348b8..644f2ffece292a0f5631def23f0b6dae01826b7e 100644
+--- a/dist/plugin-B4MlD0Bd.js
++++ b/dist/plugin-B4MlD0Bd.js
+@@ -1,5 +1,4 @@
+ import assert from "node:assert/strict";
+-import { isCSSRequest, normalizePath } from "vite";
+ import fs from "node:fs";
+ import path from "node:path";
+ import { fileURLToPath } from "node:url";
+@@ -90,6 +89,13 @@ function slash(p) {
+ 	return p.replace(windowsSlashRE, "/");
+ }
+ const isWindows = typeof process !== "undefined" && process.platform === "win32";
++function normalizePath(id) {
++	return path.posix.normalize(isWindows ? slash(id) : id);
++}
++const CSS_LANGS_RE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
++function isCSSRequest(request) {
++	return CSS_LANGS_RE.test(request);
++}
+ function injectQuery(url, queryToInject) {
+ 	const { file, postfix } = splitFileAndPostfix(url);
+ 	return `${isWindows ? slash(file) : file}?${queryToInject}${postfix[0] === "?" ? `&${postfix.slice(1)}` : postfix}`;

--- a/patches/@hiogawa__vite-plugin-fullstack.patch
+++ b/patches/@hiogawa__vite-plugin-fullstack.patch
@@ -28,7 +28,7 @@ index 7ddbbcf1630129b133dbf3e8621942478b5348b8..d73f971411782d1952391aefbf1bb5ed
  function patchViteClientPlugin() {
 -	const viteClientPath = normalizePath(fileURLToPath(import.meta.resolve("vite/dist/client/client.mjs")));
 +	let viteClientPath
-+	try { viteClientPath = normalizePath(fileURLToPath(import.meta.resolve("vite/dist/client/client.mjs"))); } catch {}
++	try { viteClientPath = normalizePath(fileURLToPath(import.meta.resolve("vite/dist/client/client.mjs"))); } catch { return null; }
  	function endIndexOf(code, searchValue) {
  		const i = code.lastIndexOf(searchValue);
  		return i === -1 ? i : i + searchValue.length;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   cookie-es: ^3.1.1
   oxc-parser: link:./shims/oxc-parser
 
+patchedDependencies:
+  '@hiogawa/vite-plugin-fullstack': 7176bb7cd1cc54ef03b75fb1daff982030f5685ec1ecf33d3f35257a2a820b78
+
 importers:
 
   .:
@@ -83,7 +86,7 @@ importers:
         version: 0.0.1
       '@hiogawa/vite-plugin-fullstack':
         specifier: ^0.0.11
-        version: 0.0.11(vite@8.0.11)
+        version: 0.0.11(patch_hash=7176bb7cd1cc54ef03b75fb1daff982030f5685ec1ecf33d3f35257a2a820b78)(vite@8.0.11)
       '@netlify/edge-functions':
         specifier: ^3.0.6
         version: 3.0.6
@@ -7925,7 +7928,7 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.34)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@hiogawa/vite-plugin-fullstack@0.0.11(vite@8.0.11)':
+  '@hiogawa/vite-plugin-fullstack@0.0.11(patch_hash=7176bb7cd1cc54ef03b75fb1daff982030f5685ec1ecf33d3f35257a2a820b78)(vite@8.0.11)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.55
       magic-string: 0.30.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   oxc-parser: link:./shims/oxc-parser
 
 patchedDependencies:
-  '@hiogawa/vite-plugin-fullstack': 3acb477ca58ccd202ce7b8365ea24886b8355ce46a824232ec68a385e3edcb3c
+  '@hiogawa/vite-plugin-fullstack': 07fae0b67c822caf17077800582de7d566ace9f74ee59baba4de19a6288b720a
 
 importers:
 
@@ -86,7 +86,7 @@ importers:
         version: 0.0.1
       '@hiogawa/vite-plugin-fullstack':
         specifier: ^0.0.11
-        version: 0.0.11(patch_hash=3acb477ca58ccd202ce7b8365ea24886b8355ce46a824232ec68a385e3edcb3c)(vite@8.0.11)
+        version: 0.0.11(patch_hash=07fae0b67c822caf17077800582de7d566ace9f74ee59baba4de19a6288b720a)(vite@8.0.11)
       '@netlify/edge-functions':
         specifier: ^3.0.6
         version: 3.0.6
@@ -7928,7 +7928,7 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.34)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@hiogawa/vite-plugin-fullstack@0.0.11(patch_hash=3acb477ca58ccd202ce7b8365ea24886b8355ce46a824232ec68a385e3edcb3c)(vite@8.0.11)':
+  '@hiogawa/vite-plugin-fullstack@0.0.11(patch_hash=07fae0b67c822caf17077800582de7d566ace9f74ee59baba4de19a6288b720a)(vite@8.0.11)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.55
       magic-string: 0.30.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   oxc-parser: link:./shims/oxc-parser
 
 patchedDependencies:
-  '@hiogawa/vite-plugin-fullstack': 7176bb7cd1cc54ef03b75fb1daff982030f5685ec1ecf33d3f35257a2a820b78
+  '@hiogawa/vite-plugin-fullstack': 3acb477ca58ccd202ce7b8365ea24886b8355ce46a824232ec68a385e3edcb3c
 
 importers:
 
@@ -86,7 +86,7 @@ importers:
         version: 0.0.1
       '@hiogawa/vite-plugin-fullstack':
         specifier: ^0.0.11
-        version: 0.0.11(patch_hash=7176bb7cd1cc54ef03b75fb1daff982030f5685ec1ecf33d3f35257a2a820b78)(vite@8.0.11)
+        version: 0.0.11(patch_hash=3acb477ca58ccd202ce7b8365ea24886b8355ce46a824232ec68a385e3edcb3c)(vite@8.0.11)
       '@netlify/edge-functions':
         specifier: ^3.0.6
         version: 3.0.6
@@ -7928,7 +7928,7 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.34)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@hiogawa/vite-plugin-fullstack@0.0.11(patch_hash=7176bb7cd1cc54ef03b75fb1daff982030f5685ec1ecf33d3f35257a2a820b78)(vite@8.0.11)':
+  '@hiogawa/vite-plugin-fullstack@0.0.11(patch_hash=3acb477ca58ccd202ce7b8365ea24886b8355ce46a824232ec68a385e3edcb3c)(vite@8.0.11)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.55
       magic-string: 0.30.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,3 +43,6 @@ peerDependencyRules:
 updateConfig:
   ignoreDependencies:
     - vite7
+
+patchedDependencies:
+  '@hiogawa/vite-plugin-fullstack': patches/@hiogawa__vite-plugin-fullstack.patch

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -6,7 +6,6 @@ import { RunnerManager, loadRunner } from "env-runner";
 import { join, resolve } from "node:path";
 import { runtimeDependencies, runtimeDir } from "nitro/meta";
 import { resolveModulePath } from "exsolve";
-import { createFetchableDevEnvironment } from "./dev.ts";
 import { isAbsolute } from "pathe";
 
 export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOptions {
@@ -88,9 +87,10 @@ export function createServiceEnvironment(
       ),
     },
     dev: {
-      createEnvironment: (envName, envConfig) => {
+      createEnvironment: async (envName, envConfig) => {
         const entry = tryResolve(serviceConfig.entry);
         (ctx._viteEnvs ??= new Map()).set(envName, entry);
+        const { createFetchableDevEnvironment } = await import("./dev.ts");
         return createFetchableDevEnvironment(envName, envConfig, getEnvRunner(ctx), entry, {
           preventExternalize: isWorkerdRunner,
         });

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -45,8 +45,9 @@ export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOpti
       "process.env.NODE_ENV": JSON.stringify(ctx.nitro!.options.dev ? "development" : "production"),
     },
     dev: {
-      createEnvironment: (envName, envConfig) => {
+      createEnvironment: async (envName, envConfig) => {
         const entry = resolve(runtimeDir, "internal/vite/dev-entry.mjs");
+        const { createFetchableDevEnvironment } = await import("./dev.ts");
         const env = createFetchableDevEnvironment(envName, envConfig, getEnvRunner(ctx), entry, {
           preventExternalize: isWorkerdRunner,
         });

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -20,7 +20,6 @@ import {
   createServiceEnvironment,
   nitroServiceProxy,
 } from "./env.ts";
-import { configureViteDevServer } from "./dev.ts";
 import { runtimeDir } from "nitro/meta";
 import { resolveModulePath } from "exsolve";
 import { defu } from "defu";
@@ -251,8 +250,9 @@ function nitroMain(ctx: NitroPluginContext): VitePlugin {
       },
     },
 
-    configureServer: (server) => {
+    configureServer: async (server) => {
       debug("[main] Configuring dev server");
+      const { configureViteDevServer } = await import("./dev.ts");
       return configureViteDevServer(ctx, server);
     },
 


### PR DESCRIPTION
Nitro can be used to build a Vite application for production deployment anywhere without being installed and used via `npx|pnpx|bunx nitro build --builder vite`.

However in some places (dev paths) we were importing from vite which is not possible as vite is not a direct nitro dep. Also fullstack plugin needed two small utils can be inlined.