### PR TITLE
docs: use variable font weight range for geist

### DIFF
--- a/docs/.docs/nuxt.config.ts
+++ b/docs/.docs/nuxt.config.ts
@@ -5,8 +5,8 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
   fonts: {
     families: [
-      { name: 'Geist', weights: [400, 600, 700], global: true },
-      { name: 'Geist Mono', weights: [400, 600], global: true },
+      { name: 'Geist', weights: ['100 900'], global: true },
+      { name: 'Geist Mono', weights: ['100 900'], global: true },
       { name: "Geist Pixels", src: "/assets/fonts/GeistPixel-Square.woff2", weight: 500, global: true },
     ],
   },


### PR DESCRIPTION
## Summary

- Use the variable font range (`'100 900'`) instead of static weights for Geist and Geist Mono fonts
- Fix thin font rendering in Chromium browsers (Chrome 139+)

Static weights (`[400, 600, 700]`) were causing the variable font to render incorrectly in Chromium, appearing much thinner than intended. Safari was unaffected. Using the full variable font range ensures consistent rendering across all browsers.

| Before | After |
|:------:|:-----:|
| <img width="1716" alt="Before" src="https://github.com/user-attachments/assets/b7f1bfdc-af37-4625-bd05-1ca21e59aa19" /> | <img width="1716" alt="After" src="https://github.com/user-attachments/assets/5563f61b-fad6-4864-a7aa-8dd521585b69" /> |