### PR TITLE
fix(hmr): add hmr tests when reload hangs

### DIFF
--- a/test/dev/dev-reload-race.test.ts
+++ b/test/dev/dev-reload-race.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import { isWindows } from "std-env";
+import { describe, expect, it } from "vitest";
+import { type Context, describeIf, setupTest } from "../tests";
+
+const HANG_TIMEOUT_MS = 10_000;
+const REQUEST_ASSIGN_DELAY_MS = 100;
+
+async function waitForDevWorker(
+  context: Context,
+  timeoutMilliseconds = 30_000
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMilliseconds) {
+    try {
+      await context.fetch("/api/hello");
+      return;
+    } catch {
+      // Retry until the dev worker is ready.
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 200));
+  }
+  throw new Error("Dev worker not ready");
+}
+
+async function parseFetchBody<T>(response: T): Promise<unknown> {
+  if (response instanceof Response) {
+    return response.json();
+  }
+  return response;
+}
+
+async function assertRequestCompletes<T>(
+  requestPromise: Promise<T>,
+  timeoutMilliseconds = HANG_TIMEOUT_MS
+) {
+  return Promise.race([
+    requestPromise,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("Request hung during dev reload")),
+        timeoutMilliseconds
+      )
+    ),
+  ]);
+}
+
+async function waitForDevStart(context: Context) {
+  await new Promise<void>((resolvePromise) => {
+    context.nitro!.hooks.hookOnce("dev:start", () => resolvePromise());
+  });
+}
+
+async function waitForDevReload(context: Context) {
+  await new Promise<void>((resolvePromise) => {
+    context.nitro!.hooks.hookOnce("dev:reload", () => resolvePromise());
+  });
+}
+
+function createTempFixtureRoot() {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "nitro-dev-reload-race-"));
+  mkdirSync(join(fixtureRoot, "api"), { recursive: true });
+
+  writeFileSync(
+    join(fixtureRoot, "api", "hello.ts"),
+    `export default eventHandler(() => ({ message: "initial" }));\n`
+  );
+  writeFileSync(
+    join(fixtureRoot, "api", "dev-reload-slow.ts"),
+    `export default eventHandler(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 3_000));
+  return { ok: true };
+});\n`
+  );
+
+  return fixtureRoot;
+}
+
+describe("dev server reload race", { timeout: 60_000, hookTimeout: 60_000 }, () => {
+  describe("hook-based", async () => {
+    const context = await setupTest("nitro-dev");
+
+    it("does not hang in-flight requests during rebuild", async () => {
+      await context.nitro!.hooks.callHook("dev:start");
+      await context.nitro!.hooks.callHook("dev:reload");
+      await waitForDevWorker(context);
+
+      await context.nitro!.hooks.callHook("dev:start");
+
+      const requestPromise = context.fetch("/api/dev-reload-slow");
+
+      await new Promise((resolvePromise) =>
+        setTimeout(resolvePromise, REQUEST_ASSIGN_DELAY_MS)
+      );
+
+      await context.nitro!.hooks.callHook("dev:reload");
+
+      const result = await parseFetchBody(
+        await assertRequestCompletes(requestPromise)
+      );
+      expect(result).toEqual({ ok: true });
+
+      await waitForDevWorker(context);
+    });
+  });
+
+  describeIf(!isWindows, "file edit", async () => {
+    const fixtureRoot = createTempFixtureRoot();
+    const helloPath = join(fixtureRoot, "api", "hello.ts");
+    const context = await setupTest("nitro-dev", {
+      config: {
+        rootDir: fixtureRoot,
+        srcDir: fixtureRoot,
+      },
+    });
+
+    it("does not hang in-flight requests on the second API edit", async () => {
+      const firstReloadPromise = waitForDevReload(context);
+      await fsp.writeFile(
+        helloPath,
+        `export default eventHandler(() => ({ message: "v1" }));\n`
+      );
+      await firstReloadPromise;
+      await waitForDevWorker(context);
+
+      const devStartPromise = waitForDevStart(context);
+      await fsp.writeFile(
+        helloPath,
+        `export default eventHandler(() => ({ message: "v2" }));\n`
+      );
+      await devStartPromise;
+
+      const requestPromise = context.fetch("/api/dev-reload-slow");
+
+      const devReloadPromise = waitForDevReload(context);
+
+      await new Promise((resolvePromise) =>
+        setTimeout(resolvePromise, REQUEST_ASSIGN_DELAY_MS)
+      );
+
+      await devReloadPromise;
+
+      const result = await parseFetchBody(
+        await assertRequestCompletes(requestPromise)
+      );
+      expect(result).toEqual({ ok: true });
+
+      await waitForDevWorker(context);
+    });
+  });
+});

