### PR TITLE
fix: remove stale types field pointing to missing lib/index.d.mts (#4346)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "skills"
   ],
   "type": "module",
-  "types": "./lib/index.d.mts",
   "imports": {
     "#nitro/runtime/*": "./dist/runtime/internal/*.mjs",
     "#nitro/virtual/*": "./dist/runtime/virtual/*.mjs"


### PR DESCRIPTION
Fixes #4346

### Problem

The root `types` field points to `./lib/index.d.mts`, but this file
does not exist in the published tarball. Modern TypeScript resolution
works because exports subpath entries include type declarations, but
Node10-style resolution is broken by this stale field.

TypeScript error when using the package:
```
Cannot find module 'nitro' or its corresponding type declarations.
```

### Solution

Remove the root `types` field from package.json. Modern TypeScript
resolution via the `exports` field already provides proper type
declarations for all entry points, and removing the stale field fixes
Node10-style resolution without breaking modern tooling.

### Changed

- package.json: Remove the root `types` field

### Verification

- Exports subpath entries have type declarations (e.g., `./dist/runtime/nitro.mjs` has `./dist/runtime/nitro.d.mts`)
- Modern TypeScript resolution continues to work via `exports` field
- Node10-style resolution no longer references non-existent file