### PR TITLE
fix(types): emit auto-import paths as files, not directories

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -77,7 +77,10 @@ export async function writeTypes(nitro: Nitro) {
             path = resolvedPath;
           } else {
             const subpath = await lookupNodeModuleSubpath(resolvedPath);
-            path = join(dir, name, subpath || "");
+            path =
+              subpath && subpath !== "./"
+                ? join(dir, name, subpath)
+                : resolvedPath;
           }
         }
       }

--- a/test/unit/types-imports.test.ts
+++ b/test/unit/types-imports.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import { describe, expect, it } from "vitest";
+import { createNitro, writeTypes } from "nitropack";
+
+describe("writeTypes auto-import resolution", () => {
+  const fixtureDir = mkdtempSync(join(tmpdir(), "nitro-types-"));
+
+  it("emits a file path (not a package directory) for packages whose exports map only `.`", async () => {
+    const pkgDir = join(fixtureDir, "node_modules", "exports-only-pkg");
+    mkdirSync(join(pkgDir, "dist"), { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "exports-only-pkg",
+        type: "module",
+        exports: {
+          ".": {
+            types: "./dist/index.d.ts",
+            import: "./dist/index.js",
+          },
+        },
+      })
+    );
+    writeFileSync(
+      join(pkgDir, "dist", "index.js"),
+      "export function useExportsOnly() { return true }\n"
+    );
+    writeFileSync(
+      join(pkgDir, "dist", "index.d.ts"),
+      "export declare function useExportsOnly(): boolean\n"
+    );
+
+    mkdirSync(join(fixtureDir, "server"), { recursive: true });
+    writeFileSync(
+      join(fixtureDir, "server", "package.json"),
+      '{ "type": "module" }\n'
+    );
+
+    const nitro = await createNitro({
+      rootDir: fixtureDir,
+      imports: {
+        presets: [
+          {
+            from: "exports-only-pkg",
+            imports: ["useExportsOnly"],
+          },
+        ],
+      },
+    });
+
+    await writeTypes(nitro);
+
+    const generated = readFileSync(
+      join(fixtureDir, ".nitro", "types", "nitro-imports.d.ts"),
+      "utf8"
+    );
+
+    const match = generated.match(
+      /typeof import\('([^']*exports-only-pkg[^']*)'\)/
+    );
+    expect(
+      match,
+      `expected import() referencing exports-only-pkg in:\n${generated}`
+    ).toBeTruthy();
+    const specifier = match![1]!;
+    expect(
+      specifier.endsWith("exports-only-pkg"),
+      `specifier should not end at the package directory, got ${specifier}`
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

remake of https://github.com/nitrojs/nitro/pull/4333 for v2

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

duplicate description for posterity:

`writeTypes` emits `const foo: typeof import('<path>').foo` per auto-imported binding

for some packages, the path ends up being the package directory rather than a file; this works fine for TypeScript with `moduleResolution: bundler`, but Deno's TS host doesn't apply Node directory resolution to relative specifiers and bails

this PR treats `./` the same as an empty subpath & falls back to resolvedPath, which ends up having its extension stripped

both typescript + deno should resolve this equally well.

note: packages with different `exports.types` vs `exports.imports` (eg #2384) won't work correctly, either before or after this fix (but the error slightly changes 😆)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
