### PR TITLE
fix(build): add `buildDir` to `noExternals` if inside `node_modules`

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -72,10 +72,7 @@ function getNoExternals(nitro: Nitro): RegExp[] {
     new RegExp("^" + pathRegExp(pkgDir) + "(?!.*node_modules)"),
     ...[
       nitro.options.rootDir,
-      ...[
-        nitro.options.buildDir,
-        ...nitro.options.scanDirs
-      ].filter(
+      ...[nitro.options.buildDir, ...nitro.options.scanDirs].filter(
         (dir) => dir.includes("node_modules") || !dir.startsWith(nitro.options.rootDir)
       ),
     ].map((dir) => new RegExp("^" + pathRegExp(dir) + "(?!.*node_modules)")),

--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -72,7 +72,10 @@ function getNoExternals(nitro: Nitro): RegExp[] {
     new RegExp("^" + pathRegExp(pkgDir) + "(?!.*node_modules)"),
     ...[
       nitro.options.rootDir,
-      ...nitro.options.scanDirs.filter(
+      ...[
+        nitro.options.buildDir,
+        ...nitro.options.scanDirs
+      ].filter(
         (dir) => dir.includes("node_modules") || !dir.startsWith(nitro.options.rootDir)
       ),
     ].map((dir) => new RegExp("^" + pathRegExp(dir) + "(?!.*node_modules)")),


### PR DESCRIPTION
If buildDir is inside node_modules (default is `node_modules/.nitro`) it should be explicitly included in noExternal of baseConfig to avoid being externalized. This fixes issue with prerender bundle having buildDir as externals (since default assumes `node_modules/.nitro` is a pkg!)