### PR TITLE
docs: fix misleading middleware example path in routing docs (#4354)

### DIFF
--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -271,12 +271,15 @@ export default defineConfig({
   handlers: [
     {
       route: "/api/**",
-      handler: "./server/middleware/api-auth.ts",
+      handler: "./server/utils/api-auth.ts",
       middleware: true,
     },
   ],
 });
 ```
+
+> [!WARNING]
+> When using `handlers` for route-scoped middleware, place handler files outside the `server/middleware/` directory. Files in `server/middleware/` run globally for all requests regardless of the `route` pattern.
 
 Each handler entry supports the following options:
 
@@ -408,7 +411,7 @@ export default defineConfig({
   handlers: [
     {
       route: "/api/**",
-      handler: "./server/middleware/api-auth.ts",
+      handler: "./server/utils/api-auth.ts",
       middleware: true,
     },
   ],


### PR DESCRIPTION
Fixes #4354

Changed the route-scoped middleware example to use `./server/utils/api-auth.ts` instead of `./server/middleware/api-auth.ts` to avoid confusion with global middleware behavior.

Also added a warning note clarifying that files in `server/middleware/` run globally regardless of the `route` pattern.