### PR TITLE
feat(cache): warn when recompute is cheaper than cache retrieval

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -40,6 +40,8 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   return _defineCachedFunction(fn, {
     group: "nitro/functions",
     onError: defaultOnError,
+    // Warn in dev when caching a value costs more than recomputing it (#2559).
+    warnWhenSlower: import.meta.dev,
     ...opts,
   });
 }
@@ -52,6 +54,7 @@ export function defineCachedHandler(
   const ocacheHandler = _defineCachedHandler(handler as any, {
     group: "nitro/handlers",
     onError: defaultOnError,
+    warnWhenSlower: import.meta.dev,
     toResponse: (value, event) => toResponse(value, event as H3Event),
     createResponse: (body, init) => new FastResponse(body, init),
     handleCacheHeaders: (event, conditions) => handleCacheHeaders(event as H3Event, conditions),

--- a/test/unit/cache.test.ts
+++ b/test/unit/cache.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the options Nitro forwards to ocache.
+const { setStorage, captured } = vi.hoisted(() => {
+  const captured: { fnOpts?: any; handlerOpts?: any } = {};
+  return {
+    captured,
+    setStorage: vi.fn(),
+  };
+});
+
+vi.mock("ocache", () => ({
+  setStorage,
+  defineCachedFunction: (_fn: any, opts: any) => {
+    captured.fnOpts = opts;
+    return _fn;
+  },
+  defineCachedHandler: (handler: any, opts: any) => {
+    captured.handlerOpts = opts;
+    return handler;
+  },
+}));
+
+vi.mock("../../src/runtime/internal/storage.ts", () => ({
+  useStorage: () => ({ getItem: vi.fn(), setItem: vi.fn() }),
+}));
+vi.mock("../../src/runtime/internal/app.ts", () => ({
+  useNitroApp: () => ({ captureError: vi.fn() }),
+}));
+
+import { defineCachedFunction, defineCachedHandler } from "../../src/runtime/internal/cache.ts";
+
+beforeEach(() => {
+  captured.fnOpts = undefined;
+  captured.handlerOpts = undefined;
+});
+
+describe("runtime cache", () => {
+  it("enables ocache's warnWhenSlower in dev for cached functions", () => {
+    defineCachedFunction(() => 0);
+    // `import.meta.dev` is defined as true in vitest.config.ts.
+    expect(captured.fnOpts.warnWhenSlower).toBe(true);
+    expect(captured.fnOpts.group).toBe("nitro/functions");
+    expect(typeof captured.fnOpts.onError).toBe("function");
+  });
+
+  it("enables ocache's warnWhenSlower in dev for cached handlers", () => {
+    defineCachedHandler(() => "ok");
+    expect(captured.handlerOpts.warnWhenSlower).toBe(true);
+    expect(captured.handlerOpts.group).toBe("nitro/handlers");
+  });
+
+  it("lets user options override warnWhenSlower", () => {
+    defineCachedFunction(() => 0, { warnWhenSlower: false });
+    expect(captured.fnOpts.warnWhenSlower).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 process.env.NODE_ENV = "production";
 
 export default defineConfig({
+  define: { "import.meta.dev": "true" },
   test: {
     testTimeout: 30_000,
     coverage: {


### PR DESCRIPTION

### 🔗 Linked issue

Closes #2559

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`cachedEventHandler` / `cachedFunction` can be slower than the code they cache when the value is cheap to compute — the store/retrieve round-trip (and JSON (de)serialization) costs more than just recomputing it (see #2558).

This adds a **dev-only** warning to surface that. At the storage layer we measure, per cache:
- **retrieval time** — the duration of a hit `getItem`, and
- **recompute time** — the interval from a miss to its following `setItem`.

When median recompute is cheaper than median retrieval, we log a single warning suggesting the cache may be adding overhead.

Notes:
- Gated behind `import.meta.dev`, so the whole path is tree-shaken out of production builds.
- The user function is **not wrapped**, so ocache's integrity hash (used to invalidate on code edits) is unchanged and production behavior is identical.
- Warns at most once per cache; per-key tracking is bounded (256 keys) to cap dev memory.

Tested with unit tests covering the warn / no-warn / threshold / warn-once cases, plus a regression guard that the function reaches ocache unwrapped. Full suite passes on both the rollup and rolldown builders.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.