### PR TITLE
docs: update zerops provider docs

### DIFF
--- a/docs/2.deploy/20.providers/zerops.md
+++ b/docs/2.deploy/20.providers/zerops.md
@@ -6,46 +6,45 @@
 
 :read-more{title="zerops.io" to="https://zerops.io"}
 
-> [!IMPORTANT]
-> 🚧 This preset is currently experimental.
-
 Zerops supports deploying both static and server-side rendered apps with a simple configuration file in your project root.
-
-## Starter templates
-
-If you want to quckly get started with zerops and nitro you can use repositories [`zeropsio/recipe-nitro-nodejs`](https://github.com/zeropsio/recipe-nitro-nodejs) and [`zeropsio/recipe-nitro-static`](https://github.com/zeropsio/recipe-nitro-static) starter templates.
 
 ## Project setup
 
-Projects and services can be added either through [project add wizard](https://app.zerops.io/dashboard/project-add) or imported using `zerops-project-import.yml`.
+Projects and services can be added through the [Zerops dashboard](https://app.zerops.io) by clicking **Import a project**, or imported using `zerops-project-import.yaml`.
 
 ::code-group
-```yml [zerops-project-import.yml (node.js)]
+
+```yml [zerops-project-import.yaml (node.js)]
 project:
   name: nitro-app
 
 services:
   - hostname: app
-    type: nodejs@20
+    type: nodejs@22
+    enableSubdomainAccess: true
 ```
-```yml [zerops-project-import.yml (static)]
+
+```yml [zerops-project-import.yaml (static)]
 project:
   name: nitro-app
 
 services:
   - hostname: app
     type: static
+    enableSubdomainAccess: true
 ```
+
 ::
 
-Then create a `zerops.yml` config in your project root:
+Then create a `zerops.yaml` config in your project root:
 
 ::code-group
-```yml [zerops.yml (node.js)]
+
+```yml [zerops.yaml (node.js)]
 zerops:
   - setup: app
     build:
-      base: nodejs@20
+      base: nodejs@22
       envVariables:
         NITRO_PRESET: zerops
       buildCommands:
@@ -56,17 +55,18 @@ zerops:
         - package.json
         - node_modules
     run:
-      base: nodejs@20
+      base: nodejs@22
       ports:
         - port: 3000
           httpSupport: true
       start: node .output/server/index.mjs
 ```
-```yml [zerops.yml (static)]
+
+```yml [zerops.yaml (static)]
 zerops:
   - setup: app
     build:
-      base: nodejs@20
+      base: nodejs@22
       envVariables:
         NITRO_PRESET: zerops-static
       buildCommands:
@@ -77,10 +77,10 @@ zerops:
     run:
       base: static
 ```
+
 ::
 
 Now you can trigger the [build & deploy pipeline using the Zerops CLI](#building-deploying-your-app) or by connecting the app service with your [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) repository from inside the service detail.
-
 
 ## Build and deploy
 
@@ -90,11 +90,10 @@ Log in using your access token with the following command:
 
 :pm-x{command="@zerops/zcli login <token>"}
 
-Navigate to the root of your app (where `zerops.yml` is located) and run the following command to trigger the deploy:
+Navigate to the root of your app (where `zerops.yaml` is located) and run the following command to trigger the deploy:
 
 :pm-x{command="@zerops/zcli push"}
 
-Your code can be deployed automatically on each commit or a new tag by connecting the service with your [GitHub](https://docs.zerops.io/references/gitlab-integration) / [GitLab](https://docs.zerops.io/references/gitlab-integration) repository. This connection can be set up in the service detail.
+Your code can be deployed automatically on each commit or a new tag by connecting the service with your [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) repository. This connection can be set up in the service detail.
 
 
-:read-more{title="Zerops Documentation" to="https://docs.zerops.io/"}


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)

### 📝 Description

Updates the Zerops provider docs to reflect the current state of the platform:

- Remove experimental banner (preset has been stable)
- Remove outdated starter template links
- Fix import flow — "project add wizard" no longer exists, updated to current dashboard UI
- Update Node.js version from 20 to 22
- Rename `zerops.yml` to `zerops.yaml` throughout (current Zerops convention)
- Fix GitHub integration link (was incorrectly pointing to the GitLab URL)
- Add `enableSubdomainAccess` to import YAMLs

### 🧹 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.