### PR TITLE
fix(vite): close env runner during Vite environment cleanup

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -36,6 +36,7 @@ export type FetchHandler = (req: Request) => Promise<Response>;
 export interface DevServer extends RunnerRPCHooks {
   fetch: FetchHandler;
   init?: () => void | Promise<void>;
+  close?: () => void | Promise<void>;
 }
 
 // ---- Fetchable Dev Environment ----
@@ -113,6 +114,11 @@ export class FetchableDevEnvironment extends DevEnvironment {
       event: "nitro:vite-env",
       data: { name: this.name, entry: this.#entry },
     });
+  }
+
+  override async close(): Promise<void> {
+    await super.close();
+    await this.devServer.close?.();
   }
 }
 

--- a/test/vite/environment-cleanup.test.ts
+++ b/test/vite/environment-cleanup.test.ts
@@ -1,0 +1,17 @@
+import { RunnerManager } from "env-runner";
+import { describe, expect, test } from "vitest";
+import { resolveConfig } from "vite";
+import { createFetchableDevEnvironment } from "../../src/build/vite/dev.ts";
+
+describe("vite: environment cleanup", () => {
+  test("closes the env runner when the environment is closed", async () => {
+    const config = await resolveConfig({ configFile: false }, "serve");
+    const envRunner = new RunnerManager();
+    const env = createFetchableDevEnvironment("client", config, envRunner, "/entry.mjs");
+
+    await env.init();
+    await env.close();
+
+    expect(envRunner.closed).toBe(true);
+  });
+});


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#4361 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

`FetchableDevEnvironment.close()` currently does not stop the env runner created for the environment. Vite cleans up the environment itself, but the runner can keep the process alive.

I ran into this while adding the React Router example. During the build, the React Router Vite plugin creates an additional Vite server for route analysis. The server is closed correctly, but Nitro's env runner remains active, so the build finishes without exiting.

This PR closes the runner together with the Vite environment and adds a regression test for this behavior.

Resolves #4361

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
