### PR TITLE
docs: correct tsconfig paths alias in `vite-ssr-tsr-react` example

### DIFF
--- a/docs/4.examples/vite-ssr-tsr-react.md
+++ b/docs/4.examples/vite-ssr-tsr-react.md
@@ -57,7 +57,7 @@ icon: i-simple-icons-tanstack
     "baseUrl": ".",
     "jsx": "react-jsx",
     "paths": {
-      "@/*": ["sec/*"]
+      "@/*": ["./src/*"]
     }
   }
 }

--- a/examples/vite-ssr-tsr-react/tsconfig.json
+++ b/examples/vite-ssr-tsr-react/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "jsx": "react-jsx",
     "paths": {
-      "@/*": ["sec/*"]
+      "@/*": ["./src/*"]
     }
   }
 }


### PR DESCRIPTION
The `@/*` path alias in `examples/vite-ssr-tsr-react/tsconfig.json` pointed to `sec/*`, which does not exist. This causes TypeScript to fail resolving modules imported via `@/`.

Changed `"sec/*"` to `"./src/*"` to match the actual project structure and align with the convention used in `examples/vite-ssr-tss-react/tsconfig.json`.