### PR TITLE
fix(bun): polyfill ReadableStream to strip unsupported type direct

### DIFF
--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -4,29 +4,25 @@ import "#nitro/virtual/polyfills";
 // Cloudflare Workers extension. Bun follows the web spec strictly and throws
 // ERR_INVALID_ARG_VALUE for unknown `type` values. Strip it before it reaches
 // Bun's constructor so prerendering works without switching to the node preset.
+// Using class extends preserves the prototype chain so instanceof checks work correctly.
 const _OriginalReadableStream = globalThis.ReadableStream;
-const _PatchedReadableStream = function ReadableStream(
-  underlyingSource?: UnderlyingDefaultSource | UnderlyingByteSource,
-  strategy?: QueuingStrategy,
-) {
-  if (
-    underlyingSource &&
-    (underlyingSource as Record<string, unknown>).type === "direct"
+class _PatchedReadableStream extends _OriginalReadableStream {
+  constructor(
+    underlyingSource?: UnderlyingDefaultSource | UnderlyingByteSource,
+    strategy?: QueuingStrategy,
   ) {
-    const { type: _type, ...rest } = underlyingSource as Record<string, unknown>;
-    return new _OriginalReadableStream(
-      rest as UnderlyingDefaultSource,
-      strategy,
-    );
+    if (
+      underlyingSource &&
+      (underlyingSource as Record<string, unknown>).type === "direct"
+    ) {
+      const { type: _type, ...rest } =
+        underlyingSource as Record<string, unknown>;
+      super(rest as UnderlyingDefaultSource, strategy);
+    } else {
+      super(underlyingSource as UnderlyingDefaultSource, strategy);
+    }
   }
-  return new _OriginalReadableStream(
-    underlyingSource as UnderlyingDefaultSource,
-    strategy,
-  );
-} as unknown as typeof ReadableStream;
-
-Object.setPrototypeOf(_PatchedReadableStream, _OriginalReadableStream);
-_PatchedReadableStream.prototype = _OriginalReadableStream.prototype;
+}
 
 // @ts-expect-error -- intentional global override for compat
 globalThis.ReadableStream = _PatchedReadableStream;

--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -6,17 +6,14 @@ import "#nitro/virtual/polyfills";
 // Bun's constructor so prerendering works without switching to the node preset.
 // Using class extends preserves the prototype chain so instanceof checks work correctly.
 const _OriginalReadableStream = globalThis.ReadableStream;
+// @ts-expect-error -- TypeScript cannot resolve overloaded ReadableStream constructor generics via class extends
 class _PatchedReadableStream extends _OriginalReadableStream {
   constructor(
     underlyingSource?: UnderlyingDefaultSource | UnderlyingByteSource,
-    strategy?: QueuingStrategy,
+    strategy?: QueuingStrategy
   ) {
-    if (
-      underlyingSource &&
-      (underlyingSource as Record<string, unknown>).type === "direct"
-    ) {
-      const { type: _type, ...rest } =
-        underlyingSource as Record<string, unknown>;
+    if (underlyingSource && (underlyingSource as Record<string, unknown>).type === "direct") {
+      const { type: _type, ...rest } = underlyingSource as Record<string, unknown>;
       super(rest as UnderlyingDefaultSource, strategy);
     } else {
       super(underlyingSource as UnderlyingDefaultSource, strategy);
@@ -24,7 +21,6 @@ class _PatchedReadableStream extends _OriginalReadableStream {
   }
 }
 
-// @ts-expect-error -- intentional global override for compat
 globalThis.ReadableStream = _PatchedReadableStream;
 
 import type { ServerRequest } from "srvx";

--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -1,4 +1,36 @@
 import "#nitro/virtual/polyfills";
+
+// React 19's server.edge.js uses ReadableStream({ type: "direct", ... }), a
+// Cloudflare Workers extension. Bun follows the web spec strictly and throws
+// ERR_INVALID_ARG_VALUE for unknown `type` values. Strip it before it reaches
+// Bun's constructor so prerendering works without switching to the node preset.
+const _OriginalReadableStream = globalThis.ReadableStream;
+// @ts-expect-error -- intentional global override for compat
+globalThis.ReadableStream = function ReadableStream(
+  underlyingSource?: UnderlyingDefaultSource | UnderlyingByteSource,
+  strategy?: QueuingStrategy,
+) {
+  if (
+    underlyingSource &&
+    (underlyingSource as Record<string, unknown>).type === "direct"
+  ) {
+    const { type: _type, ...rest } = underlyingSource as Record<string, unknown>;
+    return new _OriginalReadableStream(
+      rest as UnderlyingDefaultSource,
+      strategy,
+    );
+  }
+  return new _OriginalReadableStream(
+    underlyingSource as UnderlyingDefaultSource,
+    strategy,
+  );
+} as unknown as typeof ReadableStream;
+Object.setPrototypeOf(globalThis.ReadableStream, _OriginalReadableStream);
+Object.setPrototypeOf(
+  globalThis.ReadableStream.prototype,
+  _OriginalReadableStream.prototype,
+);
+
 import type { ServerRequest } from "srvx";
 import { serve } from "srvx/bun";
 import wsAdapter from "crossws/adapters/bun";

--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -5,8 +5,7 @@ import "#nitro/virtual/polyfills";
 // ERR_INVALID_ARG_VALUE for unknown `type` values. Strip it before it reaches
 // Bun's constructor so prerendering works without switching to the node preset.
 const _OriginalReadableStream = globalThis.ReadableStream;
-// @ts-expect-error -- intentional global override for compat
-globalThis.ReadableStream = function ReadableStream(
+const _PatchedReadableStream = function ReadableStream(
   underlyingSource?: UnderlyingDefaultSource | UnderlyingByteSource,
   strategy?: QueuingStrategy,
 ) {
@@ -25,11 +24,12 @@ globalThis.ReadableStream = function ReadableStream(
     strategy,
   );
 } as unknown as typeof ReadableStream;
-Object.setPrototypeOf(globalThis.ReadableStream, _OriginalReadableStream);
-Object.setPrototypeOf(
-  globalThis.ReadableStream.prototype,
-  _OriginalReadableStream.prototype,
-);
+
+Object.setPrototypeOf(_PatchedReadableStream, _OriginalReadableStream);
+_PatchedReadableStream.prototype = _OriginalReadableStream.prototype;
+
+// @ts-expect-error -- intentional global override for compat
+globalThis.ReadableStream = _PatchedReadableStream;
 
 import type { ServerRequest } from "srvx";
 import { serve } from "srvx/bun";

--- a/test/fixture/server/routes/bun-direct-stream.ts
+++ b/test/fixture/server/routes/bun-direct-stream.ts
@@ -1,0 +1,15 @@
+export default () => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    // @ts-expect-error - direct is a Cloudflare extension
+    type: "direct",
+    start(controller) {
+      controller.enqueue(encoder.encode("bun-direct"));
+      controller.close();
+    },
+  });
+
+  return {
+    isStream: stream instanceof ReadableStream,
+  };
+};

--- a/test/fixture/server/routes/bun-direct-stream.ts
+++ b/test/fixture/server/routes/bun-direct-stream.ts
@@ -11,5 +11,6 @@ export default () => {
 
   return {
     isStream: stream instanceof ReadableStream,
+    hasCorrectPrototype: Object.getPrototypeOf(stream) === ReadableStream.prototype,
   };
 };

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -8,27 +8,32 @@ const hasBun = execaCommandSync("bun --version", { stdio: "ignore", reject: fals
 
 describe.runIf(hasBun)("nitro:preset:bun", async () => {
   const ctx = await setupTest("bun");
-  testNitro(ctx, async () => {
-    const port = await getRandomPort();
-    process.env.PORT = String(port);
-    execa("bun", [resolve(ctx.outDir, "server/index.mjs")], {
-      stdio: "inherit",
-    });
-    ctx.server = {
-      url: `http://127.0.0.1:${port}`,
-      close: () => {
-        // p.kill()
-      },
-    } as any;
-    await waitForPort(port);
-    return async ({ url, ...opts }) => {
-      const res = await ctx.fetch(url, opts);
-      return res;
-    };
-  }, (ctx, callHandler) => {
-    it("bun: ReadableStream polyfill works", async () => {
-      const { data } = await callHandler({ url: "/bun-direct-stream" });
-      expect(data.isStream).toBe(true);
-    });
-  });
+  testNitro(
+    ctx,
+    async () => {
+      const port = await getRandomPort();
+      process.env.PORT = String(port);
+      execa("bun", [resolve(ctx.outDir, "server/index.mjs")], {
+        stdio: "inherit",
+      });
+      ctx.server = {
+        url: `http://127.0.0.1:${port}`,
+        close: () => {
+          // p.kill()
+        },
+      } as any;
+      await waitForPort(port);
+      return async ({ url, ...opts }) => {
+        const res = await ctx.fetch(url, opts);
+        return res;
+      };
+    },
+    (ctx, callHandler) => {
+      it("bun: ReadableStream polyfill works", async () => {
+        const { data } = await callHandler({ url: "/bun-direct-stream" });
+        expect(data.isStream).toBe(true);
+        expect(data.hasCorrectPrototype).toBe(true);
+      });
+    }
+  );
 });

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -1,7 +1,7 @@
 import { execa, execaCommandSync } from "execa";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { resolve } from "pathe";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
 
 const hasBun = execaCommandSync("bun --version", { stdio: "ignore", reject: false }).exitCode === 0;
@@ -25,5 +25,10 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       const res = await ctx.fetch(url, opts);
       return res;
     };
+  }, (ctx, callHandler) => {
+    it("bun: ReadableStream polyfill works", async () => {
+      const { data } = await callHandler({ url: "/bun-direct-stream" });
+      expect(data.isStream).toBe(true);
+    });
   });
 });

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -9,30 +9,35 @@ const hasBun = execaSync("bun", ["--version"], { stdio: "ignore", reject: false 
 
 describe.runIf(hasBun)("nitro:preset:bun", async () => {
   const ctx = await setupTest("bun");
-  testNitro(ctx, async () => {
-    const port = await getRandomPort();
-    process.env.PORT = String(port);
-    const p = execa("bun", [resolve(ctx.outDir, "server/index.mjs")], {
-      stdio: process.env.TEST_DEBUG ? "inherit" : "ignore",
-      reject: false,
-    });
-    ctx.server = {
-      url: `http://127.0.0.1:${port}`,
-      close: async () => {
-        p.kill();
-      },
-    } as any;
-    await waitForPort(port);
-    return async ({ url, ...opts }) => {
-      const res = await ctx.fetch(url, opts);
-      return res;
-    };
-  }, (ctx, callHandler) => {
-    it("bun: ReadableStream polyfill works", async () => {
-      const { data } = await callHandler({ url: "/bun-direct-stream" });
-      expect(data.isStream).toBe(true);
-    });
-  });
+  testNitro(
+    ctx,
+    async () => {
+      const port = await getRandomPort();
+      process.env.PORT = String(port);
+      const p = execa("bun", [resolve(ctx.outDir, "server/index.mjs")], {
+        stdio: process.env.TEST_DEBUG ? "inherit" : "ignore",
+        reject: false,
+      });
+      ctx.server = {
+        url: `http://127.0.0.1:${port}`,
+        close: async () => {
+          p.kill();
+        },
+      } as any;
+      await waitForPort(port);
+      return async ({ url, ...opts }) => {
+        const res = await ctx.fetch(url, opts);
+        return res;
+      };
+    },
+    (ctx, callHandler) => {
+      it("bun: ReadableStream polyfill works", async () => {
+        const { data } = await callHandler({ url: "/bun-direct-stream" });
+        expect(data.isStream).toBe(true);
+        expect(data.hasCorrectPrototype).toBe(true);
+      });
+    }
+  );
 
   testCloseHook(ctx, { command: "bun", args: (entry) => [entry] });
 });

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -1,7 +1,7 @@
 import { execa, execaSync } from "execa";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { resolve } from "pathe";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
 import { testCloseHook } from "./_close-hook.ts";
 
@@ -27,6 +27,11 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       const res = await ctx.fetch(url, opts);
       return res;
     };
+  }, (ctx, callHandler) => {
+    it("bun: ReadableStream polyfill works", async () => {
+      const { data } = await callHandler({ url: "/bun-direct-stream" });
+      expect(data.isStream).toBe(true);
+    });
   });
 
   testCloseHook(ctx, { command: "bun", args: (entry) => [entry] });


### PR DESCRIPTION
Polyfill global ReadableStream in bun preset to strip type=direct (Cloudflare Workers extension) before delegating to native constructor. Prototype chain preserved. Fixes #4259