### PR TITLE
fix(runtime): avoid std-env in warning stub

### DIFF
--- a/src/runtime/virtual/_runtime_warn.ts
+++ b/src/runtime/virtual/_runtime_warn.ts
@@ -1,5 +1,7 @@
 import consola from "consola";
-import { isTest } from "std-env";
+
+const env: Record<string, string | undefined> | undefined = globalThis.process?.env;
+const isTest: boolean = env?.NODE_ENV === "test" || !!env?.TEST;
 
 if (!isTest) {
   consola.warn(


### PR DESCRIPTION
### 🔗 Linked issue

No existing issue found. Minimal reproduction:

| | Link | Expected |
|---|---|---|
| Bug | [nitro-v3-std-env-repro](https://stackblitz.com/github/onmax/repros/tree/repro/nitro-v3-std-env-repro/nitro-v3-std-env-repro?startScript=repro) | Fails with `ERR_MODULE_NOT_FOUND` for `std-env` |
| Fix | [nitro-v3-std-env-repro-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nitro-v3-std-env-repro/nitro-v3-std-env-repro-fix?startScript=repro) | Shows Nitro's warning and returns the stub config |

Related history: #3629, #3861

PR made with Codex

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nitro v3's published virtual runtime stubs are intended to let imports such as `nitro/runtime-config` work outside a built Nitro app. When that fallback is used outside tests, Nitro should show the warning added in #3861 and continue with the stub implementation.

The issue comes from the interaction between two earlier changes:

- #3629 intentionally reduced Nitro's production install footprint by tracing several runtime dependencies instead of keeping them in `dependencies`; `std-env` moved out of production dependencies as part of that direction.
- #3861 later added `_runtime_warn.ts` for the public virtual runtime stubs, and that warning helper imported `isTest` from `std-env`.

That creates a clean-install failure in Nitro v3 before the intended warning can run:

```js
import { useRuntimeConfig } from "nitro/runtime-config";

console.log(useRuntimeConfig());
```

With only `nitro@3.0.260522-beta` installed, this currently throws:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'std-env' imported from .../nitro/dist/runtime/virtual/_runtime_warn.mjs
```

This PR keeps the install-footprint direction from #3629 by making the test guard dependency-free instead of adding `std-env` back to Nitro's production dependencies. The guard preserves the relevant `std-env` `isTest` behavior for this use case: suppress the warning when `NODE_ENV === "test"` or `TEST` is set.

The guard uses optional `globalThis.process?.env`, matching the environment access pattern already used by Nitro's runtime config and by `std-env` itself. The existing `consola.warn` behavior is left unchanged; this PR only removes the missing `std-env` runtime import.

I verified lint, build, and a local packed clean install without `std-env`; `import("nitro/runtime-config")` reaches Nitro's intended warning and returns the stub config.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
