### PR TITLE
perf: skip duplicate routing sync

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -78,8 +78,5 @@ export async function createNitro(
   // Ensure initial handlers are populated
   await scanHandlers(nitro);
 
-  // Sync routers
-  nitro.routing.sync();
-
   return nitro;
 }


### PR DESCRIPTION

This PR removes a duplicate routing sync introduced by [`0fe0b835`](https://github.com/nitrojs/nitro/commit/0fe0b835), which added `nitro.routing.sync()` after the initial handler scan. Later, [`7857f44e`](https://github.com/nitrojs/nitro/commit/7857f44e) moved that responsibility into `scanHandlers()`, causing routing to be rebuilt twice during initialization. 

Removing the second call keeps behavior while reducing unnecessary startup work.