### PR TITLE
docs: fix event.path usage and misleading middleware path in examples

### DIFF
--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -271,7 +271,7 @@ export default defineConfig({
   handlers: [
     {
       route: "/api/**",
-      handler: "./server/middleware/api-auth.ts",
+      handler: "./server/handlers/api-auth.ts",
       middleware: true,
     },
   ],
@@ -408,7 +408,7 @@ export default defineConfig({
   handlers: [
     {
       route: "/api/**",
-      handler: "./server/middleware/api-auth.ts",
+      handler: "./server/handlers/api-auth.ts",
       middleware: true,
     },
   ],

--- a/docs/1.docs/50.lifecycle.md
+++ b/docs/1.docs/50.lifecycle.md
@@ -21,7 +21,7 @@ import { definePlugin } from "nitro";
 
 export default definePlugin((nitroApp) => {
   nitroApp.hooks.hook("request", (event) => {
-    console.log(`Incoming request on ${event.path}`);
+    console.log(`Incoming request on ${event.url.pathname}`);
   });
 });
 ```


### PR DESCRIPTION
## Changes

### 1. lifecycle.md: Fix `event.path` → `event.url.pathname`

The `request` hook receives an `HTTPEvent` (from h3), not an `H3Event`. The `HTTPEvent` interface does not have a `path` property — the correct way to access the path is `event.url.pathname`.

```diff
-    console.log(`Incoming request on ${event.path}`);
+    console.log(`Incoming request on ${event.url.pathname}`);
```

Fixes #4375

### 2. routing.md: Fix misleading middleware handler path

The route-scoped middleware example used `./server/middleware/api-auth.ts` as the handler path. Since files in the `middleware/` directory are automatically registered as global middleware (matching `/**`), this:
- Makes the `route: "/api/**"` config completely redundant
- Causes the middleware to execute twice (once globally, once via the route config)

Changed to `./server/handlers/api-auth.ts` to avoid the conflict.

Fixes #4354
