### PR TITLE
fix(build): escape dynamic route segments in Rollup chunk names

### DIFF
--- a/src/build/chunks.ts
+++ b/src/build/chunks.ts
@@ -78,7 +78,7 @@ export function getChunkName(chunk: { name: string; moduleIds: string[] }, nitro
       .flatMap((h) => h.data)
       .find((h) => h.handler === mainId);
     if (routeHandler?.route) {
-      return `_routes/${routeToFsPath(routeHandler.route)}.mjs`;
+      return `_routes/${routeToFsPath(routeHandler.route).replace(/\[([^\]]*)\]/g, "_$1_")}.mjs`;
     }
 
     const taskHandler = Object.entries(nitro.options.tasks).find(

--- a/test/unit/chunks.test.ts
+++ b/test/unit/chunks.test.ts
@@ -149,7 +149,7 @@ describe("getChunkName", () => {
     );
   });
 
-  it("returns _routes/<path>.mjs for dynamic route", () => {
+  it("returns _routes/<path>.mjs for dynamic route (brackets escaped for Rollup)", () => {
     const n = createNitro({
       routing: {
         routes: {
@@ -162,8 +162,30 @@ describe("getChunkName", () => {
       },
     } as any);
     expect(getChunkName(createChunk("route", ["/src/routes/api/users/[id].ts"]), n)).toBe(
-      "_routes/api/users/[id].mjs"
+      "_routes/api/users/_id_.mjs"
     );
+  });
+
+  it("returns _routes/<path>.mjs for nested dynamic route (brackets escaped for Rollup)", () => {
+    const n = createNitro({
+      routing: {
+        routes: {
+          routes: [
+            {
+              data: [
+                {
+                  route: "/api/applications/:id/context",
+                  handler: "/src/routes/api/applications/[id]/context.get.ts",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    } as any);
+    expect(
+      getChunkName(createChunk("route", ["/src/routes/api/applications/[id]/context.get.ts"]), n)
+    ).toBe("_routes/api/applications/_id_/context.mjs");
   });
 
   it("returns _routes/index.mjs for root route", () => {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #4289

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getChunkName` returns `_routes/<path>.mjs` for server route handlers, deriving the path from `routeToFsPath`. Routes with dynamic segments (e.g. `/api/applications/:id/context`) produce paths containing square brackets (`[id]`), which Rollup rejects as invalid `chunkFileNames` placeholders with `"[id]" is not a valid placeholder`.

Applied `.replace(/\[([^\]]*)\]/g, "_$1_")` to the route-derived path inside `getChunkName` before building the chunk name. `routeToFsPath` is unchanged.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.