### PR TITLE
fix(config): detect `vite.config.c[jt]s`

### DIFF
--- a/src/config/resolvers/builder.ts
+++ b/src/config/resolvers/builder.ts
@@ -62,7 +62,7 @@ async function installPkg(pkg: string, root: string) {
 }
 
 function hasNitroViteConfig(options: NitroOptions): boolean {
-  const configExts = [".ts", ".mts", ".js", ".mjs"];
+  const configExts = [".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"];
   for (const ext of configExts) {
     const configPath = resolve(options.rootDir, `vite.config${ext}`);
     if (existsSync(configPath)) {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- `resolveBuilder`'s `hasNitroViteConfig()` only checked `vite.config.{ts,mts,js,mjs}` when auto-detecting the `vite` builder, missing `.cjs`/`.cts` configs.
- Vite itself already resolves `vite.config.cjs` and `vite.config.cts` as first-class config files (see `DEFAULT_CONFIG_FILES` in [vite's constants.ts](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L98-L105), and the [Vite config docs](https://vite.dev/config/): "other JS and TS extensions are also supported"). Nitro's own builder detection was just out of sync with that list.
- Added `.cjs` and `.cts` to `configExts` so a `vite.config.cjs`/`.cts` containing the `nitro()` plugin is now correctly detected and `builder` defaults to `"vite"`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
