### PR TITLE
fix(build,azure-swa): prefer index.mjs serverEntry; fix Azure SWA request URL and body

### DIFF
--- a/src/build/info.ts
+++ b/src/build/info.ts
@@ -1,5 +1,5 @@
 import type { Nitro, NitroBuildInfo, WorkerAddress } from "nitro/types";
-import { join, relative, resolve } from "pathe";
+import { extname, join, relative, resolve } from "pathe";
 import { version as nitroVersion } from "nitro/meta";
 import { presetsWithConfig } from "../presets/_types.gen.ts";
 import { writeFile } from "../utils/fs.ts";
@@ -44,32 +44,11 @@ export async function findLastBuildDir(root: string): Promise<string> {
   return outputDir;
 }
 
-type OutputChunk = { type: "chunk"; isEntry?: boolean; fileName: string };
-
-/**
- * Prefer `server/index.mjs` when multiple entry chunks exist.
- * Vite Module Federation marks expose chunks as entries too; without this,
- * `nitro.json` can point at an expose chunk instead of the server bundle.
- */
-export function resolveNitroServerEntryFileName(
-  output: RolldownOutput | RollupOutput | undefined
-): string | undefined {
-  const entries =
-    output?.output?.filter(
-      (o): o is OutputChunk => o.type === "chunk" && !!(o as OutputChunk).isEntry
-    ) ?? [];
-
-  if (entries.length === 0) return undefined;
-  if (entries.length === 1) return entries[0].fileName;
-
-  return (entries.find((c) => /(^|\/)index\.mjs$/.test(c.fileName)) ?? entries[0]).fileName;
-}
-
 export async function writeBuildInfo(
   nitro: Nitro,
   output: RolldownOutput | RollupOutput | undefined
 ): Promise<NitroBuildInfo> {
-  const serverEntryName = resolveNitroServerEntryFileName(output);
+  const serverEntryName = resolveNitroServerEntryFileName(output, nitro.options.entry);
 
   const buildInfoPath = resolve(nitro.options.output.dir, "nitro.json");
   const buildInfo: NitroBuildInfo = {
@@ -123,4 +102,27 @@ export async function writeDevBuildInfo(nitro: Nitro, addr?: WorkerAddress): Pro
     },
   };
   await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2));
+}
+
+function resolveNitroServerEntryFileName(
+  output: RolldownOutput | RollupOutput | undefined,
+  nitroEntry: string
+): string | undefined {
+  return (
+    output?.output.find(
+      (entry) =>
+        entry.type === "chunk" && entry.isEntry && isNitroEntry(entry.facadeModuleId, nitroEntry)
+    ) ??
+    output?.output.find(
+      (entry) => entry.type === "chunk" && entry.isEntry && entry.fileName === "index.mjs"
+    ) ??
+    output?.output.find((entry) => entry.type === "chunk" && entry.isEntry)
+  )?.fileName;
+}
+
+function isNitroEntry(facadeModuleId: string | null, nitroEntry: string): boolean {
+  if (!facadeModuleId) return false;
+  if (facadeModuleId === nitroEntry) return true;
+  const extension = extname(facadeModuleId);
+  return !!extension && facadeModuleId.slice(0, -extension.length) === nitroEntry;
 }

--- a/src/build/info.ts
+++ b/src/build/info.ts
@@ -44,11 +44,32 @@ export async function findLastBuildDir(root: string): Promise<string> {
   return outputDir;
 }
 
