### PR TITLE
ci: improve actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,11 @@ jobs:
         with: { node-version: lts/*, cache: pnpm }
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm typecheck
-      - run: pnpm vitest run test/unit
-      - run: pnpm vitest run test/minimal
-      - run: pnpm vitest run test/vite
+      - parallel:
+          - run: pnpm typecheck
+          - run: pnpm vitest run test/unit
+          - run: pnpm vitest run test/minimal
+          - run: pnpm vitest run test/vite
   tests-rollup:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -50,10 +51,11 @@ jobs:
       - run: pnpm stub && pnpm lint
         if: ${{ matrix.os != 'windows-latest' }}
       - run: pnpm build
-      - run: pnpm vitest run test/examples
-        env: { NITRO_BUILDER: rollup, NITRO_VITE_PKG: vite7 }
-      - run: pnpm vitest run test/presets
-        env: { NITRO_BUILDER: rollup, NITRO_VITE_PKG: vite7 }
+      - parallel:
+          - run: pnpm vitest run test/examples
+            env: { NITRO_BUILDER: rollup, NITRO_VITE_PKG: vite7 }
+          - run: pnpm vitest run test/presets
+            env: { NITRO_BUILDER: rollup, NITRO_VITE_PKG: vite7 }
 
   tests-rolldown:
     runs-on: ${{ matrix.os }}
@@ -76,10 +78,11 @@ jobs:
         with: { deno-version: 2.8.3 }
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm vitest run test/examples
-        env: { NITRO_BUILDER: rolldown, NITRO_VITE_PKG: vite }
-      - run: pnpm vitest run test/presets
-        env: { NITRO_BUILDER: rolldown, NITRO_VITE_PKG: vite }
+      - parallel:
+          - run: pnpm vitest run test/examples
+            env: { NITRO_BUILDER: rolldown, NITRO_VITE_PKG: vite }
+          - run: pnpm vitest run test/presets
+            env: { NITRO_BUILDER: rolldown, NITRO_VITE_PKG: vite }
   publish-pkg-pr-new:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     environment: npm-publish-nightly
     permissions: { id-token: write, contents: read }
     needs: [tests-checks, tests-rollup, tests-rolldown]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'nitrojs/nitro'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { fetch-depth: 0, persist-credentials: false }

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,9 +34,10 @@ jobs:
 
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm lint
-      - run: pnpm typecheck
-      - run: pnpm test:rolldown
+      - parallel:
+          - run: pnpm lint
+          - run: pnpm typecheck
+          - run: pnpm test:rolldown
 
       - name: Publish to npm with provenance
         # Uses OIDC trusted publishing — no NPM_TOKEN needed.


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

GitHub Actions [announced](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) the `parallel` keyword yesterday — syntactic sugar that groups independent steps to run concurrently within a single job, then waits for all of them before continuing. See the [workflow syntax docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel) for the full reference.

| Workflow | Job | Parallelised steps |
|---|---|---|
| `ci.yml` | `tests-checks` | `pnpm typecheck` + `pnpm vitest run test/unit` + `pnpm vitest run test/minimal` + `pnpm vitest run test/vite` |
| `ci.yml` | `tests-rollup` | `pnpm vitest run test/examples` + `pnpm vitest run test/presets` |
| `ci.yml` | `tests-rolldown` | `pnpm vitest run test/examples` + `pnpm vitest run test/presets` |
| `npm-publish.yml` | `publish` | `pnpm lint` + `pnpm typecheck` + `pnpm test:rolldown` |

I've also scoped the nightly publish job to only run in this repo, not forks.

Related:
- https://github.com/nuxt/.github/pull/42
- https://github.com/nuxt/nuxt/pull/35448

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
