### PR TITLE
fix(types): only strip extensions that ts retries

### DIFF
--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -237,10 +237,7 @@ export async function writeTypes(nitro: Nitro) {
             return path;
           }
           const stats = await fsp.stat(path).catch(() => null /* file does not exist */);
-          return relativeWithDot(
-            tsconfigDir,
-            stats?.isFile() ? path.replace(/(?<=\w)\.\w+$/g, "") /* remove extension */ : path
-          );
+          return relativeWithDot(tsconfigDir, stats?.isFile() ? stripPathsExt(path) : path);
         })
       );
       tsConfig.compilerOptions!.paths[alias] = [...new Set(paths)];
@@ -284,4 +281,12 @@ const RELATIVE_RE = /^\.{1,2}\//;
 export function relativeWithDot(from: string, to: string) {
   const rel = relative(from, to);
   return RELATIVE_RE.test(rel) ? rel : "./" + rel;
+}
+
+// Strip only the extensions TS retries from a bare `paths` candidate.
+// https://github.com/microsoft/TypeScript/blob/main/src/compiler/moduleNameResolver.ts
+const PATHS_STRIPPABLE_EXT_RE = /\.(?:tsx?|jsx?|[cm]js)$/;
+
+export function stripPathsExt(path: string) {
+  return path.replace(PATHS_STRIPPABLE_EXT_RE, "");
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

spotted this when testing nuxt v5. this also needs to be fixed in nuxt, and is _very weird_. I was not aware of this behaviour, but here's what it looks like:

https://stackblitz.com/edit/node-4mtandbr?file=tsconfig.json,index.ts

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