+type OutputChunk = { type: "chunk"; isEntry?: boolean; fileName: string };
+
+/**
+ * Prefer `server/index.mjs` when multiple entry chunks exist.
+ * Vite Module Federation marks expose chunks as entries too; without this,
+ * `nitro.json` can point at an expose chunk instead of the server bundle.
+ */
+export function resolveNitroServerEntryFileName(
+  output: RolldownOutput | RollupOutput | undefined
+): string | undefined {
+  const entries =
+    output?.output?.filter(
+      (o): o is OutputChunk => o.type === "chunk" && !!(o as OutputChunk).isEntry
+    ) ?? [];
+
+  if (entries.length === 0) return undefined;
+  if (entries.length === 1) return entries[0].fileName;
+
+  return (entries.find((c) => /(^|\/)index\.mjs$/.test(c.fileName)) ?? entries[0]).fileName;
+}
+
 export async function writeBuildInfo(
   nitro: Nitro,
   output: RolldownOutput | RollupOutput | undefined
 ): Promise<NitroBuildInfo> {
-  const serverEntryName = output?.output?.find((o) => o.type === "chunk" && o.isEntry)?.fileName;
+  const serverEntryName = resolveNitroServerEntryFileName(output);
 
   const buildInfoPath = resolve(nitro.options.output.dir, "nitro.json");
   const buildInfo: NitroBuildInfo = {

--- a/src/presets/azure/runtime/_utils.ts
+++ b/src/presets/azure/runtime/_utils.ts
@@ -66,5 +66,5 @@ export async function azureResponseBody(response: Response): Promise<string | Bu
 }
 
 function isTextType(contentType = "") {
-  return /^text\/|\/(javascript|json|xml)|utf-?8/i.test(contentType);
+  return /^text\/|\/(javascript|json|xml)|\+(json|xml)|utf-?8/i.test(contentType);
 }

--- a/src/presets/azure/runtime/_utils.ts
+++ b/src/presets/azure/runtime/_utils.ts
@@ -54,3 +54,17 @@ function parseNumber(maxAge: string) {
     return maxAgeAsNumber;
   }
 }
+
+// Azure Functions v3 expects string | Buffer, not a ReadableStream.
+export async function azureResponseBody(response: Response): Promise<string | Buffer | undefined> {
+  if (!response.body) {
+    return undefined;
+  }
+  const buffer = Buffer.from(await new Response(response.body).arrayBuffer());
+  const contentType = response.headers.get("content-type") || "";
+  return isTextType(contentType) ? buffer.toString("utf8") : buffer;
+}
+
+function isTextType(contentType = "") {
+  return /^text\/|\/(javascript|json|xml)|utf-?8/i.test(contentType);
+}

--- a/src/presets/azure/runtime/azure-swa.ts
+++ b/src/presets/azure/runtime/azure-swa.ts
@@ -1,5 +1,4 @@
 import "#nitro/virtual/polyfills";
-import { parseURL } from "ufo";
 import { useNitroApp } from "nitro/app";
 import { getAzureParsedCookiesFromHeaders } from "./_utils.ts";
 
@@ -7,19 +6,17 @@ import type { HttpRequest, HttpResponse, HttpResponseSimple } from "@azure/funct
 
 const nitroApp = useNitroApp();
 
-export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
-  let url: string;
+/** `new Request()` requires an absolute URL; Azure SWA only provides relative paths. */
+export function resolveAzureSwaRequestUrl(req: HttpRequest): string {
   if (req.headers["x-ms-original-url"]) {
-    // This URL has been proxied as there was no static file matching it.
-    const parsedURL = parseURL(req.headers["x-ms-original-url"]);
-    url = parsedURL.pathname + parsedURL.search;
-  } else {
-    // Because Azure SWA handles /api/* calls differently they
-    // never hit the proxy and we have to reconstitute the URL.
-    url = "/api/" + (req.params.url || "");
+    return req.headers["x-ms-original-url"];
   }
+  // /api/* calls never hit the SWA proxy, so we reconstitute the URL.
+  return new URL("/api/" + (req.params.url || ""), "http://nitro.local").href;
+}
 
