### PR TITLE
fix(build): escape dynamic route segments in Rollup chunk names

### DIFF
--- a/src/build/chunks.ts
+++ b/src/build/chunks.ts
@@ -78,7 +78,7 @@ export function getChunkName(chunk: { name: string; moduleIds: string[] }, nitro
       .flatMap((h) => h.data)
       .find((h) => h.handler === mainId);
     if (routeHandler?.route) {
-      return `_routes/${routeToFsPath(routeHandler.route)}.mjs`;
+      return `_routes/${routeToFsPath(routeHandler.route).replace(/\[([^\]]*)\]/g, "_$1_")}.mjs`;
     }
 
     const taskHandler = Object.entries(nitro.options.tasks).find(

--- a/src/build/chunks.ts
+++ b/src/build/chunks.ts
@@ -78,7 +78,7 @@ export function getChunkName(chunk: { name: string; moduleIds: string[] }, nitro
       .flatMap((h) => h.data)
       .find((h) => h.handler === mainId);
     if (routeHandler?.route) {
-      return `_routes/${routeToFsPath(routeHandler.route).replace(/\[([^\]]*)\]/g, "_$1_")}.mjs`;
+      return `_routes/${routeToFsPath(routeHandler.route).replace(/\[([^\]]*)\]/g, "%5B$1%5D")}.mjs`;
     }
 
     const taskHandler = Object.entries(nitro.options.tasks).find(

--- a/test/unit/chunks.test.ts
+++ b/test/unit/chunks.test.ts
@@ -162,7 +162,7 @@ describe("getChunkName", () => {
       },
     } as any);
     expect(getChunkName(createChunk("route", ["/src/routes/api/users/[id].ts"]), n)).toBe(
-      "_routes/api/users/_id_.mjs"
+      "_routes/api/users/%5Bid%5D.mjs"
     );
   });
 
@@ -185,7 +185,29 @@ describe("getChunkName", () => {
     } as any);
     expect(
       getChunkName(createChunk("route", ["/src/routes/api/applications/[id]/context.get.ts"]), n)
-    ).toBe("_routes/api/applications/_id_/context.mjs");
+    ).toBe("_routes/api/applications/%5Bid%5D/context.mjs");
+  });
+
+  it("dynamic :id and literal _id_ segment produce distinct chunk names (no collision)", () => {
+    const dynamic = createNitro({
+      routing: {
+        routes: {
+          routes: [{ data: [{ route: "/api/:id", handler: "/src/routes/api/[id].ts" }] }],
+        },
+      },
+    } as any);
+    const literal = createNitro({
+      routing: {
+        routes: {
+          routes: [{ data: [{ route: "/api/_id_", handler: "/src/routes/api/_id_.ts" }] }],
+        },
+      },
+    } as any);
+    const dynamicChunk = getChunkName(createChunk("route", ["/src/routes/api/[id].ts"]), dynamic);
+    const literalChunk = getChunkName(createChunk("route", ["/src/routes/api/_id_.ts"]), literal);
+    expect(dynamicChunk).toBe("_routes/api/%5Bid%5D.mjs");
+    expect(literalChunk).toBe("_routes/api/_id_.mjs");
+    expect(dynamicChunk).not.toBe(literalChunk);
   });
 
   it("returns _routes/index.mjs for root route", () => {

--- a/test/unit/chunks.test.ts
+++ b/test/unit/chunks.test.ts
@@ -149,7 +149,7 @@ describe("getChunkName", () => {
     );
   });
 
-  it("returns _routes/<path>.mjs for dynamic route", () => {
+  it("returns _routes/<path>.mjs for dynamic route (brackets escaped for Rollup)", () => {
     const n = createNitro({
       routing: {
         routes: {
@@ -162,8 +162,30 @@ describe("getChunkName", () => {
       },
     } as any);
     expect(getChunkName(createChunk("route", ["/src/routes/api/users/[id].ts"]), n)).toBe(
-      "_routes/api/users/[id].mjs"
+      "_routes/api/users/_id_.mjs"
     );
+  });
+
+  it("returns _routes/<path>.mjs for nested dynamic route (brackets escaped for Rollup)", () => {
+    const n = createNitro({
+      routing: {
+        routes: {
+          routes: [
+            {
+              data: [
+                {
+                  route: "/api/applications/:id/context",
+                  handler: "/src/routes/api/applications/[id]/context.get.ts",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    } as any);
+    expect(
+      getChunkName(createChunk("route", ["/src/routes/api/applications/[id]/context.get.ts"]), n)
+    ).toBe("_routes/api/applications/_id_/context.mjs");
   });
 
   it("returns _routes/index.mjs for root route", () => {


### PR DESCRIPTION
## What

`getChunkName` passes the output of `routeToFsPath` directly as a Rollup `chunkFileNames` pattern. `routeToFsPath` encodes dynamic params as `[id]`, `[...]`, etc., but Rollup interprets `[xxx]` as a placeholder token and rejects any name that contains brackets.

Before this fix, routes with dynamic segments (e.g. `/api/users/:id`) would cause a Rollup error at build time:

```
[rolldown:chunk_filenames] Invalid pattern in `output.chunkFileNames`
```

## How

Replace `[` → `%5B` and `]` → `%5D` using `.replace(/\[([^\]]*)\]/g, "%5B$1%5D")` on the `routeToFsPath` output before it is used as a chunk name.

`%` is never emitted by `routeToFsPath` for literal path segments (it maps non-alphanumeric characters to `_`), so percent-encoded brackets are guaranteed to be in a distinct namespace from any literal segment. This avoids the collision where `/api/:id` and `/api/_id_` would previously both emit `_routes/api/_id_.mjs`.

## Tests

- Updated existing dynamic-route test to expect `%5Bid%5D`
- Added nested dynamic route test (`/api/applications/:id/context`)
- Added explicit collision regression test: asserts `/api/:id` → `_routes/api/%5Bid%5D.mjs` and `/api/_id_` → `_routes/api/_id_.mjs` are not equal