### PR TITLE
fix(vite): respect bun/deno export conditions in dev server

### DIFF
--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -169,9 +169,7 @@ export async function reloadEnvRunner(ctx: NitroPluginContext) {
 }
 
 async function _loadRunner(ctx: NitroPluginContext, manager: RunnerManager) {
-  const runnerName = (ctx.nitro!.options.devServer.runner ||
-    process.env.NITRO_DEV_RUNNER ||
-    "node-worker") as RunnerName;
+  const runnerName = _devRunner(ctx);
   const entry = resolve(runtimeDir, "internal/vite/dev-worker.mjs");
   let runner;
   if (runnerName === "miniflare") {
@@ -193,14 +191,15 @@ async function _loadRunner(ctx: NitroPluginContext, manager: RunnerManager) {
   await manager.reload(runner);
 }
 
-// Resolve export conditions for the (non-workerd) dev/build environment.
-// When the Nitro dev server itself runs under Bun or Deno, prepend the matching
-// runtime condition so packages like `srvx` resolve to their runtime-native
-// adapter (which returns a native `Response`) instead of the `node` adapter,
-// whose `NodeResponse` wrapper is rejected by `Bun.serve`/`Deno.serve`.
+// Resolve export conditions for the (non-workerd) dev environment.
+// With the default `node-worker` runner, the module runner executes in a worker
+// thread of the same host runtime (Bun => Bun, Deno => Deno), so prepend the
+// matching export condition to let packages resolve their runtime-native entry
+// instead of the `node` one. Other runners (process-based or miniflare) run in a
+// different runtime, so the host condition must not leak into their resolution.
 function _devRuntimeConditions(ctx: NitroPluginContext): string[] {
   const exportConditions = ctx.nitro!.options.exportConditions!;
-  if (!ctx.nitro!.options.dev) {
+  if (!ctx.nitro!.options.dev || _devRunner(ctx) !== "node-worker") {
     return exportConditions;
   }
   const runtimeCondition =
@@ -214,12 +213,16 @@ function _devRuntimeConditions(ctx: NitroPluginContext): string[] {
     : exportConditions;
 }
 
+function _devRunner(ctx: NitroPluginContext): RunnerName {
+  return (ctx.nitro!.options.devServer.runner ||
+    process.env.NITRO_DEV_RUNNER ||
+    "node-worker") as RunnerName;
+}
+
 // workerd-based runners (miniflare) cannot handle CJS externals via import(),
 // so all dependencies must be processed through Vite's transform pipeline.
 function _isWorkerdRunner(ctx: NitroPluginContext): boolean {
-  const runnerName =
-    ctx.nitro!.options.devServer.runner || process.env.NITRO_DEV_RUNNER || "node-worker";
-  return runnerName === "miniflare";
+  return _devRunner(ctx) === "miniflare";
 }
 
 function tryResolve(id: string) {

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -35,8 +35,8 @@ export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOpti
       // condition which often resolves to CJS entries.
       conditions: isWorkerdRunner
         ? ["workerd", "worker", ...ctx.nitro!.options.exportConditions!.filter((c) => c !== "node")]
-        : _devRuntimeConditions(ctx),
-      externalConditions: _devRuntimeConditions(ctx).filter((c) => !/browser|wasm|module/.test(c)),
+        : _resolveConditions(ctx),
+      externalConditions: _resolveConditions(ctx).filter((c) => !/browser|wasm|module/.test(c)),
     },
     define: {
       // Workaround for tanstack-start (devtools)
@@ -82,8 +82,8 @@ export function createServiceEnvironment(
       ...(isDev ? { noExternal: isWorkerdRunner ? true : [/^nitro(\/|$)/] } : {}),
       conditions: isWorkerdRunner
         ? ["workerd", "worker", ...ctx.nitro!.options.exportConditions!.filter((c) => c !== "node")]
-        : _devRuntimeConditions(ctx),
-      externalConditions: _devRuntimeConditions(ctx).filter((c) => !/browser|wasm|module/.test(c)),
+        : _resolveConditions(ctx),
+      externalConditions: _resolveConditions(ctx).filter((c) => !/browser|wasm|module/.test(c)),
     },
     dev: {
       createEnvironment: async (envName, envConfig) => {
@@ -187,13 +187,14 @@ async function _loadRunner(ctx: NitroPluginContext, manager: RunnerManager) {
   await manager.reload(runner);
 }
 
-// Resolve export conditions for the (non-workerd) dev environment.
-// With the default `node-worker` runner, the module runner executes in a worker
-// thread of the same host runtime (Bun => Bun, Deno => Deno), so prepend the
-// matching export condition to let packages resolve their runtime-native entry
-// instead of the `node` one. Other runners (process-based or miniflare) run in a
-// different runtime, so the host condition must not leak into their resolution.
-function _devRuntimeConditions(ctx: NitroPluginContext): string[] {
+// Resolve export conditions for the (non-workerd) environment.
+// In dev with the default `node-worker` runner, the module runner executes in a
+// worker thread of the same host runtime (Bun => Bun, Deno => Deno), so prepend
+// the matching export condition to let packages resolve their runtime-native
+// entry instead of the `node` one. Other runners (process-based or miniflare)
+// run in a different runtime, so the host condition must not leak into their
+// resolution; outside of dev the conditions are returned unchanged.
+function _resolveConditions(ctx: NitroPluginContext): string[] {
   const exportConditions = ctx.nitro!.options.exportConditions!;
   if (!ctx.nitro!.options.dev || _devRunner(ctx) !== "node-worker") {
     return exportConditions;

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -35,7 +35,7 @@ export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOpti
       // condition which often resolves to CJS entries.
       conditions: isWorkerdRunner
         ? ["workerd", "worker", ...ctx.nitro!.options.exportConditions!.filter((c) => c !== "node")]
-        : ctx.nitro!.options.exportConditions,
+        : _devRuntimeConditions(ctx),
       externalConditions: ctx.nitro!.options.exportConditions?.filter(
         (c) => !/browser|wasm|module/.test(c)
       ),
@@ -84,7 +84,7 @@ export function createServiceEnvironment(
       ...(isDev ? { noExternal: isWorkerdRunner ? true : [/^nitro(\/|$)/] } : {}),
       conditions: isWorkerdRunner
         ? ["workerd", "worker", ...ctx.nitro!.options.exportConditions!.filter((c) => c !== "node")]
-        : ctx.nitro!.options.exportConditions,
+        : _devRuntimeConditions(ctx),
       externalConditions: ctx.nitro!.options.exportConditions?.filter(
         (c) => !/browser|wasm|module/.test(c)
       ),
@@ -191,6 +191,27 @@ async function _loadRunner(ctx: NitroPluginContext, manager: RunnerManager) {
     });
   }
   await manager.reload(runner);
+}
+
+// Resolve export conditions for the (non-workerd) dev/build environment.
+// When the Nitro dev server itself runs under Bun or Deno, prepend the matching
+// runtime condition so packages like `srvx` resolve to their runtime-native
+// adapter (which returns a native `Response`) instead of the `node` adapter,
+// whose `NodeResponse` wrapper is rejected by `Bun.serve`/`Deno.serve`.
+function _devRuntimeConditions(ctx: NitroPluginContext): string[] {
+  const exportConditions = ctx.nitro!.options.exportConditions!;
+  if (!ctx.nitro!.options.dev) {
+    return exportConditions;
+  }
+  const runtimeCondition =
+    typeof (globalThis as any).Bun !== "undefined"
+      ? "bun"
+      : typeof (globalThis as any).Deno !== "undefined"
+        ? "deno"
+        : undefined;
+  return runtimeCondition && !exportConditions.includes(runtimeCondition)
+    ? [runtimeCondition, ...exportConditions]
+    : exportConditions;
 }
 
 // workerd-based runners (miniflare) cannot handle CJS externals via import(),

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -36,9 +36,7 @@ export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOpti
       conditions: isWorkerdRunner
         ? ["workerd", "worker", ...ctx.nitro!.options.exportConditions!.filter((c) => c !== "node")]
         : _devRuntimeConditions(ctx),
-      externalConditions: ctx.nitro!.options.exportConditions?.filter(
-        (c) => !/browser|wasm|module/.test(c)
-      ),
+      externalConditions: _devRuntimeConditions(ctx).filter((c) => !/browser|wasm|module/.test(c)),
     },
     define: {
       // Workaround for tanstack-start (devtools)
@@ -85,9 +83,7 @@ export function createServiceEnvironment(
       conditions: isWorkerdRunner
         ? ["workerd", "worker", ...ctx.nitro!.options.exportConditions!.filter((c) => c !== "node")]
         : _devRuntimeConditions(ctx),
-      externalConditions: ctx.nitro!.options.exportConditions?.filter(
-        (c) => !/browser|wasm|module/.test(c)
-      ),
+      externalConditions: _devRuntimeConditions(ctx).filter((c) => !/browser|wasm|module/.test(c)),
     },
     dev: {
       createEnvironment: async (envName, envConfig) => {


### PR DESCRIPTION
When the Nitro dev server runs under **Bun** (`bun --bun`) or **Deno**, the Vite module runner resolves the `node` export condition, so packages are loaded through their `node` entry instead of their runtime-native one.

This PR adds `_devRuntimeConditions(ctx)`, used by both the Nitro and service environments, to prepend the host runtime's export condition:

- under Bun → prepend `"bun"`
- under Deno → prepend `"deno"`

### Scope

This only applies in **dev** and only with the default **`node-worker`** runner, where the module runner executes in a worker thread of the *same* host runtime (Bun ⇒ Bun, Deno ⇒ Deno).

Process-based runners (`bun-process`, `deno-process`, `node-process`, …) and `miniflare` execute in a *different* runtime than the host, so the host-detected condition is intentionally **not** applied to them — otherwise it would leak the wrong condition into their resolution.

This is a generic fix to honor `bun`/`deno` export conditions; it is not tied to any single dependency.