### PR TITLE
feat: infer types for serverFetch

### DIFF
--- a/docs/4.examples/server-fetch.md
+++ b/docs/4.examples/server-fetch.md
@@ -41,7 +41,8 @@ export default defineConfig({
 
 ```json [tsconfig.json]
 {
-  "extends": "nitro/tsconfig"
+  "extends": "nitro/tsconfig",
+  "include": ["./node_modules/.nitro/types/nitro.d.ts", "./**/*"]
 }
 ```
 
@@ -59,10 +60,9 @@ export default defineHandler(() => "Hello!");
 ```
 
 ```ts [routes/index.ts]
-import { defineHandler } from "nitro";
-import { fetch } from "nitro";
+import { defineHandler, serverFetch } from "nitro";
 
-export default defineHandler(() => fetch("/hello"));
+export default defineHandler(() => serverFetch("/hello"));
 ```
 
 ::
@@ -71,18 +71,17 @@ export default defineHandler(() => fetch("/hello"));
 
 <!-- automd:file src="../../examples/server-fetch/README.md" -->
 
-When you need one route to call another, use Nitro's `fetch` function instead of the global fetch. It makes internal requests that stay in-process, avoiding network round-trips. The request never leaves the server.
+When you need one route to call another, use Nitro's `serverFetch` function. It makes internal requests that stay in-process, avoiding network round-trips. The request never leaves the server.
 
 ## Main Route
 
 ```ts [routes/index.ts]
-import { defineHandler } from "nitro";
-import { fetch } from "nitro";
+import { defineHandler, serverFetch } from "nitro";
 
-export default defineHandler(() => fetch("/hello"));
+export default defineHandler(() => serverFetch("/hello"));
 ```
 
-The index route imports `fetch` from `nitro` (not the global fetch) and calls the `/hello` route. This request is handled internally without going through the network stack.
+The index route imports `serverFetch` from `nitro` and calls the `/hello` route. This request is handled internally without going through the network stack.
 
 ## Internal API Route
 
@@ -92,9 +91,35 @@ import { defineHandler } from "nitro";
 export default defineHandler(() => "Hello!");
 ```
 
-A simple route that returns "Hello!". When the index route calls `fetch("/hello")`, this handler runs and its response is returned directly.
+A simple route that returns "Hello!". When the index route calls `serverFetch("/hello")`, this handler runs and its response is returned directly.
 
 <!-- /automd -->
+
+## Type Safety
+
+`serverFetch` supports type safety for your generated routes. To enable route types, add `node_modules/.nitro/types/nitro.d.ts` to your `tsconfig.json`:
+
+```json
+{
+  "extends": "nitro/tsconfig",
+  "include": ["./node_modules/.nitro/types/nitro.d.ts", "./**/*"]
+}
+```
+
+Once the generated declarations are included, known paths are autocompleted, the `method` option is narrowed to the methods a route actually handles, and the response body is inferred from the route handler.
+
+In this example, `serverFetch("/hello")` returns a typed response whose JSON body is inferred as `string`:
+
+```ts
+const res = await serverFetch("/hello"); // path autocompleted
+const data = await res.json();           // string
+```
+
+Dynamic paths can also be typed when TypeScript can match them to a generated route pattern.
+
+## `fetch` helper
+
+Nitro also exports a `fetch` helper. It is fetch-compatible and can call relative Nitro routes through the same internal server fetch mechanism, while still supporting regular external requests. Prefer `serverFetch` when you are intentionally calling a known Nitro route and want generated route types. Use `fetch` when the code should keep the broader Fetch API shape, for example when the request target can be either internal or external.
 
 ## Learn More
 

--- a/examples/server-fetch/README.md
+++ b/examples/server-fetch/README.md
@@ -1,15 +1,14 @@
-When you need one route to call another, use Nitro's `fetch` function instead of the global fetch. It makes internal requests that stay in-process, avoiding network round-trips. The request never leaves the server.
+When you need one route to call another, use Nitro's `serverFetch` function. It makes internal requests that stay in-process, avoiding network round-trips. The request never leaves the server.
 
 ## Main Route
 
 ```ts [routes/index.ts]
-import { defineHandler } from "nitro";
-import { fetch } from "nitro";
+import { defineHandler, serverFetch } from "nitro";
 
-export default defineHandler(() => fetch("/hello"));
+export default defineHandler(() => serverFetch("/hello"));
 ```
 
-The index route imports `fetch` from `nitro` (not the global fetch) and calls the `/hello` route. This request is handled internally without going through the network stack.
+The index route imports `serverFetch` from `nitro` and calls the `/hello` route. This request is handled internally without going through the network stack.
 
 ## Internal API Route
 
@@ -19,4 +18,4 @@ import { defineHandler } from "nitro";
 export default defineHandler(() => "Hello!");
 ```
 
-A simple route that returns "Hello!". When the index route calls `fetch("/hello")`, this handler runs and its response is returned directly.
+A simple route that returns "Hello!". When the index route calls `serverFetch("/hello")`, this handler runs and its response is returned directly.

--- a/examples/server-fetch/routes/index.ts
+++ b/examples/server-fetch/routes/index.ts
@@ -1,4 +1,3 @@
-import { defineHandler } from "nitro";
-import { fetch } from "nitro";
+import { defineHandler, serverFetch } from "nitro";
 
-export default defineHandler(() => fetch("/hello"));
+export default defineHandler(() => serverFetch("/hello"));

--- a/examples/server-fetch/tsconfig.json
+++ b/examples/server-fetch/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "nitro/tsconfig"
+  "extends": "nitro/tsconfig",
+  "include": ["./node_modules/.nitro/types/nitro.d.ts", "./**/*"]
 }

--- a/package.json
+++ b/package.json
@@ -62,9 +62,10 @@
     "nitro": "node ./src/cli/index.ts",
     "release": "node ./scripts/release.ts",
     "stub": "obuild --stub",
-    "test": "pnpm lint && pnpm build && pnpm typecheck && pnpm test:rollup && pnpm test:rolldown",
+    "test": "pnpm lint && pnpm build && pnpm typecheck && pnpm test:types && pnpm test:rollup && pnpm test:rolldown",
     "test:rolldown": "NITRO_BUILDER=rolldown pnpm vitest",
     "test:rollup": "NITRO_BUILDER=rollup pnpm vitest",
+    "test:types": "vitest --typecheck.only",
     "typecheck": "tsgo --noEmit --skipLibCheck"
   },
   "dependencies": {
@@ -125,6 +126,7 @@
     "etag": "^1.8.1",
     "execa": "^9.6.1",
     "exsolve": "^1.0.8",
+    "fetchdts": "^0.1.7",
     "get-port-please": "^3.2.0",
     "get-tsconfig": "^4.14.0",
     "giget": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       exsolve:
         specifier: ^1.0.8
         version: 1.1.0
+      fetchdts:
+        specifier: ^0.1.7
+        version: 0.1.7
       get-port-please:
         specifier: ^3.2.0
         version: 3.2.0

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -1,4 +1,4 @@
-import type { MatchedRouteRules, NitroApp, NitroRuntimeHooks } from "nitro/types";
+import type { MatchedRouteRules, NitroApp, NitroRuntimeHooks, ServerFetch } from "nitro/types";
 import type { ServerRequest, ServerRequestContext } from "srvx";
 import type { H3EventContext, Middleware, WebSocketHooks } from "h3";
 import { toRequest } from "h3";
@@ -37,7 +37,7 @@ export function useNitroHooks(): HookableCore<NitroRuntimeHooks> {
   return (nitroApp.hooks = new HookableCore<NitroRuntimeHooks>());
 }
 
-export function serverFetch(
+function serverFetchImpl(
   resource: string | URL | Request,
   init?: RequestInit,
   context?: ServerRequestContext | H3EventContext
@@ -52,9 +52,11 @@ export function serverFetch(
   }
 }
 
+export const serverFetch: ServerFetch = serverFetchImpl;
+
 export async function resolveWebsocketHooks(req: ServerRequest): Promise<Partial<WebSocketHooks>> {
   // https://github.com/h3js/h3/blob/c11ca743d476e583b3b47de1717e6aae92114357/src/utils/ws.ts#L37
-  const hooks = ((await serverFetch(req)) as any).crossws as Partial<WebSocketHooks>;
+  const hooks = ((await serverFetchImpl(req)) as any).crossws as Partial<WebSocketHooks>;
   return hooks || {};
 }
 
@@ -64,7 +66,7 @@ export function fetch(
   context?: ServerRequestContext | H3EventContext
 ): Promise<Response> {
   if (typeof resource === "string" && resource.charCodeAt(0) === 47) {
-    return serverFetch(resource, init, context);
+    return serverFetchImpl(resource, init, context);
   }
   resource = (resource as any)._request || resource; // unwrap srvx request
   return globalThis.fetch(resource, init);

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -1,5 +1,5 @@
 // Config
-import type { NitroConfig } from "nitro/types";
+import type { NitroConfig, ServerFetch } from "nitro/types";
 import type { ServerRequestContext } from "srvx";
 import { toRequest, type H3EventContext } from "h3";
 
@@ -24,7 +24,7 @@ export {
 export type { H3Event, EventHandlerRequest, EventHandlerWithFetch } from "h3";
 
 // Runtime
-export function serverFetch(
+function serverFetchImpl(
   resource: string | URL | Request,
   init?: RequestInit,
   context?: ServerRequestContext | H3EventContext
@@ -45,13 +45,15 @@ export function serverFetch(
   }
 }
 
+export const serverFetch: ServerFetch = serverFetchImpl;
+
 export function fetch(
   resource: string | URL | Request,
   init?: RequestInit,
   context?: ServerRequestContext | H3EventContext
 ): Promise<Response> {
   if (typeof resource === "string" && resource.charCodeAt(0) === 47) {
-    return serverFetch(resource, init, context);
+    return serverFetchImpl(resource, init, context);
   }
   resource = (resource as any)._request || resource; // unwrap srvx request
   return globalThis.fetch(resource, init);

--- a/src/types/fetch/fetch.ts
+++ b/src/types/fetch/fetch.ts
@@ -1,4 +1,7 @@
 import type { HTTPMethod } from "h3";
+import type { TypedResponse } from "fetchdts";
+import type { ServerRequestContext } from "srvx";
+import type { H3EventContext } from "h3";
 import type { FetchOptions, FetchRequest, FetchResponse } from "ofetch";
 import type { MatchedRoutes } from "./_match.ts";
 
@@ -56,13 +59,10 @@ export interface NitroFetchOptions<
 }
 
 // Extract the route method from options which might be undefined or without a method parameter.
-export type ExtractedRouteMethod<
-  R extends NitroFetchRequest,
-  O extends NitroFetchOptions<R>,
-> = O extends undefined
+export type ExtractedRouteMethod<O extends { method?: unknown }> = O extends undefined
   ? "get"
-  : Lowercase<Exclude<O["method"], undefined>> extends RouterMethod
-    ? Lowercase<Exclude<O["method"], undefined>>
+  : Lowercase<Extract<O["method"], string>> extends RouterMethod
+    ? Lowercase<Extract<O["method"], string>>
     : "get";
 
 export type Base$Fetch<
@@ -76,7 +76,7 @@ export type Base$Fetch<
   request: R,
   opts?: O
 ) => Promise<
-  TypedInternalResponse<R, T, NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<R, O>>
+  TypedInternalResponse<R, T, NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<O>>
 >;
 
 export interface $Fetch<
@@ -92,17 +92,34 @@ export interface $Fetch<
     opts?: O
   ): Promise<
     FetchResponse<
-      TypedInternalResponse<
-        R,
-        T,
-        NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<R, O>
-      >
+      TypedInternalResponse<R, T, NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<O>>
     >
   >;
   create<T = DefaultT, R extends NitroFetchRequest = DefaultR>(
     defaults: FetchOptions
   ): $Fetch<T, R>;
 }
+
+export type ServerFetchInit<
+  R extends NitroFetchRequest,
+  M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>,
+> = Omit<RequestInit, "method"> & {
+  method?: Uppercase<M>;
+};
+
+export type ServerFetch = <
+  R extends NitroFetchRequest = NitroFetchRequest,
+  O extends ServerFetchInit<R> = ServerFetchInit<R>,
+  T = unknown,
+>(
+  resource: R,
+  init?: O,
+  context?: ServerRequestContext | H3EventContext
+) => Promise<
+  TypedResponse<
+    TypedInternalResponse<R, T, ServerFetchInit<R> extends O ? "get" : ExtractedRouteMethod<O>>
+  >
+>;
 
 // eslint-disable-next-line unicorn/require-module-specifiers
 export type {};

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.test-d.ts"],
+  "exclude": []
+}

--- a/test/unit/server-fetch-types.test-d.ts
+++ b/test/unit/server-fetch-types.test-d.ts
@@ -1,0 +1,30 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { serverFetch } from "nitro";
+import type { ServerFetchInit } from "nitro/types";
+import "../fixture/node_modules/.nitro/types/nitro.d.ts";
+
+describe("serverFetch types", () => {
+  it("infers response json from generated fixture routes", async () => {
+    const hello = await serverFetch("/api/hello");
+    expectTypeOf(await hello.json()).toEqualTypeOf<{ message: string }>();
+
+    const hey = await serverFetch("/api/hey", { method: "GET" });
+    expectTypeOf(await hey.json()).toEqualTypeOf<string>();
+
+    const upload = await serverFetch("/api/upload", { method: "POST" });
+    expectTypeOf(await upload.json()).toEqualTypeOf<string>();
+
+    const unknown = await serverFetch("/unknown-resource");
+    expectTypeOf(await unknown.json()).toEqualTypeOf<unknown>();
+  });
+
+  it("narrows ServerFetchInit methods to generated fixture routes", () => {
+    expectTypeOf({ method: "POST" } as const).toExtend<ServerFetchInit<"/api/upload">>();
+    expectTypeOf({ method: "GET" } as const).not.toExtend<ServerFetchInit<"/api/upload">>();
+  });
+
+  it("narrows methods to those available on generated fixture routes", async () => {
+    // @ts-expect-error GET is not available for this known POST-only route.
+    await serverFetch("/api/upload", { method: "GET" });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
   "exclude": [
     "examples/import-alias/**",
     "examples/vite-rsc/**",
+    "test/**/*.test-d.ts",
     "test/fixture/server/routes/jsx.tsx",
     "examples/vite-ssr-html/vite.config.ts",
     "examples/vite-ssr-solid/src/entry-server.tsx",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,9 @@ export default defineConfig({
       include: ["src/**/*.ts", "!src/types/**/*.ts"],
     },
     include: ["test/**/*.test.ts"],
+    typecheck: {
+      ignoreSourceErrors: true,
+      tsconfig: "test/tsconfig.json",
+    },
   },
 });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Partially addresses #2758

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds generated-route type inference for `serverFetch`.

`serverFetch` now uses the generated Nitro route declarations to infer response JSON types for known routes and narrow the `method` option to methods supported by the matched route. Unknown routes still fall back to `unknown`, preserving compatibility for dynamic or untyped paths.

This is intended to be runtime-compatible, but it may expose type-level incompatibilities in code that relied on overly broad `serverFetch` inputs. In particular, known routes now narrow accepted methods to the methods declared by the route, and `URL`/`Request` are no longer part of the typed `serverFetch` request input.

The PR also adds Vitest type tests covering response inference, method narrowing, and unknown-route fallback against the existing test fixture app.

Documentation and the `server-fetch` example were updated to use `serverFetch` as the recommended API for internal server-to-server route calls. A separate note documents the exported `fetch` helper as a broader fetch-compatible API that can still use the internal server fetch mechanism for relative Nitro routes, while keeping `serverFetch` as the typed route-aware API.

Typed `fetch`/`$fetch`, route input typing, and serialization-related improvements remain follow-up work for #2758.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
