### PR TITLE
types: export missing h3 types from runtime

### DIFF
--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -21,7 +21,7 @@ export {
   HTTPError,
   HTTPResponse,
 } from "h3";
-export type { H3Event } from "h3";
+export type { H3Event, EventHandlerRequest, EventHandlerWithFetch } from 'h3';
 
 // Runtime
 export function serverFetch(

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -21,7 +21,7 @@ export {
   HTTPError,
   HTTPResponse,
 } from "h3";
-export type { H3Event, EventHandlerRequest, EventHandlerWithFetch } from 'h3';
+export type { H3Event, EventHandlerRequest, EventHandlerWithFetch } from "h3";
 
 // Runtime
 export function serverFetch(


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #4344

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using a dependency manager that uses a symlink strategy such as `pnpm`, `bun`, or `npm` with the `--install-strategy=linked` flag, TypeScript will flag the types that come from these module paths as non-portable, which is correct.

```ts
export default defineHandler((request) => {
  // ...
});

// Error: The inferred type of 'default' cannot be named without a reference to 'EventHandlerRequest' from '.bun/h3@2.0.1-rc.22+a8f2d2f34545c24c/node_modules/h3'. This is likely not portable. A type annotation is necessary.ts(2883)
```

This PR exports the types that are depended upon by the exported h3 helpers.

The alternative is making h3 a peerDependency or documenting that users install "h3" as a direct dependent of their project, but that feels like a lot more hoop-jumping when h3 is so integral to nitro.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
