### PR TITLE
fix(vite): generate nitro types in vite builder

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -13,6 +13,7 @@ import { join } from "pathe";
 import { debounce } from "perfect-debounce";
 import { withBase } from "ufo";
 import { scanHandlers } from "../../scan.ts";
+import { writeTypes } from "../types.ts";
 import { getEnvRunner } from "./env.ts";
 
 // https://vite.dev/guide/api-environment-runtimes.html#modulerunner
@@ -150,6 +151,7 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   const reload = debounce(async () => {
     await scanHandlers(nitro);
     nitro.routing.sync();
+    await writeTypes(nitro);
     nitroEnv.moduleGraph.invalidateAll();
     nitroEnv.hot.send({ type: "full-reload" });
   });

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -9,7 +9,7 @@ import type {
 import type { InputOption } from "rollup";
 import type { NitroPluginConfig, NitroPluginContext } from "./types.ts";
 import { resolve, join } from "pathe";
-import { createNitro, prepare } from "../../builder.ts";
+import { createNitro, prepare, writeTypes } from "../../builder.ts";
 import { getBundlerConfig } from "./bundler.ts";
 import { buildEnvironments } from "./prod.ts";
 import {
@@ -432,6 +432,9 @@ async function setupNitroContext(
     ctx.nitro,
     ctx.bundlerConfig.rollupConfig || (ctx.bundlerConfig.rolldownConfig as any)
   );
+
+  // Generate types (runtime config, imports, routes)
+  await writeTypes(ctx.nitro);
 
   // Warm up env runner for dev
   if (ctx.nitro.options.dev) {

--- a/test/vite/types.test.ts
+++ b/test/vite/types.test.ts
@@ -1,0 +1,60 @@
+import { existsSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "pathe";
+import type { ViteDevServer } from "vite";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+
+const { createServer, createBuilder } = (await import(
+  process.env.NITRO_VITE_PKG || "vite"
+)) as typeof import("vite");
+
+const rootDir = fileURLToPath(new URL("./app-fixture", import.meta.url));
+const typesDir = join(rootDir, "node_modules/.nitro/types");
+
+const DECLARATION_FILES = [
+  "nitro.d.ts",
+  "nitro-routes.d.ts",
+  "nitro-config.d.ts",
+  "nitro-imports.d.ts",
+];
+
+const expectDeclarationFiles = () => {
+  for (const file of DECLARATION_FILES) {
+    expect(existsSync(join(typesDir, file)), `${file} should exist`).toBe(true);
+  }
+};
+
+describe("vite:types (dev)", () => {
+  let server: ViteDevServer;
+  const originalCwd = process.cwd();
+
+  beforeAll(async () => {
+    rmSync(typesDir, { recursive: true, force: true });
+    process.chdir(rootDir);
+    server = await createServer({ root: rootDir });
+  }, 30_000);
+
+  afterAll(async () => {
+    await server?.close();
+    process.chdir(originalCwd);
+  });
+
+  test("generates all nitro type declaration files", expectDeclarationFiles);
+});
+
+describe("vite:types (prod)", () => {
+  const originalCwd = process.cwd();
+
+  beforeAll(async () => {
+    rmSync(typesDir, { recursive: true, force: true });
+    process.chdir(rootDir);
+    const builder = await createBuilder({ root: rootDir, logLevel: "warn" });
+    await builder.buildApp();
+  }, 30_000);
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+  });
+
+  test("generates all type declaration files", expectDeclarationFiles);
+});


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#4379

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite builder did not generate Nitro types, so `.nitro/types/` declarations were missing during dev and build.

This PR makes the Vite builder run Nitro type generation during setup, and also regenerates types after Nitro config changes in dev mode. This makes route, config, and import declarations available for Vite-based projects.

Added tests for both Vite dev and prod builder flows to make sure the expected declaration files are written.

Resolves #4379

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
