### PR TITLE
fix(dev): restrict /_nitro/tasks endpoint to local requests

### DIFF
--- a/src/dev/_request.ts
+++ b/src/dev/_request.ts
@@ -1,0 +1,26 @@
+import { getRequestIP, type H3Event } from "h3";
+
+/**
+ * Whether a request to the dev server originates from the loopback interface.
+ *
+ * Used to gate dev-only debug endpoints (the VFS viewer and the task runner) so
+ * they are not reachable from other hosts when the dev server is bound to a
+ * non-loopback address, which is the default (`devServer.hostname` is unset).
+ */
+export function isLocalDevRequest(event: H3Event): boolean {
+  const { socket } = event.runtime?.node?.req || {};
+
+  // prettier-ignore
+  const isUnixSocket =
+    // No network addresses
+    (!socket?.remoteAddress && !socket?.localAddress) &&
+    // Empty address object
+    Object.keys(socket?.address?.() || {}).length === 0 &&
+    // Socket is readable/writable but has no port info
+    socket?.readable && socket?.writable && !socket?.remotePort;
+
+  const ip = getRequestIP(event, { xForwardedFor: isUnixSocket });
+  const v4 = ip?.toLowerCase().startsWith("::ffff:") ? ip.slice(7) : ip;
+
+  return Boolean(v4 && /^(?:::1|127\.\d+\.\d+\.\d+)$/.test(v4));
+}

--- a/src/dev/app.ts
+++ b/src/dev/app.ts
@@ -10,6 +10,7 @@ import { stat } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { createGzip, createBrotliCompress } from "node:zlib";
 import { createVFSHandler } from "./vfs.ts";
+import { isLocalDevRequest } from "./_request.ts";
 
 import devErrorHandler, {
   defaultHandler as devErrorHandlerInternal,
@@ -61,6 +62,19 @@ export class NitroDevApp {
 
     // Debugging endpoint to view vfs
     app.get("/_vfs/**", createVFSHandler(this.nitro));
+
+    // Restrict the dev task runner to local requests, mirroring the VFS viewer.
+    // The `/_nitro/tasks` routes are handled by the worker (via the catch-all)
+    // and execute server tasks with caller-supplied payload; without this gate
+    // they are reachable by any host that can reach the dev server, which binds
+    // all interfaces by default (`devServer.hostname` is unset).
+    const assertLocalTaskRequest = (event: H3Event) => {
+      if (!isLocalDevRequest(event)) {
+        throw new HTTPError({ statusText: "Forbidden IP", status: 403 });
+      }
+    };
+    app.use("/_nitro/tasks", assertLocalTaskRequest);
+    app.use("/_nitro/tasks/**", assertLocalTaskRequest);
 
     // Serve asset dirs
     for (const asset of this.nitro.options.publicAssets) {

--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -1,28 +1,11 @@
-import { HTTPError, defineHandler, getRequestIP } from "h3";
+import { HTTPError, defineHandler } from "h3";
 import type { Nitro } from "nitro/types";
+import { isLocalDevRequest } from "./_request.ts";
 
 export function createVFSHandler(nitro: Nitro) {
   return defineHandler(async (event) => {
-    const { socket } = event.runtime?.node?.req || {};
-
-    // prettier-ignore
-    const isUnixSocket =
-      // No network addresses
-      (!socket?.remoteAddress && !socket?.localAddress) &&
-      // Empty address object
-      Object.keys(socket?.address?.() || {}).length === 0 &&
-      // Socket is readable/writable but has no port info
-      socket?.readable && socket?.writable && !socket?.remotePort;
-
-    const ip = getRequestIP(event, { xForwardedFor: isUnixSocket });
-    const v4 = ip?.toLowerCase().startsWith("::ffff:") ? ip.slice(7) : ip;
-
-    const isLocalRequest = v4 && /^(?:::1|127\.\d+\.\d+\.\d+)$/.test(v4);
-    if (!isLocalRequest) {
-      throw new HTTPError({
-        statusText: `Forbidden IP: "${ip || "?"}"`,
-        status: 403,
-      });
+    if (!isLocalDevRequest(event)) {
+      throw new HTTPError({ statusText: "Forbidden IP", status: 403 });
     }
 
     const url = event.context.params?._ || "";


### PR DESCRIPTION
### Summary

The development task runner endpoints, `/_nitro/tasks` and `/_nitro/tasks/:name`, execute server tasks with caller-supplied payload (`{ ...getQuery(event), ...body }`) and have no access control. The dev server binds all network interfaces by default (`devServer.hostname` is unset in `src/config/defaults.ts`), so any host that can reach the dev server can enumerate the project's tasks and invoke them — for example a `db:*` migration or seed task — with attacker-controlled input. A co-located process or a different local user can do the same over loopback.

The VFS debug viewer already restricts itself to loopback requests (`createVFSHandler` in `src/dev/vfs.ts`), so the framework already treats dev debug surfaces as local-only; the task runner just did not follow the same rule. (The preview server also hard-codes `--host localhost`, while the dev server defaults to all interfaces.)

### Change

- Extract the loopback check from `vfs.ts` into a shared `isLocalDevRequest` helper (`src/dev/_request.ts`).
- Apply it to `/_nitro/tasks` and `/_nitro/tasks/**` at the dev-app layer — the same layer as the VFS viewer, where the real client socket is visible (the task routes are otherwise handled by the worker via the catch-all).

### Verification

With `test/fixture` (which enables `experimental.tasks`), running the dev server:

- `GET /_nitro/tasks` and `GET /_nitro/tasks/db:migrate` continue to work (HTTP 200) over loopback (`127.0.0.1`).
- The same requests to the machine's LAN address now return `403 Forbidden IP` instead of executing.
- `/_vfs/` behaves identically to before (loopback 200, non-loopback 403), now via the shared helper.

### Scope and alternatives

Dev-server only; production output is unaffected, and the task routes require the experimental tasks feature. An `Origin`/CSRF check would additionally harden the drive-by-from-a-visited-page vector, and binding the dev server to `localhost` by default (as the preview server already does) would be a broader option. This change keeps to the minimal, behavior-preserving fix that mirrors the existing VFS gate. Happy to add a regression test or take a different approach if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
