### PR TITLE
docs: fix inline escaing

### DIFF
--- a/docs/1.docs/6.server-entry.md
+++ b/docs/1.docs/6.server-entry.md
@@ -45,7 +45,7 @@ export default defineHandler((event) => {
 ::
 
 ::tip
-When `server.ts` is detected, Nitro will log in the terminal: `Detected \`server.ts\` as server entry.`
+When `server.ts` is detected, Nitro will log in the terminal: ``Detected `server.ts` as server entry.``
 ::
 
 With this setup:


### PR DESCRIPTION
Couldn't build the docs locally so I figured I could test with a preview deploy