### PR TITLE
feat(build): support custom framework preview/deploy commands

### DIFF
--- a/src/build/rolldown/prod.ts
+++ b/src/build/rolldown/prod.ts
@@ -48,10 +48,12 @@ export async function buildProduction(nitro: Nitro, config: RolldownOptions) {
   const rewriteRelativePaths = (input: string) => {
     return input.replace(/([\s:])\.\/(\S*)/g, `$1${rOutput}/$2`);
   };
-  nitro.logger.success("You can preview this build using `npx nitro preview`");
+  const previewCommand = nitro.options.framework.previewCommand || "npx nitro preview";
+  nitro.logger.success(`You can preview this build using \`${previewCommand}\``);
   if (buildInfo.commands!.deploy) {
+    const deployCommand = nitro.options.framework.deployCommand || "npx nitro deploy --prebuilt";
     nitro.logger.success(
-      rewriteRelativePaths("You can deploy this build using `npx nitro deploy --prebuilt`")
+      rewriteRelativePaths(`You can deploy this build using \`${deployCommand}\``)
     );
   }
 }

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -120,9 +120,11 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
 
   // Show deploy and preview commands
   if (!isTest && !isCI) console.log();
-  nitro.logger.success("You can preview this build using `npx vite preview`");
+  const previewCommand = nitro.options.framework.previewCommand || "npx nitro preview";
+  nitro.logger.success(`You can preview this build using \`${previewCommand}\``);
   if (nitro.options.commands.deploy) {
-    nitro.logger.success("You can deploy this build using `npx nitro deploy --prebuilt`");
+    const deployCommand = nitro.options.framework.deployCommand || "npx nitro deploy --prebuilt";
+    nitro.logger.success(`You can deploy this build using \`${deployCommand}\``);
   }
 }
 

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -120,7 +120,7 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
 
   // Show deploy and preview commands
   if (!isTest && !isCI) console.log();
-  const previewCommand = nitro.options.framework.previewCommand || "npx nitro preview";
+  const previewCommand = nitro.options.framework.previewCommand || "npx vite preview";
   nitro.logger.success(`You can preview this build using \`${previewCommand}\``);
   if (nitro.options.commands.deploy) {
     const deployCommand = nitro.options.framework.deployCommand || "npx nitro deploy --prebuilt";

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -69,6 +69,22 @@ export type NitroTypes = {
 export interface NitroFrameworkInfo {
   name?: "nitro" | (string & {});
   version?: string;
+  /**
+   * Command shown in build output as the suggested preview command.
+   *
+   * Display-only: Nitro never executes this. Use this when the framework
+   * wraps `nitro preview` with its own CLI (e.g. `npx nuxt preview`).
+   * Defaults to `npx nitro preview`.
+   */
+  previewCommand?: string;
+  /**
+   * Command shown in build output as the suggested deploy command.
+   *
+   * Display-only: Nitro never executes this. Use this when the framework
+   * wraps `nitro deploy` with its own CLI (e.g. `npx nuxt deploy`).
+   * Defaults to `npx nitro deploy --prebuilt`.
+   */
+  deployCommand?: string;
 }
 
 /**


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

testing vite environment api with nuxt, I was surprised to see this printed out at the end of the build:

```
ℹ Generated playground/.output/nitro.json
✔ You can preview this build using npx vite preview
│
└  ✨ Build complete!
```

I think it makes sense for frameworks with their own CLI to provide a custom preview/deploy command rather than hard-coding it to `vite preview`, or `nitro deploy`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
