### PR TITLE
fix(vite): respect tanstack start route manifest in dev

### DIFF
--- a/docs/4.examples/vite-ssr-tss-react.md
+++ b/docs/4.examples/vite-ssr-tss-react.md
@@ -20,9 +20,9 @@ icon: i-simple-icons-tanstack
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "@tanstack/react-router": "^1.168.8",
-    "@tanstack/react-router-devtools": "^1.166.11",
-    "@tanstack/react-start": "^1.167.13",
+    "@tanstack/react-router": "^1.170.4",
+    "@tanstack/react-router-devtools": "^1.167.0",
+    "@tanstack/react-start": "^1.168.6",
     "nitro": "latest",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/examples/vite-ssr-tss-react/package.json
+++ b/examples/vite-ssr-tss-react/package.json
@@ -6,9 +6,9 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "@tanstack/react-router": "^1.168.8",
-    "@tanstack/react-router-devtools": "^1.166.11",
-    "@tanstack/react-start": "^1.167.13",
+    "@tanstack/react-router": "^1.170.4",
+    "@tanstack/react-router-devtools": "^1.167.0",
+    "@tanstack/react-start": "^1.168.6",
     "nitro": "latest",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,13 +644,13 @@ importers:
   examples/vite-ssr-tss-react:
     dependencies:
       '@tanstack/react-router':
-        specifier: ^1.168.8
+        specifier: ^1.170.4
         version: 1.170.4(react-dom@19.2.6)(react@19.2.6)
       '@tanstack/react-router-devtools':
-        specifier: ^1.166.11
+        specifier: ^1.167.0
         version: 1.167.0(@tanstack/react-router@1.170.4)(@tanstack/router-core@1.171.2)(csstype@3.2.3)(react-dom@19.2.6)(react@19.2.6)
       '@tanstack/react-start':
-        specifier: ^1.167.13
+        specifier: ^1.168.6
         version: 1.168.6(@vitejs/plugin-rsc@0.5.26)(crossws@0.4.5)(react-dom@19.2.6)(react@19.2.6)(vite-plugin-solid@2.11.12)(vite@8.0.13)
       nitro:
         specifier: workspace:*

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -252,14 +252,13 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     // (`routes/[...].ts` -> `/**`, `routes/[...slug].ts` -> `/**:slug`) is as authoritative as the
     // SSR `/**` and must not swallow Vite asset serves either, so both forms count as catch-all;
     // prefixed splat routes (`/api/photos/**`) are deterministic user routes and stay explicit.
-    const match = nitro.routing.routes.match(
-      req.method || "",
-      new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost").pathname
-    );
+    const pathname = new URL(withBase(req.url!, nitro.options.baseURL), "http://localhost")
+      .pathname;
+    const match = nitro.routing.routes.match(req.method || "", pathname);
     const matchedHandlers = match ? (Array.isArray(match) ? match : [match]) : [];
-    const isExplicitRoute = matchedHandlers.some(
-      (h) => h?.route && h.route !== "/**" && !h.route.startsWith("/**:")
-    );
+    const isExplicitRoute =
+      matchedHandlers.some((h) => h?.route && h.route !== "/**" && !h.route.startsWith("/**:")) ||
+      matchesStartRoute(pathname);
 
     // An explicit user route is a deterministic match and always wins, regardless of how the
     // browser tags the request (#4108, #4241, #4252, #4270) — no heuristic may override it.
@@ -306,4 +305,44 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   return () => {
     server.middlewares.use(nitroDevMiddleware);
   };