-  const request = new Request(url, {
+export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
+  const request = new Request(resolveAzureSwaRequestUrl(req), {
     method: req.method || undefined,
     // https://github.com/Azure/azure-functions-nodejs-worker/issues/294
     // https://github.com/Azure/azure-functions-host/issues/293
@@ -27,12 +24,14 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   });
 
   const response = await nitroApp.fetch(request);
+  // Azure Functions v3 expects string | Buffer, not a ReadableStream.
+  const body = response.body ? await new Response(response.body).text() : undefined;
 
   // (v3 - current) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v3#http-response
   // (v4) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status: response.status,
-    body: response.body,
+    body,
     cookies: getAzureParsedCookiesFromHeaders(response.headers),
     headers: Object.fromEntries(
       [...response.headers.entries()].filter(([key]) => key !== "set-cookie")

--- a/src/presets/azure/runtime/azure-swa.ts
+++ b/src/presets/azure/runtime/azure-swa.ts
@@ -1,6 +1,6 @@
 import "#nitro/virtual/polyfills";
 import { useNitroApp } from "nitro/app";
-import { getAzureParsedCookiesFromHeaders } from "./_utils.ts";
+import { azureResponseBody, getAzureParsedCookiesFromHeaders } from "./_utils.ts";
 
 import type { HttpRequest, HttpResponse, HttpResponseSimple } from "@azure/functions";
 
@@ -24,8 +24,7 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   });
 
   const response = await nitroApp.fetch(request);
-  // Azure Functions v3 expects string | Buffer, not a ReadableStream.
-  const body = response.body ? await new Response(response.body).text() : undefined;
+  const body = await azureResponseBody(response);
 
   // (v3 - current) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v3#http-response
   // (v4) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response

--- a/test/unit/azure-swa.test.ts
+++ b/test/unit/azure-swa.test.ts
@@ -48,6 +48,13 @@ describe("azureResponseBody", () => {
     await expect(azureResponseBody(response)).resolves.toBe("hello");
   });
 
+  it("returns text for structured +json content types", async () => {
+    const response = new Response('{"title":"Bad Request"}', {
+      headers: { "content-type": "application/problem+json; charset=utf-8" },
+    });
+    await expect(azureResponseBody(response)).resolves.toBe('{"title":"Bad Request"}');
+  });
+
   it("returns a Buffer for binary content types", async () => {
     const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     const response = new Response(bytes, {

--- a/test/unit/azure-swa.test.ts
+++ b/test/unit/azure-swa.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#nitro/virtual/polyfills", () => ({}));
+vi.mock("nitro/app", () => ({ useNitroApp: () => ({}) }));
+
+import { resolveAzureSwaRequestUrl } from "../../src/presets/azure/runtime/azure-swa.ts";
+
+describe("resolveAzureSwaRequestUrl", () => {
+  it("uses x-ms-original-url as-is when present", () => {
+    expect(
+      resolveAzureSwaRequestUrl({
+        headers: { "x-ms-original-url": "https://example.com/foo?bar=1" },
+        params: {},
+      } as Parameters<typeof resolveAzureSwaRequestUrl>[0])
+    ).toBe("https://example.com/foo?bar=1");
+  });
+
+  it("builds an absolute URL for direct /api/* invocations", () => {
+    expect(
+      resolveAzureSwaRequestUrl({
+        headers: {},
+        params: { url: "hello" },
+      } as Parameters<typeof resolveAzureSwaRequestUrl>[0])
+    ).toBe("http://nitro.local/api/hello");
+  });
+
+  it("handles empty params.url", () => {
+    expect(
+      resolveAzureSwaRequestUrl({
+        headers: {},
+        params: {},
+      } as Parameters<typeof resolveAzureSwaRequestUrl>[0])
+    ).toBe("http://nitro.local/api/");
+  });
+});

--- a/test/unit/azure-swa.test.ts
+++ b/test/unit/azure-swa.test.ts
@@ -4,6 +4,7 @@ vi.mock("#nitro/virtual/polyfills", () => ({}));
 vi.mock("nitro/app", () => ({ useNitroApp: () => ({}) }));
 
 import { resolveAzureSwaRequestUrl } from "../../src/presets/azure/runtime/azure-swa.ts";
+import { azureResponseBody } from "../../src/presets/azure/runtime/_utils.ts";
 
 describe("resolveAzureSwaRequestUrl", () => {
   it("uses x-ms-original-url as-is when present", () => {
@@ -31,5 +32,29 @@ describe("resolveAzureSwaRequestUrl", () => {
         params: {},
       } as Parameters<typeof resolveAzureSwaRequestUrl>[0])
     ).toBe("http://nitro.local/api/");
+  });
+});
+
+describe("azureResponseBody", () => {
+  it("returns undefined when response has no body", async () => {
+    const response = new Response(null, { status: 204 });
+    await expect(azureResponseBody(response)).resolves.toBeUndefined();
+  });
+
+  it("returns text for text content types", async () => {
+    const response = new Response("hello", {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+    await expect(azureResponseBody(response)).resolves.toBe("hello");
+  });
+
+  it("returns a Buffer for binary content types", async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const response = new Response(bytes, {
+      headers: { "content-type": "image/png" },
+    });
+    const body = await azureResponseBody(response);
+    expect(body).toBeInstanceOf(Buffer);
+    expect(body).toEqual(Buffer.from(bytes));
   });
 });

--- a/test/unit/azure-swa.test.ts
+++ b/test/unit/azure-swa.test.ts
@@ -12,7 +12,7 @@ describe("resolveAzureSwaRequestUrl", () => {
       resolveAzureSwaRequestUrl({
         headers: { "x-ms-original-url": "https://example.com/foo?bar=1" },
         params: {},
-      } as Parameters<typeof resolveAzureSwaRequestUrl>[0])
+      } as unknown as Parameters<typeof resolveAzureSwaRequestUrl>[0])
     ).toBe("https://example.com/foo?bar=1");
   });
 
@@ -21,7 +21,7 @@ describe("resolveAzureSwaRequestUrl", () => {
       resolveAzureSwaRequestUrl({
         headers: {},
         params: { url: "hello" },
-      } as Parameters<typeof resolveAzureSwaRequestUrl>[0])
+      } as unknown as Parameters<typeof resolveAzureSwaRequestUrl>[0])
     ).toBe("http://nitro.local/api/hello");
   });
 

