### PR TITLE
fix(vite): support Bun-only dev server

### DIFF
--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -167,9 +167,7 @@ export async function reloadEnvRunner(ctx: NitroPluginContext) {
 }
 
 async function _loadRunner(ctx: NitroPluginContext, manager: RunnerManager) {
-  const runnerName = (ctx.nitro!.options.devServer.runner ||
-    process.env.NITRO_DEV_RUNNER ||
-    "node-worker") as RunnerName;
+  const runnerName = getDevRunnerName(ctx);
   const entry = resolve(runtimeDir, "internal/vite/dev-worker.mjs");
   let runner;
   if (runnerName === "miniflare") {
@@ -233,9 +231,7 @@ export function nitroServiceProxy(): VitePlugin {
 // workerd-based runners (miniflare) cannot handle CJS externals via import(),
 // so all dependencies must be processed through Vite's transform pipeline.
 function _isWorkerdRunner(ctx: NitroPluginContext): boolean {
-  const runnerName =
-    ctx.nitro!.options.devServer.runner || process.env.NITRO_DEV_RUNNER || "node-worker";
-  return runnerName === "miniflare";
+  return getDevRunnerName(ctx) === "miniflare";
 }
 
 function tryResolve(id: string) {
@@ -248,4 +244,16 @@ function tryResolve(id: string) {
     try: true,
   });
   return resolved || id;
+}
+
+function getDevRunnerName(ctx: NitroPluginContext): RunnerName {
+  return (ctx.nitro!.options.devServer.runner ||
+    process.env.NITRO_DEV_RUNNER ||
+    getDefaultDevRunnerName()) as RunnerName;
+}
+
+function getDefaultDevRunnerName(): RunnerName {
+  return typeof (globalThis as typeof globalThis & { Bun?: unknown }).Bun === "undefined"
+    ? "node-worker"
+    : "bun-process";
 }

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -176,7 +176,9 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
 
   async #reload() {
     const runnerName =
-      this.nitro.options.devServer.runner || process.env.NITRO_DEV_RUNNER || "node-worker";
+      this.nitro.options.devServer.runner ||
+      process.env.NITRO_DEV_RUNNER ||
+      getDefaultDevRunnerName();
     const runner = await loadRunner(runnerName as RunnerName, {
       name: `Nitro_${this.#workerIdCtr++}`,
       data: { entry: this.#entry, ...this.#workerData },
@@ -247,4 +249,10 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   }
 
   // #endregion
+}
+
+function getDefaultDevRunnerName(): RunnerName {
+  return typeof (globalThis as typeof globalThis & { Bun?: unknown }).Bun === "undefined"
+    ? "node-worker"
+    : "bun-process";
 }

--- a/src/runtime/internal/vite/dev-worker.mjs
+++ b/src/runtime/internal/vite/dev-worker.mjs
@@ -148,13 +148,15 @@ globalThis.__transform_html__ = async function (html) {
 
 // ----- Exports (env-runner AppEntry) -----
 
-export function fetch(req) {
+export async function fetch(req) {
   const viteEnv = req?.headers.get("x-vite-env") || "nitro";
-  const env = envs[viteEnv];
+  const env = await waitForViteEnv(viteEnv);
   if (!env) {
-    return renderError(req, httpError(500, `Unknown vite environment "${viteEnv}"`));
+    return normalizeBunResponse(
+      await renderError(req, httpError(500, `Unknown vite environment "${viteEnv}"`))
+    );
   }
-  return env.fetch(req);
+  return normalizeBunResponse(await env.fetch(req));
 }
 
 export function upgrade(context) {
@@ -209,6 +211,28 @@ function httpError(status, message) {
   error.status = status;
   error.name = "NitroViteError";
   return error;
+}
+
+async function waitForViteEnv(name) {
+  let env = envs[name];
+  for (let i = 0; i < 5 && !env; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 100 * Math.pow(2, i)));
+    env = envs[name];
+  }
+  return env;
+}
+
+export function normalizeBunResponse(response) {
+  if (typeof Bun === "undefined") {
+    return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 async function renderError(req, error) {

--- a/test/unit/vite-dev-worker.test.ts
+++ b/test/unit/vite-dev-worker.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { normalizeBunResponse } = await import("../../src/runtime/internal/vite/dev-worker.mjs");
+
+describe("vite dev worker", () => {
+  it("leaves responses untouched outside Bun", () => {
+    const response = new Response("ok", {
+      headers: { "content-length": "2" },
+    });
+
+    expect(normalizeBunResponse(response)).toBe(response);
+  });
+
+  it("drops explicit content length before Bun serves the response", async () => {
+    vi.stubGlobal("Bun", {});
+    try {
+      const response = normalizeBunResponse(
+        new Response("ok", {
+          headers: {
+            "content-length": "2",
+            "content-type": "text/plain",
+          },
+        })
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.headers.has("content-length")).toBe(false);
+      expect(response.headers.get("content-type")).toBe("text/plain");
+      expect(await response.text()).toBe("ok");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4182

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When Nitro dev runs inside Bun, the default `node-worker` runner still requires Node to be available. This selects the `bun-process` dev runner by default when Nitro itself is running under Bun, while preserving explicit `devServer.runner` and `NITRO_DEV_RUNNER` overrides.

The dev worker now also normalizes responses before Bun serves them by dropping explicit `content-length`, avoiding duplicate header parse errors when Bun sends the response. It waits briefly for Vite to register the environment before handling the first request, which avoids a first-request race in the Bun process runner.

Validation:

- `pnpm vitest run test/unit/vite-dev-worker.test.ts --reporter verbose`
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm build --stub`
- No-Node Bun smoke: `PATH=/tmp/nitro-no-node-bin:/usr/bin:/bin:/usr/sbin:/sbin bun run dev` in `examples/vite-nitro-plugin`, first request returned `HTTP/1.1 200 OK` and `Hello from virtual entry!`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. (Not applicable: runtime dev-server bug fix.)