### PR TITLE
presets(vercel): use reflinks for custom function dirs

### DIFF
--- a/src/presets/_utils/fs.ts
+++ b/src/presets/_utils/fs.ts
@@ -1,5 +1,5 @@
 import fsp from "node:fs/promises";
-import { relative, dirname } from "pathe";
+import { relative, dirname, join } from "pathe";
 import consola from "consola";
 import { colors } from "consola/utils";
 
@@ -21,5 +21,47 @@ export async function isDirectory(path: string) {
     return (await fsp.stat(path)).isDirectory();
   } catch {
     return false;
+  }
+}
+
+/**
+ * Recursively recreate `src` at `dest` using hard links for files.
+ *
+ * Hard links share inodes with the source, so deployment targets that
+ * read files into per-function bundles (e.g. Vercel Lambda packaging)
+ * see them as regular files while local disk usage stays flat.
+ *
+ * Directories cannot be hard-linked, so the tree is recreated and each
+ * file is linked individually. Symlinks are preserved as symlinks.
+ * Falls back to `copyFile` when crossing filesystems (`EXDEV`) or when
+ * the platform refuses the link operation (`EPERM`).
+ *
+ * Entries listed in `skip` are ignored at the top level only.
+ */
+export async function hardLinkDir(src: string, dest: string, options: { skip?: Set<string> } = {}) {
+  await fsp.mkdir(dest, { recursive: true });
+  const entries = await fsp.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (options.skip?.has(entry.name)) {
+      continue;
+    }
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await hardLinkDir(srcPath, destPath);
+    } else if (entry.isSymbolicLink()) {
+      const target = await fsp.readlink(srcPath);
+      await fsp.symlink(target, destPath);
+    } else {
+      try {
+        await fsp.link(srcPath, destPath);
+      } catch (err: any) {
+        if (err?.code === "EXDEV" || err?.code === "EPERM") {
+          await fsp.copyFile(srcPath, destPath);
+        } else {
+          throw err;
+        }
+      }
+    }
   }
 }

--- a/src/presets/_utils/fs.ts
+++ b/src/presets/_utils/fs.ts
@@ -1,5 +1,5 @@
 import fsp from "node:fs/promises";
-import { relative, dirname, join } from "pathe";
+import { relative, dirname } from "pathe";
 import consola from "consola";
 import { colors } from "consola/utils";
 
@@ -21,47 +21,5 @@ export async function isDirectory(path: string) {
     return (await fsp.stat(path)).isDirectory();
   } catch {
     return false;
-  }
-}
-
-/**
- * Recursively recreate `src` at `dest` using hard links for files.
- *
- * Hard links share inodes with the source, so deployment targets that
- * read files into per-function bundles (e.g. Vercel Lambda packaging)
- * see them as regular files while local disk usage stays flat.
- *
- * Directories cannot be hard-linked, so the tree is recreated and each
- * file is linked individually. Symlinks are preserved as symlinks.
- * Falls back to `copyFile` when crossing filesystems (`EXDEV`) or when
- * the platform refuses the link operation (`EPERM`).
- *
- * Entries listed in `skip` are ignored at the top level only.
- */
-export async function hardLinkDir(src: string, dest: string, options: { skip?: Set<string> } = {}) {
-  await fsp.mkdir(dest, { recursive: true });
-  const entries = await fsp.readdir(src, { withFileTypes: true });
-  for (const entry of entries) {
-    if (options.skip?.has(entry.name)) {
-      continue;
-    }
-    const srcPath = join(src, entry.name);
-    const destPath = join(dest, entry.name);
-    if (entry.isDirectory()) {
-      await hardLinkDir(srcPath, destPath);
-    } else if (entry.isSymbolicLink()) {
-      const target = await fsp.readlink(srcPath);
-      await fsp.symlink(target, destPath);
-    } else {
-      try {
-        await fsp.link(srcPath, destPath);
-      } catch (err: any) {
-        if (err?.code === "EXDEV" || err?.code === "EPERM") {
-          await fsp.copyFile(srcPath, destPath);
-        } else {
-          throw err;
-        }
-      }
-    }
   }
 }

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -1,6 +1,6 @@
 import fsp from "node:fs/promises";
 import { defu } from "defu";
-import { writeFile } from "../_utils/fs.ts";
+import { hardLinkDir, writeFile } from "../_utils/fs.ts";
 import type { Nitro, NitroRouteRules } from "nitro/types";
 import { dirname, relative, resolve } from "pathe";
 import { Router } from "../../routing.ts";
@@ -636,11 +636,9 @@ async function createFunctionDirWithCustomConfig(
   overrides: VercelServerlessFunctionConfig,
   functionPath: string
 ) {
-  // Copy the entire server directory instead of symlinking individual
-  // entries. Vercel's build container preserves symlinks in the Lambda
-  // zip, but symlinks pointing outside the .func directory break at
-  // runtime because the target path doesn't exist on Lambda.
-  await fsp.cp(serverDir, funcDir, { recursive: true });
+  await hardLinkDir(serverDir, funcDir, {
+    skip: new Set([".vc-config.json"]),
+  });
   const mergedConfig = defu(overrides, baseFunctionConfig);
   for (const [key, value] of Object.entries(overrides)) {
     if (Array.isArray(value)) {

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -1,8 +1,9 @@
 import fsp from "node:fs/promises";
+import { constants } from "node:fs";
 import { defu } from "defu";
-import { hardLinkDir, writeFile } from "../_utils/fs.ts";
+import { writeFile } from "../_utils/fs.ts";
 import type { Nitro, NitroRouteRules } from "nitro/types";
-import { dirname, relative, resolve } from "pathe";
+import { basename, dirname, relative, resolve } from "pathe";
 import { Router } from "../../routing.ts";
 import { joinURL, withLeadingSlash, withoutLeadingSlash } from "ufo";
 import type {
@@ -636,8 +637,10 @@ async function createFunctionDirWithCustomConfig(
   overrides: VercelServerlessFunctionConfig,
   functionPath: string
 ) {
-  await hardLinkDir(serverDir, funcDir, {
-    skip: new Set([".vc-config.json"]),
+  await fsp.cp(serverDir, funcDir, {
+    recursive: true,
+    mode: constants.COPYFILE_FICLONE,
+    filter: (src) => basename(src) !== ".vc-config.json",
   });
   const mergedConfig = defu(overrides, baseFunctionConfig);
   for (const [key, value] of Object.entries(overrides)) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a function needs a modified `.vc-config.json`, we previously copied the entire `__server.func` directory and then overwrote the config. We now copy it with copy-on-write (`COPYFILE_FICLONE`) reflinks, which share the underlying data blocks on supported filesystems (and transparently fall back to a regular copy when unsupported), and skip copying the base `.vc-config.json` since a merged one is written right after.

We avoid symlinking entries within a function dir because Vercel's build container cannot resolve symlinks that point outside the `.func` directory at runtime.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
