### PR TITLE
 feat(vite): use explicit module graph for service entries

### DIFF
--- a/src/build/plugins/virtual.ts
+++ b/src/build/plugins/virtual.ts
@@ -49,7 +49,7 @@ export function virtual(input: VirtualModule[]): Plugin {
       handler: async (id) => {
         const mod = modules.get(id);
         if (!mod) {
-          throw new Error(`Virtual module ${id} not found.`);
+          return null
         }
         return {
           code: await mod.render(),

--- a/src/build/plugins/virtual.ts
+++ b/src/build/plugins/virtual.ts
@@ -49,7 +49,7 @@ export function virtual(input: VirtualModule[]): Plugin {
       handler: async (id) => {
         const mod = modules.get(id);
         if (!mod) {
-          return null
+          return null;
         }
         return {
           code: await mod.render(),

--- a/src/build/virtual/renderer-template.ts
+++ b/src/build/virtual/renderer-template.ts
@@ -38,8 +38,8 @@ export default function rendererTemplate(nitro: Nitro) {
           return /* js */ `
             import { renderToResponse } from 'rendu'
             import { fetch, serverFetch } from 'nitro/app'
-            ${nitro.options.builder === 'vite' ? `import { fetchViteEnv } from "nitro/vite/runtime"` : ''}
-            const context = { fetch, serverFetch${nitro.options.builder === 'vite' ? ', fetchViteEnv' : ''} }
+            ${nitro.options.builder === "vite" ? `import { fetchViteEnv } from "nitro/vite/runtime"` : ""}
+            const context = { fetch, serverFetch${nitro.options.builder === "vite" ? ", fetchViteEnv" : ""} }
             const template = ${template};
             export const rendererTemplate = (request) => renderToResponse(template, { request, context })
             `;

--- a/src/build/virtual/renderer-template.ts
+++ b/src/build/virtual/renderer-template.ts
@@ -37,9 +37,11 @@ export default function rendererTemplate(nitro: Nitro) {
           });
           return /* js */ `
             import { renderToResponse } from 'rendu'
-            import { serverFetch } from 'nitro/app'
+            import { fetch, serverFetch } from 'nitro/app'
+            ${nitro.options.builder === 'vite' ? `import { fetchViteEnv } from "nitro/vite/runtime"` : ''}
+            const context = { fetch, serverFetch${nitro.options.builder === 'vite' ? ', fetchViteEnv' : ''} }
             const template = ${template};
-            export const rendererTemplate = (request) => renderToResponse(template, { request, context: { serverFetch } })
+            export const rendererTemplate = (request) => renderToResponse(template, { request, context })
             `;
         }
       }

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -188,49 +188,6 @@ async function _loadRunner(ctx: NitroPluginContext, manager: RunnerManager) {
   await manager.reload(runner);
 }
 
-// Service environments (e.g. SSR) must not bundle their own copy of `nitro/*`
-// runtime modules. In dev, imports are proxied to the Nitro environment via
-// __VITE_ENVIRONMENT_RUNNER_IMPORT__. In prod, they are externalized (see createServiceEnvironment).
-const NITRO_PROXY_PREFIX = "\0nitro-env-proxy:";
-
-export function nitroServiceProxy(): VitePlugin {
-  return {
-    name: "nitro:service-proxy",
-    enforce: "pre",
-    applyToEnvironment: (env) => env.name !== "nitro" && env.config.consumer === "server",
-    apply: (_config, configEnv) => configEnv.command === "serve",
-
-    resolveId: {
-      filter: { id: /^nitro(\/|$)/ },
-      handler(id) {
-        if (id === "nitro" || id.startsWith("nitro/")) {
-          return { id: NITRO_PROXY_PREFIX + id, moduleSideEffects: false };
-        }
-      },
-    },
-
-    load: {
-      filter: { id: /^\0nitro-env-proxy:/ },
-      handler(id) {
-        if (!id.startsWith(NITRO_PROXY_PREFIX)) {
-          return;
-        }
-        const originalId = id.slice(NITRO_PROXY_PREFIX.length);
-        // __vite_ssr_exportAll__ is provided by the module runner execution context.
-        // It re-exports all enumerable own properties (except "default") from the source module.
-        return {
-          code: [
-            `const _mod = await globalThis.__VITE_ENVIRONMENT_RUNNER_IMPORT__("nitro", ${JSON.stringify(originalId)});`,
-            `__vite_ssr_exportAll__(_mod);`,
-            `export default _mod.default;`,
-          ].join("\n"),
-          map: null,
-        };
-      },
-    },
-  };
-}
-
 // workerd-based runners (miniflare) cannot handle CJS externals via import(),
 // so all dependencies must be processed through Vite's transform pipeline.
 function _isWorkerdRunner(ctx: NitroPluginContext): boolean {

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -11,14 +11,13 @@ import type { NitroPluginConfig, NitroPluginContext } from "./types.ts";
 import { resolve, join } from "pathe";
 import { createNitro, prepare } from "../../builder.ts";
 import { getBundlerConfig } from "./bundler.ts";
-import { buildEnvironments, prodSetup } from "./prod.ts";
+import { buildEnvironments } from "./prod.ts";
 import {
   initEnvRunner,
   getEnvRunner,
   createNitroEnvironment,
   createServiceEnvironments,
   createServiceEnvironment,
-  nitroServiceProxy,
 } from "./env.ts";
 import { runtimeDir } from "nitro/meta";
 import { resolveModulePath } from "exsolve";
@@ -28,6 +27,7 @@ import { NitroDevApp } from "../../dev/app.ts";
 import { nitroPreviewPlugin } from "./preview.ts";
 import assetsPlugin from "@hiogawa/vite-plugin-fullstack/assets";
 import type { NitroConfig } from "nitro/types";
+import { nitroServiceEntries, nitroDevServiceProxy } from "./services.ts";
 
 // https://vite.dev/guide/api-environment-plugins
 // https://vite.dev/guide/api-environment-frameworks.html
@@ -49,8 +49,8 @@ export function nitro(pluginConfig: NitroPluginConfig = {}): VitePlugin[] {
     nitroEnv(ctx),
     nitroMain(ctx),
     nitroPrepare(ctx),
-    nitroService(ctx),
-    nitroServiceProxy(),
+    nitroServiceEntries(ctx),
+    nitroDevServiceProxy(),
     nitroPreviewPlugin(ctx),
     pluginConfig.experimental?.vite?.assetsImport !== false &&
       assetsPlugin({
@@ -309,35 +309,6 @@ function nitroPrepare(ctx: NitroPluginContext): VitePlugin {
   };
 }
 
-function nitroService(ctx: NitroPluginContext): VitePlugin {
-  return {
-    name: "nitro:service",
-    enforce: "pre",
-    sharedDuringBuild: true,
-    applyToEnvironment: (env) => env.name === "nitro",
-
-    resolveId: {
-      filter: { id: /^#nitro-vite-setup$/ },
-      async handler(id) {
-        // Virtual modules
-        if (id === "#nitro-vite-setup") {
-          return { id, moduleSideEffects: true };
-        }
-      },
-    },
-
-    load: {
-      filter: { id: /^#nitro-vite-setup$/ },
-      async handler(id) {
-        // Virtual modules
-        if (id === "#nitro-vite-setup") {
-          return prodSetup(ctx);
-        }
-      },
-    },
-  };
-}
-
 // --- internal helpers ---
 
 function createContext(pluginConfig: NitroPluginConfig): NitroPluginContext {
@@ -438,14 +409,6 @@ async function setupNitroContext(
     baseURL: "/",
     fallthrough: true,
   });
-
-  // Nitro Vite Production Runtime
-  if (!ctx.nitro.options.dev) {
-    ctx.nitro.options.unenv.push({
-      meta: { name: "nitro-vite" },
-      polyfill: ["#nitro-vite-setup"],
-    });
-  }
 
   // Call build:before hook **before resolving rollup config** for compatibility
   await ctx.nitro.hooks.callHook("build:before", ctx.nitro);

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -51,7 +51,7 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
       const html = await readFile(outputPath, "utf8").then((r) =>
         r.replace(
           "<!--ssr-outlet-->",
-          `{{{ globalThis.__nitro_vite_envs__?.["ssr"]?.fetch($REQUEST) || "" }}}`
+          `{{{ fetchViteEnv("ssr", $REQUEST) || "" }}}`
         )
       );
       await rm(outputPath);
@@ -126,44 +126,4 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
     const deployCommand = nitro.options.framework.deployCommand || "npx nitro deploy --prebuilt";
     nitro.logger.success(`You can deploy this build using \`${deployCommand}\``);
   }
-}
-
-export function prodSetup(ctx: NitroPluginContext): string {
-  const serviceNames = Object.keys(ctx.services);
-
-  const serviceEntries = serviceNames.map((name) => {
-    const entry = resolve(
-      ctx.nitro!.options.buildDir,
-      "vite/services",
-      name,
-      ctx._entryPoints[name]
-    );
-    return [name, entry];
-  });
-
-  return /* js */ `
-function lazyService(loader) {
-  let promise, mod
-  return {
-    fetch(req) {
-      if (mod) { return mod.fetch(req) }
-      if (!promise) {
-        promise = loader().then(_mod => (mod = _mod.default || _mod))
-      }
-      return promise.then(mod => mod.fetch(req))
-    }
-  }
-}
-
-const services = {
-${serviceEntries
-  .map(
-    ([name, entry]) =>
-      /* js */ `[${JSON.stringify(name)}]: lazyService(() => import(${JSON.stringify(entry)}))`
-  )
-  .join(",\n")}
-};
-
-globalThis.__nitro_vite_envs__ = services;
-  `;
 }

--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -49,10 +49,7 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
     const outputPath = resolve(nitroOptions.output.publicDir, basename(clientInput as string));
     if (existsSync(outputPath)) {
       const html = await readFile(outputPath, "utf8").then((r) =>
-        r.replace(
-          "<!--ssr-outlet-->",
-          `{{{ fetchViteEnv("ssr", $REQUEST) || "" }}}`
-        )
+        r.replace("<!--ssr-outlet-->", `{{{ fetchViteEnv("ssr", $REQUEST) || "" }}}`)
       );
       await rm(outputPath);
       const tmp = resolve(nitroOptions.buildDir, "vite/index.html");

--- a/src/build/vite/services.ts
+++ b/src/build/vite/services.ts
@@ -1,0 +1,121 @@
+import type { NitroPluginContext } from "./types.ts";
+import type { Plugin as VitePlugin } from "vite";
+import { resolve } from "pathe";
+
+export function nitroServiceEntries(ctx: NitroPluginContext): VitePlugin {
+  return {
+    name: "nitro:services",
+    enforce: "pre",
+    sharedDuringBuild: true,
+    applyToEnvironment: (env) => env.name === "nitro",
+    resolveId: {
+      filter: { id: /^#nitro\/virtual\/vite-services$/ },
+      async handler(id) {
+        if (id === "#nitro/virtual/vite-services") {
+          return { id };
+        }
+      },
+    },
+    load: {
+      filter: { id: /^#nitro\/virtual\/vite-services$/ },
+      async handler(id) {
+        if (id === "#nitro/virtual/vite-services") {
+          return viteServicesTemplate(ctx);
+        }
+      },
+    },
+  };
+}
+
+function viteServicesTemplate(ctx: NitroPluginContext): string {
+  const serviceNames = Object.keys(ctx.services);
+
+  if (ctx.nitro!.options.dev) {
+    return /* js */ `
+export const viteServices = {
+${serviceNames
+  .map(
+    (name) =>
+      `  get [${JSON.stringify(name)}]() { return globalThis.__nitro_vite_envs__[${JSON.stringify(name)}] }`
+  )
+  .join(",\n")}
+};
+  `;
+  }
+
+  const serviceEntries = serviceNames.map((name) => {
+    const entry = resolve(
+      ctx.nitro!.options.buildDir,
+      "vite/services",
+      name,
+      ctx._entryPoints[name]
+    );
+    return [name, entry];
+  });
+
+  return /* js */ `
+function lazyService(loader) {
+  let promise, mod
+  return {
+    fetch(req) {
+      if (mod) { return mod.fetch(req) }
+      if (!promise) {
+        promise = loader().then(_mod => (mod = _mod.default || _mod))
+      }
+      return promise.then(mod => mod.fetch(req))
+    }
+  }
+}
+
+export const viteServices = {
+${serviceEntries
+  .map(
+    ([name, entry]) =>
+      `[${JSON.stringify(name)}]: lazyService(() => import(${JSON.stringify(entry)}))`
+  )
+  .join(",\n")}
+};
+  `;
+}
+
+// Service environments (e.g. SSR) must not bundle their own copy of `nitro/*`
+// runtime modules. In dev, imports are proxied to the Nitro environment via
+// __VITE_ENVIRONMENT_RUNNER_IMPORT__. In prod, they are externalized (see createServiceEnvironment).
+const NITRO_PROXY_PREFIX = "\0nitro-env-proxy:";
+export function nitroDevServiceProxy(): VitePlugin {
+  return {
+    name: "nitro:dev-service-proxy",
+    enforce: "pre",
+    applyToEnvironment: (env) => env.name !== "nitro" && env.config.consumer === "server",
+    apply: (_config, configEnv) => configEnv.command === "serve",
+
+    resolveId: {
+      filter: { id: /^nitro(\/|$)/ },
+      handler(id) {
+        if (id === "nitro" || id.startsWith("nitro/")) {
+          return { id: NITRO_PROXY_PREFIX + id, moduleSideEffects: false };
+        }
+      },
+    },
+
+    load: {
+      filter: { id: /^\0nitro-env-proxy:/ },
+      handler(id) {
+        if (!id.startsWith(NITRO_PROXY_PREFIX)) {
+          return;
+        }
+        const originalId = id.slice(NITRO_PROXY_PREFIX.length);
+        // __vite_ssr_exportAll__ is provided by the module runner execution context.
+        // It re-exports all enumerable own properties (except "default") from the source module.
+        return {
+          code: [
+            `const _mod = await globalThis.__VITE_ENVIRONMENT_RUNNER_IMPORT__("nitro", ${JSON.stringify(originalId)});`,
+            `__vite_ssr_exportAll__(_mod);`,
+            `export default _mod.default;`,
+          ].join("\n"),
+          map: null,
+        };
+      },
+    },
+  };
+}

--- a/src/runtime/virtual/vite-services.ts
+++ b/src/runtime/virtual/vite-services.ts
@@ -1,0 +1,5 @@
+import "./_runtime_warn.ts";
+
+export type ViteService = { fetch: (req: Request) => Response | Promise<Response> };
+
+export declare const viteServices: Record<string, ViteService>;

--- a/src/runtime/vite.ts
+++ b/src/runtime/vite.ts
@@ -1,20 +1,12 @@
 import { HTTPError, toRequest } from "h3";
-
-type FetchableEnv = {
-  fetch: (request: Request) => Response | Promise<Response>;
-};
-
-declare global {
-  var __nitro_vite_envs__: Record<string, FetchableEnv>;
-}
+import { viteServices } from "#nitro/virtual/vite-services";
 
 export function fetchViteEnv(
   viteEnvName: string,
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
-  const envs = globalThis.__nitro_vite_envs__ || {};
-  const viteEnv = envs[viteEnvName as keyof typeof envs] as FetchableEnv;
+  const viteEnv = viteServices[viteEnvName];
   if (!viteEnv) {
     throw HTTPError.status(404);
   }


### PR DESCRIPTION
This PR updates nitro/vite (prod) to use explicit vfs module import to access other vite envs rather than relying on global