### PR TITLE
build: point root types to published declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "skills"
   ],
   "type": "module",
-  "types": "./lib/index.d.mts",
+  "types": "./dist/runtime/nitro.d.mts",
   "imports": {
     "#nitro/runtime/*": "./dist/runtime/internal/*.mjs",
     "#nitro/virtual/*": "./dist/runtime/virtual/*.mjs"


### PR DESCRIPTION
## Summary

- point the root `types` field at the declaration generated beside the root runtime export
- restore TypeScript resolution for consumers using legacy `moduleResolution: "node"`

Fixes #4346.

## Validation

- `pnpm typecheck`
- `git diff --check`
- confirmed `dist/runtime/nitro.d.mts` is generated and included by the package `files` list
- reproduced the published-package failure before the change with `nitro@3.0.260610-beta`: TypeScript follows `./lib/index.d.mts`, which is absent from the tarball

`pnpm build` generated the runtime declarations but did not complete on local Node.js 22.13.1 because `node ./scripts/gen-presets.ts` does not support direct `.ts` execution on that Node version.