### PR TITLE
fix(vite): route asset-extensioned URLs matching explicit routes to nitro

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -1,5 +1,4 @@
 import type { NitroPluginContext } from "./types.ts";
-import type { NitroEventHandler } from "nitro/types";
 import type { DevEnvironmentContext, ResolvedConfig, ViteDevServer } from "vite";
 import type { FetchFunctionOptions, FetchResult } from "vite/module-runner";
 import type { RunnerRPCHooks } from "env-runner";
@@ -248,18 +247,23 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
       return next();
     }
 
-    // `nitro.routing.routes` always includes the SSR catch-all `/**` in SSR apps, so an
-    // explicit user route must be told apart from the catch-all (see `classifyRouteMatch`).
-    const matchKind = classifyRouteMatch(
-      nitro.routing.routes.match(
-        req.method || "",
-        new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname
-      )
+    // `nitro.routing.routes` always includes the SSR catch-all `/**` in SSR apps, so an explicit
+    // user route must be told apart from the catch-all. A root-level user catch-all
+    // (`routes/[...].ts` -> `/**`, `routes/[...slug].ts` -> `/**:slug`) is as authoritative as the
+    // SSR `/**` and must not swallow Vite asset serves either, so both forms count as catch-all;
+    // prefixed splat routes (`/api/photos/**`) are deterministic user routes and stay explicit.
+    const match = nitro.routing.routes.match(
+      req.method || "",
+      new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname
+    );
+    const matchedHandlers = match ? (Array.isArray(match) ? match : [match]) : [];
+    const isExplicitRoute = matchedHandlers.some(
+      (h) => h?.route && h.route !== "/**" && !h.route.startsWith("/**:")
     );
 
     // An explicit user route is a deterministic match and always wins, regardless of how the
     // browser tags the request (#4108, #4241, #4252, #4270) — no heuristic may override it.
-    if (matchKind === "explicit") {
+    if (isExplicitRoute) {
       return nitroDevMiddleware(req, res, next);
     }
 
@@ -269,12 +273,14 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     res.setHeader("vary", "sec-fetch-dest, accept");
     const fetchDest = req.headers["sec-fetch-dest"];
     const ext = req.url!.split(/[?#]/, 1)[0].match(/\.([a-z0-9]+)$/i)?.[1];
+
     // A known asset extension without `text/html` in `Accept` — the fallback signal when
     // `Sec-Fetch-Dest` is unavailable. The header is absent on plain-HTTP non-loopback origins
     // (e.g. http://10.0.0.x, #4234), and `empty` (fetch/XHR) is ambiguous: it tags both API
     // calls and `fetch()`ed assets, so it falls back to the extension like a missing header.
     const isAssetByExt =
       !!ext && ASSET_EXT_RE.test(ext) && !/\btext\/html\b/.test(req.headers["accept"] || "");
+
     // `document`/`iframe`/`frame` are definite navigations; any other concrete `Sec-Fetch-Dest`
     // (`image`, `video`, `style`, ...) is a definite asset load.
     const isAsset =
@@ -282,9 +288,10 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
         ? !/^(?:document|iframe|frame)$/.test(fetchDest)
         : isAssetByExt;
 
-    // Non-asset requests go to Nitro: the SSR catch-all renders them, and bare (extensionless)
-    // unmatched URLs default to Nitro as page navigations.
-    if (!isAsset && (matchKind === "catchall" || !ext)) {
+    // Non-asset requests go to Nitro: the catch-all (`matchedHandlers` are all catch-all here,
+    // since explicit routes already returned) renders them, and bare (extensionless) unmatched
+    // URLs default to Nitro as page navigations.
+    if (!isAsset && (matchedHandlers.length > 0 || !ext)) {
       return nitroDevMiddleware(req, res, next);
     }
 
@@ -299,23 +306,4 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   return () => {
     server.middlewares.use(nitroDevMiddleware);
   };
-}
-
-// Classify a `nitro.routing.routes` match into an explicit user route, a root-level catch-all,
-// or no match. In SSR apps the catch-all `/**` (renderer/serverEntry) matches every URL, so a
-// truthy match alone can't tell whether route matching is authoritative (explicit route) or
-// whether a heuristic is needed (catch-all only). A root-level user catch-all (`routes/[...].ts`
-// -> `/**`, `routes/[...slug].ts` -> `/**:slug`) is just as authoritative as the SSR `/**` and
-// must not swallow Vite asset serves either, so both forms count as catch-all. Prefixed splat
-// routes (`/api/photos/**`) are deterministic user routes and stay explicit.
-function classifyRouteMatch(
-  match: undefined | NitroEventHandler | NitroEventHandler[]
-): "explicit" | "catchall" | "none" {
-  if (!match) {
-    return "none";
-  }
-  const handlers = Array.isArray(match) ? match : [match];
-  return handlers.some((h) => h?.route && h.route !== "/**" && !h.route.startsWith("/**:"))
-    ? "explicit"
-    : "catchall";
 }

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -1,4 +1,5 @@
 import type { NitroPluginContext } from "./types.ts";
+import type { NitroEventHandler } from "nitro/types";
 import type { DevEnvironmentContext, ResolvedConfig, ViteDevServer } from "vite";
 import type { FetchFunctionOptions, FetchResult } from "vite/module-runner";
 import type { RunnerRPCHooks } from "env-runner";
@@ -242,42 +243,69 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   // Handle server routes first to avoid conflicts with static assets served by Vite from the root
   // https://github.com/vitejs/vite/pull/20866
   server.middlewares.use(function nitroDevMiddlewarePre(req, res, next) {
-    const fetchDest = req.headers["sec-fetch-dest"];
-    const accept = req.headers["accept"];
-    const ext = req.url!.split(/[?#]/, 1)[0].match(/\.([a-z0-9]+)$/i)?.[1];
-    const isNitroRoute = !!nitro.routing.routes.match(
-      req.method || "",
-      new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname
-    );
-    // Sec-Fetch-* is only sent on "potentially trustworthy" origins, so on plain-HTTP non-loopback (e.g. http://10.0.0.x) it's absent and a splat Nitro route may swallow browser asset loads (#4234). When the header is missing, treat known asset extensions without `text/html` in Accept as asset loads and let Vite handle them.
-    const isAssetByDest =
-      typeof fetchDest === "string" && !/^(document|iframe|frame|empty)$/.test(fetchDest);
-    const isAssetByExt = !!ext && ASSET_EXT_RE.test(ext);
-    const acceptsHTML = typeof accept === "string" && /\btext\/html\b/.test(accept);
-    const treatAsAsset = isAssetByDest || (!fetchDest && isAssetByExt && !acceptsHTML);
-    res.setHeader("vary", "sec-fetch-dest, accept");
-    // An explicit Nitro route reaches Nitro even when the request is tagged as an asset (e.g. `<img src="/api/image">` with `sec-fetch-dest: image`, #4241), UNLESS the URL also has an asset-like extension — in that case Vite stays the definitive handler so a splat doesn't swallow `<script src=".../entry-client.ts">` (#4234).
-    const nitroWins = isNitroRoute && !(isAssetByExt && treatAsAsset);
-    // Fallback for unknown URLs: extensionless, non-asset requests default to Nitro (page navigation, SSR catch-all).
-    const documentFallback = !ext && !treatAsAsset;
-    const routeToNitro =
-      (nitroWins || documentFallback) &&
-      // Special prefixes (/__vue-router/auto-routes, /@vite-plugin-layouts/, etc)
-      !/^\/(?:__|@)/.test(req.url!);
-    if (routeToNitro) {
-      nitroDevMiddleware(req, res, next);
-    } else {
-      if (treatAsAsset) {
-        // This is an asset load — Vite is the definitive handler. Mark the
-        // request so the catch-all `nitroDevMiddleware` registered after Vite
-        // doesn't fall back into a splat Nitro route on a 404.
-        (req as IncomingMessage & { _nitroHandled?: boolean })._nitroHandled = true;
-      }
-      next();
+    // Vite-internal prefixes (/@vite/client, /__vue-router/auto-routes, ...) are never Nitro's.
+    if (/^\/(?:__|@)/.test(req.url!)) {
+      return next();
     }
+
+    // `nitro.routing.routes` always includes the SSR catch-all `/**` in SSR apps, so an
+    // explicit user route must be told apart from the catch-all (see `classifyRouteMatch`).
+    const matchKind = classifyRouteMatch(
+      nitro.routing.routes.match(
+        req.method || "",
+        new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname
+      )
+    );
+
+    // An explicit user route is a deterministic match and always wins, regardless of how the
+    // browser tags the request (#4108, #4241, #4252, #4270) — no heuristic may override it.
+    if (matchKind === "explicit") {
+      return nitroDevMiddleware(req, res, next);
+    }
+
+    // Otherwise the request is unmatched or matched only by the SSR catch-all `/**` — genuinely
+    // ambiguous between a page navigation (-> Nitro) and an asset load (-> Vite). A wrong guess
+    // here only affects the catch-all fallback, never an explicit route.
+    res.setHeader("vary", "sec-fetch-dest, accept");
+    const fetchDest = req.headers["sec-fetch-dest"];
+    const ext = req.url!.split(/[?#]/, 1)[0].match(/\.([a-z0-9]+)$/i)?.[1];
+    // `Sec-Fetch-*` is only sent on "potentially trustworthy" origins, so on plain-HTTP
+    // non-loopback (e.g. http://10.0.0.x) it's absent (#4234); fall back to a known asset
+    // extension without `text/html` in `Accept`.
+    const isAsset =
+      typeof fetchDest === "string"
+        ? !/^(?:document|iframe|frame|empty)$/.test(fetchDest)
+        : !!ext && ASSET_EXT_RE.test(ext) && !/\btext\/html\b/.test(req.headers["accept"] || "");
+
+    // Non-asset requests go to Nitro: the SSR catch-all renders them, and bare (extensionless)
+    // unmatched URLs default to Nitro as page navigations.
+    if (!isAsset && (matchKind === "catchall" || !ext)) {
+      return nitroDevMiddleware(req, res, next);
+    }
+
+    if (isAsset) {
+      // Vite is the definitive handler — mark the request so the catch-all `nitroDevMiddleware`
+      // registered after Vite doesn't fall back into a splat Nitro route on a 404.
+      (req as IncomingMessage & { _nitroHandled?: boolean })._nitroHandled = true;
+    }
+    next();
   });
 
   return () => {
     server.middlewares.use(nitroDevMiddleware);
   };
+}
+
+// Classify a `nitro.routing.routes` match into an explicit user route, the SSR catch-all `/**`,
+// or no match. In SSR apps the catch-all `/**` (renderer/serverEntry) matches every URL, so a
+// truthy match alone can't tell whether route matching is authoritative (explicit route) or
+// whether a heuristic is needed (catch-all only).
+function classifyRouteMatch(
+  match: undefined | NitroEventHandler | NitroEventHandler[]
+): "explicit" | "catchall" | "none" {
+  if (!match) {
+    return "none";
+  }
+  const handlers = Array.isArray(match) ? match : [match];
+  return handlers.some((h) => h?.route !== "/**") ? "explicit" : "catchall";
 }

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -269,13 +269,18 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     res.setHeader("vary", "sec-fetch-dest, accept");
     const fetchDest = req.headers["sec-fetch-dest"];
     const ext = req.url!.split(/[?#]/, 1)[0].match(/\.([a-z0-9]+)$/i)?.[1];
-    // `Sec-Fetch-*` is only sent on "potentially trustworthy" origins, so on plain-HTTP
-    // non-loopback (e.g. http://10.0.0.x) it's absent (#4234); fall back to a known asset
-    // extension without `text/html` in `Accept`.
+    // A known asset extension without `text/html` in `Accept` — the fallback signal when
+    // `Sec-Fetch-Dest` is unavailable. The header is absent on plain-HTTP non-loopback origins
+    // (e.g. http://10.0.0.x, #4234), and `empty` (fetch/XHR) is ambiguous: it tags both API
+    // calls and `fetch()`ed assets, so it falls back to the extension like a missing header.
+    const isAssetByExt =
+      !!ext && ASSET_EXT_RE.test(ext) && !/\btext\/html\b/.test(req.headers["accept"] || "");
+    // `document`/`iframe`/`frame` are definite navigations; any other concrete `Sec-Fetch-Dest`
+    // (`image`, `video`, `style`, ...) is a definite asset load.
     const isAsset =
-      typeof fetchDest === "string"
-        ? !/^(?:document|iframe|frame|empty)$/.test(fetchDest)
-        : !!ext && ASSET_EXT_RE.test(ext) && !/\btext\/html\b/.test(req.headers["accept"] || "");
+      typeof fetchDest === "string" && fetchDest !== "empty"
+        ? !/^(?:document|iframe|frame)$/.test(fetchDest)
+        : isAssetByExt;
 
     // Non-asset requests go to Nitro: the SSR catch-all renders them, and bare (extensionless)
     // unmatched URLs default to Nitro as page navigations.

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -301,10 +301,12 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   };
 }
 
-// Classify a `nitro.routing.routes` match into an explicit user route, the SSR catch-all `/**`,
+// Classify a `nitro.routing.routes` match into an explicit user route, a root-level catch-all,
 // or no match. In SSR apps the catch-all `/**` (renderer/serverEntry) matches every URL, so a
 // truthy match alone can't tell whether route matching is authoritative (explicit route) or
-// whether a heuristic is needed (catch-all only).
+// whether a heuristic is needed (catch-all only). A root-level user catch-all (`routes/[...].ts`
+// -> `/**`, `routes/[...slug].ts` -> `/**:slug`) is just as authoritative as the SSR `/**` and
+// must not swallow Vite asset serves either, so both forms count as catch-all.
 function classifyRouteMatch(
   match: undefined | NitroEventHandler | NitroEventHandler[]
 ): "explicit" | "catchall" | "none" {
@@ -312,5 +314,11 @@ function classifyRouteMatch(
     return "none";
   }
   const handlers = Array.isArray(match) ? match : [match];
-  return handlers.some((h) => h?.route !== "/**") ? "explicit" : "catchall";
+  return handlers.some((h) => h?.route && !isRootCatchAll(h.route)) ? "explicit" : "catchall";
+}
+
+// A root-level catch-all: literal `/**` or a named root wildcard like `/**:slug`. Prefixed
+// splat routes (`/api/photos/**`) are deterministic user routes and are never root catch-alls.
+function isRootCatchAll(route: string): boolean {
+  return route === "/**" || route.startsWith("/**:");
 }

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -306,7 +306,8 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
 // truthy match alone can't tell whether route matching is authoritative (explicit route) or
 // whether a heuristic is needed (catch-all only). A root-level user catch-all (`routes/[...].ts`
 // -> `/**`, `routes/[...slug].ts` -> `/**:slug`) is just as authoritative as the SSR `/**` and
-// must not swallow Vite asset serves either, so both forms count as catch-all.
+// must not swallow Vite asset serves either, so both forms count as catch-all. Prefixed splat
+// routes (`/api/photos/**`) are deterministic user routes and stay explicit.
 function classifyRouteMatch(
   match: undefined | NitroEventHandler | NitroEventHandler[]
 ): "explicit" | "catchall" | "none" {
@@ -314,11 +315,7 @@ function classifyRouteMatch(
     return "none";
   }
   const handlers = Array.isArray(match) ? match : [match];
-  return handlers.some((h) => h?.route && !isRootCatchAll(h.route)) ? "explicit" : "catchall";
-}
-
-// A root-level catch-all: literal `/**` or a named root wildcard like `/**:slug`. Prefixed
-// splat routes (`/api/photos/**`) are deterministic user routes and are never root catch-alls.
-function isRootCatchAll(route: string): boolean {
-  return route === "/**" || route.startsWith("/**:");
+  return handlers.some((h) => h?.route && h.route !== "/**" && !h.route.startsWith("/**:"))
+    ? "explicit"
+    : "catchall";
 }

--- a/test/vite/app.test.ts
+++ b/test/vite/app.test.ts
@@ -50,4 +50,36 @@ describe("vite:app", () => {
     const value = await res.text();
     expect(value).toBe("value-from-ssr");
   });
+
+  // #4234: a request matching only the SSR `/**` catch-all (no explicit route) that looks like
+  // an asset must be handled by Vite, not swallowed by the catch-all renderer.
+  test("does not let the SSR catch-all swallow asset-tagged requests", async () => {
+    const res = await fetch(`${serverURL}/missing-asset.css`, {
+      headers: { "sec-fetch-dest": "style" },
+      redirect: "manual",
+    });
+    // The SSR renderer would answer 200 with JSON; Vite 404s a missing asset.
+    expect(res.status).not.toBe(200);
+  });
+
+  // #4234: with `Sec-Fetch-*` absent (plain-HTTP non-loopback origins), a known asset extension
+  // is the only signal — such a catch-all-only request must still reach Vite, not the renderer.
+  test("does not let the SSR catch-all swallow asset loads when sec-fetch-dest is absent", async () => {
+    const res = await fetch(`${serverURL}/missing-asset.js`, {
+      headers: { accept: "*/*" },
+      redirect: "manual",
+    });
+    expect(res.status).not.toBe(200);
+  });
+
+  // A page navigation matching only the SSR `/**` catch-all must reach the renderer.
+  test("routes page navigations to the SSR catch-all renderer", async () => {
+    const res = await fetch(`${serverURL}/some/nested/page`, {
+      headers: { "sec-fetch-dest": "document", accept: "text/html" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { config: string };
+    expect(data.config).toBe("NITRO_");
+  });
 });

--- a/test/vite/app.test.ts
+++ b/test/vite/app.test.ts
@@ -72,6 +72,16 @@ describe("vite:app", () => {
     expect(res.status).not.toBe(200);
   });
 
+  // `Sec-Fetch-Dest: empty` (fetch/XHR) is ambiguous: a `fetch()`ed asset matching only the SSR
+  // `/**` catch-all must reach Vite via the extension heuristic, not be swallowed by the renderer.
+  test("does not let the SSR catch-all swallow fetch()ed assets (sec-fetch-dest: empty)", async () => {
+    const res = await fetch(`${serverURL}/missing-asset.css`, {
+      headers: { "sec-fetch-dest": "empty" },
+      redirect: "manual",
+    });
+    expect(res.status).not.toBe(200);
+  });
+
   // A page navigation matching only the SSR `/**` catch-all must reach the renderer.
   test("routes page navigations to the SSR catch-all renderer", async () => {
     const res = await fetch(`${serverURL}/some/nested/page`, {

--- a/test/vite/baseurl-dotted-param.test.ts
+++ b/test/vite/baseurl-dotted-param.test.ts
@@ -58,8 +58,8 @@ describe("vite:baseURL dotted params", { sequential: true }, () => {
     expect(await response.text()).toBe("image");
   });
 
-  // #4234: a `.ts`/asset URL that matches no explicit Nitro route (only the SSR `/**` splat renderer) must be handled by Vite, not swallowed by the splat. Browsers omit Sec-Fetch-* on plain-HTTP non-loopback origins, so the asset extension is the only signal.
-  test("does not misroute asset loads to the splat renderer when sec-fetch-dest is absent", async () => {
+  // #4234: a `.ts`/asset URL that matches no Nitro route must be handled by Vite, not diverted to Nitro. Browsers omit Sec-Fetch-* on plain-HTTP non-loopback origins, so the asset extension is the only signal.
+  test("does not misroute unmatched asset loads to Nitro when sec-fetch-dest is absent", async () => {
     const response = await fetch(`${serverURL}/subdir/src/entry-client.ts`, {
       headers: { accept: "*/*" },
       redirect: "manual",

--- a/test/vite/baseurl-dotted-param.test.ts
+++ b/test/vite/baseurl-dotted-param.test.ts
@@ -58,13 +58,34 @@ describe("vite:baseURL dotted params", { sequential: true }, () => {
     expect(await response.text()).toBe("image");
   });
 
-  // Browsers omit Sec-Fetch-* on plain-HTTP non-loopback origins (e.g. http://10.0.0.x:3000). Without that signal, a splat Nitro route would swallow `<script src=".../entry-client.ts">` requests. Accept + asset extension is used as a fallback to keep asset loads routed to Vite.
-  test("does not misroute asset loads to splat Nitro routes when sec-fetch-dest is absent", async () => {
-    const response = await fetch(`${serverURL}/subdir/api/proxy/entry-client.ts`, {
+  // #4234: a `.ts`/asset URL that matches no explicit Nitro route (only the SSR `/**` splat renderer) must be handled by Vite, not swallowed by the splat. Browsers omit Sec-Fetch-* on plain-HTTP non-loopback origins, so the asset extension is the only signal.
+  test("does not misroute asset loads to the splat renderer when sec-fetch-dest is absent", async () => {
+    const response = await fetch(`${serverURL}/subdir/src/entry-client.ts`, {
       headers: { accept: "*/*" },
       redirect: "manual",
     });
-    expect(await response.text()).not.toBe("entry-client.ts");
+    expect(response.status).not.toBe(200);
+    expect(await response.text()).not.toContain("fixture");
+  });
+
+  // #4252: an explicit Nitro route whose URL ends in an asset-like extension (`.jpg`) must still reach the route handler instead of being misrouted to Vite's static middleware.
+  test("routes URLs with asset-like extensions to an explicit Nitro route", async () => {
+    const response = await fetch(`${serverURL}/subdir/api/proxy/12345.jpg`, {
+      headers: { accept: "*/*" },
+      redirect: "manual",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("12345.jpg");
+  });
+
+  // #4270: an asset `Sec-Fetch-Dest` (e.g. `video`) must not divert an explicit Nitro route to Vite, even when the URL also has an asset-like extension.
+  test("routes asset-tagged requests to an explicit Nitro route", async () => {
+    const response = await fetch(`${serverURL}/subdir/api/proxy/clip.mp4`, {
+      headers: { "sec-fetch-dest": "video" },
+      redirect: "manual",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("clip.mp4");
   });
 
   // The extension extraction must look at the path only — a `.png` in the query string (e.g. `?file=bar.png`) must not flag the request as an asset and divert it to Vite.

--- a/test/vite/root-wildcard-fixture/routes/[...path].ts
+++ b/test/vite/root-wildcard-fixture/routes/[...path].ts
@@ -1,0 +1,1 @@
+export default (event: any) => "root-wildcard:" + (event.context.params?.path ?? "");

--- a/test/vite/root-wildcard-fixture/vite.config.ts
+++ b/test/vite/root-wildcard-fixture/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
+
+export default defineConfig({
+  plugins: [
+    nitro({
+      serverDir: "./",
+      serveStatic: false,
+    }),
+  ],
+});

--- a/test/vite/root-wildcard.test.ts
+++ b/test/vite/root-wildcard.test.ts
@@ -1,0 +1,66 @@
+import { fileURLToPath } from "node:url";
+import type { ViteDevServer } from "vite";
+import { beforeAll, afterAll, describe, expect, test } from "vitest";
+
+const { createServer } = (await import(
+  process.env.NITRO_VITE_PKG || "vite"
+)) as typeof import("vite");
+
+describe("vite:root wildcard routes", { sequential: true }, () => {
+  let server: ViteDevServer;
+  let serverURL: string;
+
+  const rootDir = fileURLToPath(new URL("./root-wildcard-fixture", import.meta.url));
+  const originalCwd = process.cwd();
+
+  beforeAll(async () => {
+    process.chdir(rootDir);
+    server = await createServer({ root: rootDir });
+    await server.listen("0" as unknown as number);
+    const addr = server.httpServer?.address() as {
+      port: number;
+      address: string;
+      family: string;
+    };
+    serverURL = `http://${addr.family === "IPv6" ? `[${addr.address}]` : addr.address}:${addr.port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server?.close();
+    process.chdir(originalCwd);
+  });
+
+  // #4234/#4266: a root-level user catch-all (`routes/[...path].ts` -> `/**:path`) is as
+  // authoritative as the SSR `/**` renderer — it must not swallow Vite's own asset serves
+  // (`<script src=".../entry-client.ts">`), so the asset heuristic still applies to it.
+  test("root-level named catch-all does not swallow Vite asset loads", async () => {
+    for (const fetchDest of ["script", "style", "image", undefined]) {
+      const headers: Record<string, string> = { accept: "*/*" };
+      if (fetchDest) {
+        headers["sec-fetch-dest"] = fetchDest;
+      }
+      const response = await fetch(`${serverURL}/entry-client.ts`, {
+        headers,
+        redirect: "manual",
+      });
+      // The catch-all would answer 200 (`root-wildcard:...`); Vite 404s a missing asset.
+      expect(response.status, `sec-fetch-dest: ${fetchDest}`).not.toBe(200);
+    }
+  });
+
+  // A non-asset page navigation must still reach the root catch-all handler.
+  test("root-level named catch-all handles page navigations", async () => {
+    const headerVariants: Record<string, string>[] = [
+      {},
+      { "sec-fetch-dest": "document", accept: "text/html" },
+    ];
+    for (const headers of headerVariants) {
+      const response = await fetch(`${serverURL}/some/nested/page`, {
+        headers,
+        redirect: "manual",
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("root-wildcard:some/nested/page");
+    }
+  });
+});


### PR DESCRIPTION
The dev middleware misrouted explicit Nitro routes to Vite whenever a request looked like an asset (e.g. `Sec-Fetch-Dest: video` or a `.jpg` extension), because `nitro.routing.routes` includes the SSR catch-all `/**` — making an explicit route match indistinguishable from the splat fallback, so browser heuristics were allowed to override real user routes. This classifies each match as explicit / catch-all / none so an explicit user route is a deterministic win no heuristic can touch, leaving the `sec-fetch-dest`/`accept`/extension heuristic to govern only the genuinely ambiguous SSR catch-all case; regression tests are added for both reports, and the existing #4234 test was retargeted to a non-route path since it was asserting an asset extension should override an explicit route — the exact behavior #4252 reports as a bug.

Fixes #4252
Fixes #4270
Related: #4234, #4238, #4241, #4108

🤖 Generated with [Claude Code](https://claude.com/claude-code)