### PR TITLE
docs: fix quick-start preview image

### DIFF
--- a/docs/1.docs/2.quick-start.md
+++ b/docs/1.docs/2.quick-start.md
@@ -25,7 +25,7 @@ The fastest way to create a Nitro application is using the `create-nitro-app`.
 <details>
   <summary>Preview</summary>
   <div style="display:flex;justify-content:center;">
-    <img src="https://github.com/user-attachments/assets/dbbce7a5-8567-4173-8d47-126b14cd5b1b" alt="Preview" style="max-width:100%;height:auto;display:block;" />
+    <img src="https://github.com/nitrojs/create-nitro-app/blob/main/.images/preview-dark.svg?raw=true" alt="Preview" style="max-width:100%;height:auto;display:block;" />
   </div>
 </details>
 


### PR DESCRIPTION
in #4305 the Copilot Agent added the screenshot from the issue to the docs instead of the actual preview image. 

This PR sets the correct preview image.
| BEFORE | AFTER |
|---|---|
| <img width="942" height="755" alt="Image" src="https://github.com/user-attachments/assets/d7771503-afa8-4d4b-a44b-3533b5db7327" /> | <img width="904" height="768" alt="image" src="https://github.com/user-attachments/assets/b528013c-6df9-4e49-8fda-78af0e5844f5" /> |


Fixes #4305