--- a/test/dev/dev-reload-race.test.ts
+++ b/test/dev/dev-reload-race.test.ts
@@ -79,76 +79,80 @@ function createTempFixtureRoot() {
   return fixtureRoot;
 }
 
-describe("dev server reload race", { timeout: 60_000, hookTimeout: 60_000 }, () => {
-  describe("hook-based", async () => {
-    const context = await setupTest("nitro-dev");
+describe(
+  "dev server reload race",
+  { timeout: 60_000, hookTimeout: 60_000 },
+  () => {
+    describe("hook-based", async () => {
+      const context = await setupTest("nitro-dev");
 
-    it("does not hang in-flight requests during rebuild", async () => {
-      await context.nitro!.hooks.callHook("dev:start");
-      await context.nitro!.hooks.callHook("dev:reload");
-      await waitForDevWorker(context);
+      it("does not hang in-flight requests during rebuild", async () => {
+        await context.nitro!.hooks.callHook("dev:start");
+        await context.nitro!.hooks.callHook("dev:reload");
+        await waitForDevWorker(context);
 
-      await context.nitro!.hooks.callHook("dev:start");
+        await context.nitro!.hooks.callHook("dev:start");
 
-      const requestPromise = context.fetch("/api/dev-reload-slow");
+        const requestPromise = context.fetch("/api/dev-reload-slow");
 
-      await new Promise((resolvePromise) =>
-        setTimeout(resolvePromise, REQUEST_ASSIGN_DELAY_MS)
-      );
+        await new Promise((resolvePromise) =>
+          setTimeout(resolvePromise, REQUEST_ASSIGN_DELAY_MS)
+        );
 
-      await context.nitro!.hooks.callHook("dev:reload");
+        await context.nitro!.hooks.callHook("dev:reload");
 
-      const result = await parseFetchBody(
-        await assertRequestCompletes(requestPromise)
-      );
-      expect(result).toEqual({ ok: true });
+        const result = await parseFetchBody(
+          await assertRequestCompletes(requestPromise)
+        );
+        expect(result).toEqual({ ok: true });
 
-      await waitForDevWorker(context);
-    });
-  });
-
-  describeIf(!isWindows, "file edit", async () => {
-    const fixtureRoot = createTempFixtureRoot();
-    const helloPath = join(fixtureRoot, "api", "hello.ts");
-    const context = await setupTest("nitro-dev", {
-      config: {
-        rootDir: fixtureRoot,
-        srcDir: fixtureRoot,
-      },
+        await waitForDevWorker(context);
+      });
     });
 
-    it("does not hang in-flight requests on the second API edit", async () => {
-      const firstReloadPromise = waitForDevReload(context);
-      await fsp.writeFile(
-        helloPath,
-        `export default eventHandler(() => ({ message: "v1" }));\n`
-      );
-      await firstReloadPromise;
-      await waitForDevWorker(context);
+    describeIf(!isWindows, "file edit", async () => {
+      const fixtureRoot = createTempFixtureRoot();
+      const helloPath = join(fixtureRoot, "api", "hello.ts");
+      const context = await setupTest("nitro-dev", {
+        config: {
+          rootDir: fixtureRoot,
+          srcDir: fixtureRoot,
+        },
+      });
 
-      const devStartPromise = waitForDevStart(context);
-      await fsp.writeFile(
-        helloPath,
-        `export default eventHandler(() => ({ message: "v2" }));\n`
-      );
-      await devStartPromise;
+      it("does not hang in-flight requests on the second API edit", async () => {
+        const firstReloadPromise = waitForDevReload(context);
+        await fsp.writeFile(
+          helloPath,
+          `export default eventHandler(() => ({ message: "v1" }));\n`
+        );
+        await firstReloadPromise;
+        await waitForDevWorker(context);
 
-      const requestPromise = context.fetch("/api/dev-reload-slow");
+        const devStartPromise = waitForDevStart(context);
+        await fsp.writeFile(
+          helloPath,
+          `export default eventHandler(() => ({ message: "v2" }));\n`
+        );
+        await devStartPromise;
 
-      const devReloadPromise = waitForDevReload(context);
+        const requestPromise = context.fetch("/api/dev-reload-slow");
 
-      await new Promise((resolvePromise) =>
-        setTimeout(resolvePromise, REQUEST_ASSIGN_DELAY_MS)
-      );
+        const devReloadPromise = waitForDevReload(context);
 
-      await devReloadPromise;
+        await new Promise((resolvePromise) =>
+          setTimeout(resolvePromise, REQUEST_ASSIGN_DELAY_MS)
+        );
 
-      const result = await parseFetchBody(
-        await assertRequestCompletes(requestPromise)
-      );
-      expect(result).toEqual({ ok: true });
+        await devReloadPromise;
 
-      await waitForDevWorker(context);
+        const result = await parseFetchBody(
+          await assertRequestCompletes(requestPromise)
+        );
+        expect(result).toEqual({ ok: true });
+
+        await waitForDevWorker(context);
+      });
     });
-  });
-});
+  }
+);

--- a/test/fixture/api/dev-reload-slow.ts
+++ b/test/fixture/api/dev-reload-slow.ts
@@ -1,0 +1,4 @@
+export default eventHandler(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 3_000));
+  return { ok: true };
+});

--- a/test/fixture/api/dev-reload-slow.ts
+++ b/test/fixture/api/dev-reload-slow.ts
@@ -1,4 +1,4 @@
 export default eventHandler(async () => {
-  await new Promise((resolve) => setTimeout(resolve, 3_000));
+  await new Promise((resolve) => setTimeout(resolve, 3000));
   return { ok: true };
 });


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro/issues/4359

### 📚 Description

This patch seems to fix the issue, but I am not 100% it is the correct fix.

```diff
diff --git a/src/core/dev-server/server.ts b/src/core/dev-server/server.ts
index 3d46c8ac..7da6df9d 100644
--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -85,6 +85,9 @@ class DevServer {
     nitro.hooks.hook("dev:start", () => {
       this.building = true;
       this.buildError = undefined;
+      for (const worker of this.workers) {
+        worker.close();
+      }
     });
 
     nitro.hooks.hook("dev:reload", () => {
@@ -164,12 +167,17 @@ class DevServer {
   async getWorker() {
     let retry = 0;
     const maxRetries = isTest || isCI ? 100 : 10;
+    const getWorkerStart = Date.now();
+    const maxBuildingWaitMs = 120_000;
     while (this.building || ++retry < maxRetries) {
+      if (Date.now() - getWorkerStart > maxBuildingWaitMs) {
+        return;
+      }
       if ((this.workers.length === 0 || this.buildError) && !this.building) {
         return;
       }
       const activeWorker = this.workers.find((w) => w.ready);
-      if (activeWorker) {
+      if (activeWorker && !this.building) {
         return activeWorker;
       }
       await new Promise((resolve) => setTimeout(resolve, 600));
```