--- a/test/unit/build-info.test.ts
+++ b/test/unit/build-info.test.ts
@@ -1,53 +1,92 @@
-import { describe, expect, it, vi } from "vitest";
+import type { Nitro } from "nitro/types";
+import type { RollupOutput } from "rollup";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("nitro/meta", () => ({ version: "0.0.0" }));
 vi.mock("nitro/types", () => ({}));
+vi.mock("node:fs/promises", () => ({ mkdir: vi.fn(), readFile: vi.fn(), stat: vi.fn() }));
+vi.mock("../../src/utils/fs.ts", () => ({ writeFile: vi.fn() }));
 
-import { resolveNitroServerEntryFileName } from "../../src/build/info.ts";
+import { writeBuildInfo } from "../../src/build/info.ts";
+import { writeFile } from "../../src/utils/fs.ts";
 
-describe("resolveNitroServerEntryFileName", () => {
-  it("returns undefined when there are no entry chunks", () => {
-    expect(resolveNitroServerEntryFileName({ output: [] })).toBeUndefined();
+describe("writeBuildInfo", () => {
+  afterEach(() => {
+    vi.mocked(writeFile).mockClear();
   });
 
-  it("returns the only entry chunk", () => {
-    expect(
-      resolveNitroServerEntryFileName({
-        output: [{ type: "chunk", isEntry: true, fileName: "server/index.mjs" }],
-      })
-    ).toBe("server/index.mjs");
-  });
-
-  it("prefers index.mjs when Module Federation adds extra entry chunks", () => {
-    expect(
-      resolveNitroServerEntryFileName({
+  it("records Nitro's entry when a plugin entry appears first", async () => {
+    const buildInfo = await writeBuildInfo(
+      {
+        options: {
+          rootDir: "/project",
+          entry: "/project/server",
+          output: {
+            dir: "/project/.output",
+            serverDir: "/project/.output/server",
+            publicDir: "/project/.output/public",
+          },
+          commands: {},
+        },
+      } as Nitro,
+      {
         output: [
-          { type: "chunk", isEntry: true, fileName: "App.expose.mjs" },
-          { type: "chunk", isEntry: true, fileName: "server/index.mjs" },
+          {
+            type: "chunk",
+            isEntry: true,
+            fileName: "plugin-entry.mjs",
+            facadeModuleId: "/plugin/entry.ts",
+          },
+          {
+            type: "chunk",
+            isEntry: true,
+            fileName: "index.mjs",
+            facadeModuleId: "/project/server.ts",
+          },
         ],
-      })
-    ).toBe("server/index.mjs");
+      } as unknown as RollupOutput
+    );
+
+    expect(buildInfo.serverEntry).toBe("server/index.mjs");
+    expect(writeFile).toHaveBeenCalledWith(
+      "/project/.output/nitro.json",
+      expect.stringContaining('"serverEntry": "server/index.mjs"'),
+      true
+    );
   });
 
-  it("falls back to first entry when no index.mjs is present", () => {
-    expect(
-      resolveNitroServerEntryFileName({
+  it("records Nitro's entry when a preset uses a non-default file name", async () => {
+    const buildInfo = await writeBuildInfo(
+      {
+        options: {
+          rootDir: "/project",
+          entry: "/project/server",
+          output: {
+            dir: "/project/.output",
+            serverDir: "/project/.output/server",
+            publicDir: "/project/.output/public",
+          },
+          commands: {},
+        },
+      } as Nitro,
+      {
         output: [
-          { type: "chunk", isEntry: true, fileName: "App.expose.mjs" },
-          { type: "chunk", isEntry: true, fileName: "Other.expose.mjs" },
+          {
+            type: "chunk",
+            isEntry: true,
+            fileName: "plugin-entry.mjs",
+            facadeModuleId: "/plugin/entry.ts",
+          },
+          {
+            type: "chunk",
+            isEntry: true,
+            fileName: "worker.mjs",
+            facadeModuleId: "/project/server.ts",
+          },
         ],
-      })
-    ).toBe("App.expose.mjs");
-  });
+      } as unknown as RollupOutput
+    );
 
-  it("ignores non-entry chunks", () => {
-    expect(
-      resolveNitroServerEntryFileName({
-        output: [
-          { type: "chunk", isEntry: false, fileName: "shared.mjs" },
-          { type: "chunk", isEntry: true, fileName: "server/index.mjs" },
-        ],
-      })
-    ).toBe("server/index.mjs");
+    expect(buildInfo.serverEntry).toBe("server/worker.mjs");
   });
 });

--- a/test/unit/build-info.test.ts
+++ b/test/unit/build-info.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("nitro/meta", () => ({ version: "0.0.0" }));
+vi.mock("nitro/types", () => ({}));
+
+import { resolveNitroServerEntryFileName } from "../../src/build/info.ts";
+
+describe("resolveNitroServerEntryFileName", () => {
+  it("returns undefined when there are no entry chunks", () => {
+    expect(resolveNitroServerEntryFileName({ output: [] })).toBeUndefined();
+  });
+
+  it("returns the only entry chunk", () => {
+    expect(
+      resolveNitroServerEntryFileName({
+        output: [{ type: "chunk", isEntry: true, fileName: "server/index.mjs" }],
+      })
+    ).toBe("server/index.mjs");
+  });
+
+  it("prefers index.mjs when Module Federation adds extra entry chunks", () => {
+    expect(
+      resolveNitroServerEntryFileName({
+        output: [
+          { type: "chunk", isEntry: true, fileName: "App.expose.mjs" },
+          { type: "chunk", isEntry: true, fileName: "server/index.mjs" },
+        ],
+      })
+    ).toBe("server/index.mjs");
+  });
+
+  it("falls back to first entry when no index.mjs is present", () => {
+    expect(
+      resolveNitroServerEntryFileName({
+        output: [
+          { type: "chunk", isEntry: true, fileName: "App.expose.mjs" },
+          { type: "chunk", isEntry: true, fileName: "Other.expose.mjs" },
+        ],
+      })
+    ).toBe("App.expose.mjs");
+  });
+
+  it("ignores non-entry chunks", () => {
+    expect(
+      resolveNitroServerEntryFileName({
+        output: [
+          { type: "chunk", isEntry: false, fileName: "shared.mjs" },
+          { type: "chunk", isEntry: true, fileName: "server/index.mjs" },
+        ],
+      })
+    ).toBe("server/index.mjs");
+  });
+});


### PR DESCRIPTION
## Problem

Three bugs that compound when deploying a Nitro fullstack app with Vite Module Federation `exposes` (and when using the Azure Static Web Apps preset).

### Reproduction demo

**Demo repo:** https://github.com/tonoizer/demo-nitro-vite-module-federation-serverEntry-bug

Minimal repro for the `serverEntry` / `vite preview` issue:

```bash
pnpm dlx create-nitro-app my-app
cd my-app
pnpm add -D @module-federation/vite
# add federation plugin + expose (see demo repo vite.config.ts / module-federation.config.ts)
pnpm build
pnpm check          # fails: serverEntry is server/_chunks/app.mjs
pnpm preview        # broken: 404 on / and /api/*
pnpm preview:workaround   # works: node .output/server/index.mjs
```

`pnpm dev` works — only production preview is broken because it relies on `.output/nitro.json`.

---

**1. Wrong `serverEntry` in `nitro.json`**

`writeBuildInfo` used `.find()` to pick the first `isEntry` chunk from Rollup output. Vite Module Federation marks expose chunks as entry points too, so when they appear before `server/index.mjs` in the output array, `nitro.json` points at e.g. `server/_chunks/app.mjs` instead of the server bundle. `vite preview` then loads a file with no `fetch` handler → 404 everywhere.

**2. Azure SWA: relative URL passed to `new Request()`**

`azure-swa.ts` constructed a relative path (`/api/...` or `pathname + search`) and passed it directly to `new Request(url, ...)`. Node.js requires an absolute URL — this throws in production and breaks all `/api/*` routes.

**3. Azure SWA: response body handling**

`context.res.body` was set incorrectly for Azure Functions v3 (which expects `string | Buffer`). Text responses could be empty/wrong; binary responses were corrupted when unconditionally calling `.text()`.

## Fix

- **`resolveNitroServerEntryFileName`** — when multiple `isEntry` chunks exist, prefer the one matching `/(^|\/)index\.mjs$/` (Nitro's server entry convention) instead of taking array-first.
- **`resolveAzureSwaRequestUrl`** — use `x-ms-original-url` as-is (it's already an absolute URL) or construct `new URL(path, "http://nitro.local").href` for direct `/api/*` calls.
- **`azureResponseBody`** — inspect `content-type` and return UTF-8 string for text types or `Buffer` for binary (same pattern as AWS Lambda preset).
- Unit tests for extracted helpers.

## Test plan

- [x] `pnpm vitest run test/unit/build-info.test.ts test/unit/azure-swa.test.ts`
- [ ] Demo repo: `pnpm build && pnpm check` passes; `pnpm preview` serves SPA + `/api/hello`
- [ ] Azure SWA preset: `/api/*` routes return real JSON/HTML; binary routes return correct bytes