### PR TITLE
feat(config): add `defaultPreset` to customize the fallback preset

### DIFF
--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -22,6 +22,20 @@ export default defineConfig({
 });
 ```
 
+### `defaultPreset`
+
+Customize the preset used as the **fallback** when `preset` is not set and none of the known hosting providers are auto-detected.
+
+By default, Nitro falls back to the runtime-based preset (`node`, and `deno` or `bun` when running on those runtimes). An explicit `preset`, the `NITRO_PRESET` environment variable, and auto-detected providers (Vercel, Netlify, Cloudflare Pages, ...) all take precedence over `defaultPreset`.
+
+It accepts a preset name or an inline preset definition.
+
+```ts
+export default defineConfig({
+  defaultPreset: "node_cluster", // use node_cluster instead of node_server by default
+});
+```
+
 ### `debug`
 
 - Default: `false`{lang=ts} (`true`{lang=ts} when `DEBUG` environment variable is set)

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -80,6 +80,9 @@ async function _loadUserConfig(
   // prettier-ignore
   let preset: string | undefined = (configOverrides.preset as string) || process.env.NITRO_PRESET || process.env.SERVER_PRESET
 
+  // Inline `defaultPreset` object resolved during auto-detection (injected via `resolve`)
+  let inlineDefaultPreset: (NitroConfig & { _meta?: NitroPresetMeta }) | undefined;
+
   const _dotenv = opts.dotenv ?? (configOverrides.dev && { fileName: [".env", ".env.local"] });
   const envName = opts.c12?.envName ?? (configOverrides.dev ? "development" : "production");
   const loadedConfig = await (
@@ -123,12 +126,19 @@ async function _loadUserConfig(
                 .catch(() => "nitro-dev")
             : "nitro-dev";
       } else if (!preset) {
-        // Auto detect production preset
-        preset = await resolvePreset("" /* auto detect */, {
+        // Auto detect production preset (with user-defined `defaultPreset` fallback)
+        const defaultPreset = getConf("defaultPreset");
+        const resolved = await resolvePreset("" /* auto detect */, {
           static: getConf("static"),
           dev: false,
           compatibilityDate: compatibilityDate || "latest",
-        }).then((p) => p?._meta?.name);
+          defaultPreset,
+        });
+        preset = resolved?._meta?.name;
+        // An inline `defaultPreset` object has no resolvable name, inject it directly
+        if (resolved && defaultPreset && typeof defaultPreset !== "string") {
+          inlineDefaultPreset = resolved;
+        }
       }
 
       return {
@@ -142,6 +152,9 @@ async function _loadUserConfig(
       };
     },
     async resolve(id: string) {
+      if (inlineDefaultPreset && id === inlineDefaultPreset._meta?.name) {
+        return { config: klona(inlineDefaultPreset) };
+      }
       const preset = await resolvePreset(id, {
         static: configOverrides.static,
         compatibilityDate: compatibilityDate || "latest",

--- a/src/presets/_resolve.ts
+++ b/src/presets/_resolve.ts
@@ -19,6 +19,7 @@ export async function resolvePreset(
     static?: boolean;
     compatibilityDate?: false | CompatibilityDateSpec;
     dev?: boolean;
+    defaultPreset?: string | NitroPreset;
   } = {}
 ): Promise<(NitroPreset & { _meta?: NitroPresetMeta }) | undefined> {
   if (name === ".") {
@@ -80,6 +81,18 @@ export async function resolvePreset(
   if (!name && !preset) {
     if (opts?.static) {
       return resolvePreset("static", opts);
+    }
+    // User-configured fallback preset (`defaultPreset`)
+    if (opts.defaultPreset) {
+      if (typeof opts.defaultPreset === "string") {
+        return resolvePreset(opts.defaultPreset, { ...opts, defaultPreset: undefined });
+      }
+      const config =
+        typeof opts.defaultPreset === "function" ? opts.defaultPreset() : opts.defaultPreset;
+      return {
+        ...config,
+        _meta: { name: "default", ...(config as { _meta?: NitroPresetMeta })._meta },
+      };
     }
     const runtimeMap = { deno: "deno", bun: "bun" } as Record<string, string>;
     return resolvePreset(runtimeMap[runtime] || "node", opts);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -952,6 +952,22 @@ export interface NitroConfig
     >,
     C12InputConfig<NitroConfig> {
   preset?: PresetNameInput;
+
+  /**
+   * Customize the preset used as the **fallback** when no `preset` is set and
+   * none of the known hosting providers are auto-detected.
+   *
+   * By default, Nitro falls back to the runtime-based preset (`node`, and
+   * `deno` or `bun` when running on those runtimes). An explicit `preset`,
+   * the `NITRO_PRESET` environment variable, and auto-detected providers
+   * (Vercel, Netlify, Cloudflare Pages, …) all take precedence over this.
+   *
+   * Accepts a preset name or an inline preset definition.
+   *
+   * @see https://nitro.build/config#defaultpreset
+   */
+  defaultPreset?: PresetNameInput | NitroPreset;
+
   extends?: string | string[] | NitroPreset;
   routeRules?: { [path: string]: NitroRouteConfig };
   rollupConfig?: Partial<RollupConfig>;

--- a/test/unit/default-preset.test.ts
+++ b/test/unit/default-preset.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("nitro/meta", () => ({
+  version: "0.0.0-test",
+  runtimeDir: "/tmp",
+  presetsDir: "/tmp",
+  pkgDir: "/tmp",
+  runtimeDependencies: [],
+}));
+
+// Force a "plain" environment: no hosting provider, node runtime
+vi.mock("std-env", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("std-env")>()),
+  provider: "",
+  runtime: "node",
+}));
+
+async function resolve(name: string, opts: Record<string, unknown> = {}) {
+  const { resolvePreset } = await import("../../src/presets/_resolve.ts");
+  return resolvePreset(name, { compatibilityDate: "latest", ...opts });
+}
+
+describe("defaultPreset", () => {
+  it("falls back to node-server without a defaultPreset", async () => {
+    const preset = await resolve("");
+    expect(preset?._meta?.name).toBe("node-server");
+  });
+
+  it("uses a string defaultPreset as the auto-detect fallback", async () => {
+    const preset = await resolve("", { defaultPreset: "node-cluster" });
+    expect(preset?._meta?.name).toBe("node-cluster");
+  });
+
+  it("uses an inline object defaultPreset", async () => {
+    const preset = await resolve("", {
+      defaultPreset: { entry: "./custom", _meta: { name: "my-default" } },
+    });
+    expect(preset?._meta?.name).toBe("my-default");
+    expect((preset as { entry?: string })?.entry).toBe("./custom");
+  });
+
+  it("names an inline object defaultPreset 'default' when no _meta is set", async () => {
+    const preset = await resolve("", { defaultPreset: { entry: "./custom" } });
+    expect(preset?._meta?.name).toBe("default");
+  });
+
+  it("ignores defaultPreset when an explicit preset is given", async () => {
+    const preset = await resolve("bun", { defaultPreset: "node-cluster" });
+    expect(preset?._meta?.name).toBe("bun");
+  });
+});


### PR DESCRIPTION
Adds a new `defaultPreset: string | <Preset>` config option that customizes the preset used as the **fallback** when `preset` is not set and none of the known hosting providers are auto-detected. By default Nitro falls back to the runtime-based preset (`node`, or `deno`/`bun` on those runtimes); `defaultPreset` lets you override that default (e.g. to `node-cluster`) while keeping the normal precedence intact — an explicit `preset`, the `NITRO_PRESET` env var, and auto-detected providers (Vercel, Netlify, Cloudflare Pages, …) all still take priority. It accepts either a preset name or an inline preset definition (the latter is injected as a base layer so user config still overrides it, and its nested `extends`/`preset` are resolved recursively). Includes unit tests for the resolver fallback paths and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)