+}
+
+// ---- TanStack Start route manifest probe ----
+// Start's router plugin publishes a filesystem-routes manifest on globalThis for sibling Vite
+// plugins to consume (see `@tanstack/start-plugin-core` `routes-manifest-plugin`). When present,
+// any URL matching one of Start's routes is treated as explicit so it flows through Nitro's
+// middleware (where Start's devApp gets first shot) instead of the asset/page heuristic.
+
+type StartRoutesManifest = Record<string, { filePath?: string; children?: string[] } | undefined>;
+
+let cachedStartManifest: StartRoutesManifest | undefined;
+let cachedStartMatchers: RegExp[] = [];
+
+function matchesStartRoute(pathname: string): boolean {
+  const manifest = (globalThis as { TSS_ROUTES_MANIFEST?: StartRoutesManifest })
+    .TSS_ROUTES_MANIFEST;
+  if (!manifest) return false;
+  if (manifest !== cachedStartManifest) {
+    cachedStartManifest = manifest;
+    cachedStartMatchers = [];
+    for (const [routePath, entry] of Object.entries(manifest)) {
+      if (!entry || routePath === "__root__") continue;
+      cachedStartMatchers.push(startRouteToRegex(routePath));
+    }
+  }
+  return cachedStartMatchers.some((re) => re.test(pathname));
+}
+
+function startRouteToRegex(routePath: string): RegExp {
+  let path = routePath.replace(/\/$/, "");
+  let splat = false;
+  if (path.endsWith("/$")) {
+    splat = true;
+    path = path.slice(0, -2);
+  }
+  const parts = path.split("/").map((seg) => {
+    if (seg.startsWith("$")) return "[^/]+";
+    return seg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  });
+  return new RegExp(`^${parts.join("/")}${splat ? "(?:/.*)?" : ""}/?$`);
 }


### PR DESCRIPTION
Fixes the TanStack Start regression reported in [TanStack/router#7403](https://github.com/TanStack/router/issues/7403) (specifically [this comment](https://github.com/TanStack/router/issues/7403#issuecomment-4492301829)): `<img src="/api/.../thumbnail">` returns `404 text/html` in dev, even though hitting the URL directly works.

## Why #4272 was not enough

#4272 made the dev middleware consult `nitro.routing.routes` to decide whether a request is an explicit user route. But TanStack Start API routes live at `src/routes/api/**.ts` and register via `viteDevServer.middlewares.use(...)`, so they never appear in `nitro.routing.routes` — that table only contains the SSR catch-all `/**`. As a result, `isExplicitRoute` is always `false` for Start API routes, and any image-context request (`Sec-Fetch-Dest: image`) falls into the asset branch and is claimed by Vite.

## Fix

- During dev, consult `globalThis.TSS_ROUTES_MANIFEST` (published by `@tanstack/start-plugin-core`'s `routes-manifest-plugin` for sibling Vite plugins) so URLs matching a TanStack Start filesystem route are treated as explicit.
- These requests then flow through nitro's dev middleware (where Start's `devApp` gets first shot) instead of being classified by the asset/page heuristic.
- Bumps `@tanstack/react-router`, `@tanstack/react-router-devtools`, and `@tanstack/react-start` in the `vite-ssr-tss-react` example to versions that publish the manifest (separate commit).

## Verification

Verified locally against `examples/vite-ssr-tss-react` (Start app whose API routes are not visible to nitro), with the fix toggled on/off:

| Request | Without fix | With fix |
|---|---|---|
| `GET /api/test` (plain) | 200 json | 200 json |
| `GET /api/test` + `Sec-Fetch-Dest: image` | **404 html** | 200 json |
| `GET /api/files/42` + `Sec-Fetch-Dest: image` (parametrized `\$id`) | **404 html** | 200 json |
| `GET /api/files/foo.png` + `Sec-Fetch-Dest: image` (`.png` in path param) | **404 html** | 200 json |
| `GET /api/nope/x` + image (unmatched) | 404 | 404 |
| `GET /favicon.ico` + image (real asset) | 404 | 404 |

## Caveat

The probe relies on the undocumented `globalThis.TSS_ROUTES_MANIFEST` contract. If Start renames/removes it, the fallback silently disables and we regress to the #4272 behavior. Worth coordinating with the Start team so the contract is intentional.