### PR TITLE
fix(dev): route specific Nitro paths even when URL has asset extension

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -245,10 +245,9 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     const fetchDest = req.headers["sec-fetch-dest"];
     const accept = req.headers["accept"];
     const ext = req.url!.split(/[?#]/, 1)[0].match(/\.([a-z0-9]+)$/i)?.[1];
-    const isNitroRoute = !!nitro.routing.routes.match(
-      req.method || "",
-      new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname
-    );
+    const reqPathname = new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname;
+    const nitroRouteMatch = nitro.routing.routes.match(req.method || "", reqPathname);
+    const isNitroRoute = !!nitroRouteMatch;
     // Sec-Fetch-* is only sent on "potentially trustworthy" origins, so on plain-HTTP non-loopback (e.g. http://10.0.0.x) it's absent and a splat Nitro route may swallow browser asset loads (#4234). When the header is missing, treat known asset extensions without `text/html` in Accept as asset loads and let Vite handle them.
     const isAssetByDest =
       typeof fetchDest === "string" && !/^(document|iframe|frame|empty)$/.test(fetchDest);
@@ -256,8 +255,17 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     const acceptsHTML = typeof accept === "string" && /\btext\/html\b/.test(accept);
     const treatAsAsset = isAssetByDest || (!fetchDest && isAssetByExt && !acceptsHTML);
     res.setHeader("vary", "sec-fetch-dest, accept");
-    // An explicit Nitro route reaches Nitro even when the request is tagged as an asset (e.g. `<img src="/api/image">` with `sec-fetch-dest: image`, #4241), UNLESS the URL also has an asset-like extension — in that case Vite stays the definitive handler so a splat doesn't swallow `<script src=".../entry-client.ts">` (#4234).
-    const nitroWins = isNitroRoute && !(isAssetByExt && treatAsAsset);
+    // An explicit Nitro route reaches Nitro even when the request is tagged as an asset (#4241).
+    // The asset-extension guard only applies to root-level wildcards (/**) to prevent a renderer
+    // or user catch-all from swallowing Vite's own <script>/<link> serves (#4234). Specific
+    // prefixed routes (e.g. /api/photos/**) are never wildcards on Vite-managed paths (#4252).
+    const matchedRoutePattern = Array.isArray(nitroRouteMatch)
+      ? nitroRouteMatch[0]?.route
+      : nitroRouteMatch?.route;
+    const isRootWildcard =
+      matchedRoutePattern === "/**" ||
+      matchedRoutePattern?.startsWith("/**:");
+    const nitroWins = isNitroRoute && (!isRootWildcard || !(isAssetByExt && treatAsAsset));
     // Fallback for unknown URLs: extensionless, non-asset requests default to Nitro (page navigation, SSR catch-all).
     const documentFallback = !ext && !treatAsAsset;
     const routeToNitro =

--- a/test/vite/baseurl-dotted-param-fixture/routes/[...path].ts
+++ b/test/vite/baseurl-dotted-param-fixture/routes/[...path].ts
@@ -1,0 +1,6 @@
+import type { EventHandler } from "h3";
+
+export default ((event) => {
+  const path = event.context.params?.path ?? "";
+  return `root-wildcard:${path}`;
+}) satisfies EventHandler;

--- a/test/vite/baseurl-dotted-param.test.ts
+++ b/test/vite/baseurl-dotted-param.test.ts
@@ -29,7 +29,6 @@ describe("vite:baseURL dotted params", { sequential: true }, () => {
   });
 
   test("serves Nitro API routes with dotted params under baseURL without redirecting", async () => {
-    // `image` is included to cover #4241 — `<img src="/api/...">` requests carry `sec-fetch-dest: image` but should still reach an explicit Nitro route.
     for (const fetchDest of ["empty", "document", "image", undefined]) {
       const headers: Record<string, string> = {};
       if (fetchDest) {
@@ -58,16 +57,43 @@ describe("vite:baseURL dotted params", { sequential: true }, () => {
     expect(await response.text()).toBe("image");
   });
 
-  // Browsers omit Sec-Fetch-* on plain-HTTP non-loopback origins (e.g. http://10.0.0.x:3000). Without that signal, a splat Nitro route would swallow `<script src=".../entry-client.ts">` requests. Accept + asset extension is used as a fallback to keep asset loads routed to Vite.
-  test("does not misroute asset loads to splat Nitro routes when sec-fetch-dest is absent", async () => {
-    const response = await fetch(`${serverURL}/subdir/api/proxy/entry-client.ts`, {
-      headers: { accept: "*/*" },
-      redirect: "manual",
-    });
-    expect(await response.text()).not.toBe("entry-client.ts");
+  test("prefixed splat routes win over Vite assets even with asset extensions and sec-fetch-dest", async () => {
+    for (const fetchDest of ["script", "style", "image", undefined]) {
+      const headers: Record<string, string> = { accept: "*/*" };
+      if (fetchDest) {
+        headers["sec-fetch-dest"] = fetchDest;
+      }
+      const response = await fetch(`${serverURL}/subdir/api/proxy/entry-client.ts`, {
+        headers,
+        redirect: "manual",
+      });
+      expect(response.status, `fetchDest: ${fetchDest}`).toBe(200);
+      expect(await response.text(), `fetchDest: ${fetchDest}`).toBe("entry-client.ts");
+    }
   });
 
-  // The extension extraction must look at the path only — a `.png` in the query string (e.g. `?file=bar.png`) must not flag the request as an asset and divert it to Vite.
+  test("root-level wildcards do not swallow Vite assets (protects #4234)", async () => {
+    for (const fetchDest of ["script", "style", "image", undefined]) {
+      const headers: Record<string, string> = { accept: "*/*" };
+      if (fetchDest) {
+        headers["sec-fetch-dest"] = fetchDest;
+      }
+      const response = await fetch(`${serverURL}/subdir/entry-client.ts`, {
+        headers,
+        redirect: "manual",
+      });
+      expect(response.status, `fetchDest: ${fetchDest}`).toBe(404);
+    }
+  });
+
+  test("root-level wildcards *do* swallow Vite assets when NOT an asset extension", async () => {
+    const response = await fetch(`${serverURL}/subdir/some-page`, {
+      redirect: "manual",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("root-wildcard:some-page");
+  });
+
   test("ignores asset-like extensions inside the query string when routing to Nitro", async () => {
     const response = await fetch(`${serverURL}/subdir/api/proxy/data?file=bar.png`, {
       headers: { "sec-fetch-dest": "image", accept: "image/*" },


### PR DESCRIPTION
Asset-extensioned URLs (e.g. `/api/photos/12345.jpg`) were routed to Vite's static middleware
instead of the matching Nitro handler. The `ASSET_EXT_RE` guard in `nitroDevMiddlewarePre`
applied unconditionally to any matched route, including specific prefixed catch-alls like `/api/photos/**`.

The guard was introduced (#4234) to prevent a root-level renderer or user catch-all (`/**`) from
swallowing Vite's own `<script>`/`<link>` serves on plain-HTTP non-loopback origins where
`Sec-Fetch-Dest` is absent.

**Fix**: narrow the guard so the asset-extension filter only applies when the matched Nitro route
pattern is exactly `/**`. Specific routes (`/api/**`, `/api/photos/**`) are never registered on
paths Vite owns and should always win — restoring the behaviour from `nitro@3.0.1-alpha.2`.

## Test plan

- [ ] Route `routes/api/photos/[...].ts` → `curl http://localhost:3000/api/photos/12345.jpg` returns 200 from handler (was 404)
- [ ] Root-level renderer still handles page navigations normally
- [ ] `<script src="/src/app.ts">` still served by Vite (not swallowed by renderer catch-all)
- [ ] Requests with `Sec-Fetch-Dest: image` for explicit Nitro routes still reach Nitro (#4241)

Fixes #4252
