### PR TITLE
Fix Deno dev-server crash: reconstruct Response in host realm

### DIFF
--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -50,7 +50,14 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
       if (response.status === 503 && !this.#manager.ready) {
         return this.#generateError();
       }
-      return response;
+      // Reconstruct in the current realm so runtime-native instanceof checks pass.
+      // The worker bridge returns an undici Response; runtimes like Deno reject it
+      // because it was not constructed by their own Response constructor.
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: new Headers(response.headers),
+      });
     });
 
     // Bind all methods to `this`


### PR DESCRIPTION
Fixes #4390

## Problem

Nitro's Vite dev server crashes under Deno with:
```
TypeError: Return value from serve handler must be a Response constructed via the Response constructor in this realm
```

The `catchAllHandler` in `src/dev/server.ts` calls `this.#manager.fetch(req)`, which goes through `httpxy.proxyFetch`. That builds its `Response` using undici's `Response` class. `Deno.serve` performs a native V8 realm check and rejects any `Response` not constructed by Deno's own `Response` constructor. Node's HTTP stack doesn't do this check, so the bug only surfaces in Deno dev.

## Fix

Wrap the proxied response in `new Response(...)` before returning it, so whichever runtime's global constructor is invoked:

```diff
- return response;
+ return new Response(response.body, {
+   status: response.status,
+   statusText: response.statusText,
+   headers: new Headers(response.headers),
+ });
```

`response.body` is a `ReadableStream` and is safely transferable across realm boundaries. This fix is a no-op on Node and Bun (their constructors accept the same arguments) and resolves the realm mismatch on Deno.

1 file, 4 lines.