### PR TITLE
fix(aws-lambda): use correct runtime property name and fix missing metadata

### DIFF
--- a/src/presets/aws-lambda/runtime/_utils.ts
+++ b/src/presets/aws-lambda/runtime/_utils.ts
@@ -18,9 +18,9 @@ export function awsRequest(
   // srvx compatibility
   req.runtime ??= { name: "aws-lambda" };
   // @ts-expect-error (add to srvx types)
-  req.runtime.aws ??= { event, context } as any;
+  req.runtime.awsLambda ??= { event, context } as any;
 
-  return new Request(url, { method, headers, body });
+  return req;
 }
 
 function awsEventMethod(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string {


### PR DESCRIPTION
## Problem

Two bugs in the aws-lambda preset's `awsRequest()` function:

### 1. Wrong property name: `runtime.aws` instead of `runtime.awsLambda`

The code sets `req.runtime.aws = { event, context }`, but users access `runtime.awsLambda` (as documented/described in the issue). This means `runtime.awsLambda` is always `undefined`.

### 2. Runtime metadata discarded

The function creates a `Request` object, attaches runtime metadata to it, then returns a **new** `Request()` without any metadata:

```ts
const req = new Request(url, { method, headers, body }) as ServerRequest;
req.runtime ??= { name: "aws-lambda" };
req.runtime.aws ??= { event, context };  // ← attached to req
return new Request(url, { method, headers, body });  // ← returns NEW request without metadata!
```

## Fix

```diff
  req.runtime ??= { name: "aws-lambda" };
- req.runtime.aws ??= { event, context } as any;
+ req.runtime.awsLambda ??= { event, context } as any;

- return new Request(url, { method, headers, body });
+ return req;
```

Fixes #4287
