### PR TITLE
fix(vercel): correct ISR route rewrite query preservation and decoding

### DIFF
--- a/src/presets/vercel/runtime/isr.ts
+++ b/src/presets/vercel/runtime/isr.ts
@@ -5,34 +5,21 @@ export function isrRouteRewrite(
   xNowRouteMatches: string | null
 ): [pathname: string, search: string] | undefined {
   const queryIndex = reqUrl.indexOf("?");
-  if (xNowRouteMatches) {
-    const matches = new URLSearchParams(xNowRouteMatches);
-    const isrURL = matches.get(ISR_URL_PARAM);
-    if (isrURL) {
-      // Rebuild the query from both `x-now-route-matches` and the rewritten
-      // request URL, skipping the ISR routing param and Vercel's numeric
-      // regex-capture groups (`0`, `1`, ...). Without this, `allowQuery`
-      // params (e.g. `?lang`) are dropped and the ISR cache stores the
-      // bare-path document under the query-keyed entry.
-      const sources =
-        queryIndex === -1
-          ? [matches]
-          : [matches, new URLSearchParams(reqUrl.slice(queryIndex + 1))];
-      const params = new URLSearchParams();
-      for (const source of sources) {
-        for (const [key, value] of source) {
-          if (key === ISR_URL_PARAM || /^\d+$/.test(key)) continue;
-          if (!params.has(key)) params.set(key, value);
-        }
-      }
-      return [decodeURIComponent(isrURL), params.toString()];
-    }
-  } else if (queryIndex !== -1) {
-    const reqParams = new URLSearchParams(reqUrl.slice(queryIndex + 1));
-    const isrURL = reqParams.get(ISR_URL_PARAM);
-    if (isrURL) {
-      reqParams.delete(ISR_URL_PARAM);
-      return [decodeURIComponent(isrURL), reqParams.toString()];
-    }
-  }
+  const reqParams =
+    queryIndex === -1 ? new URLSearchParams() : new URLSearchParams(reqUrl.slice(queryIndex + 1));
+
+  // The ISR routing param is carried by `x-now-route-matches` when Vercel
+  // rewrites via the route regex, otherwise it lives on the request URL.
+  const isrURL = xNowRouteMatches
+    ? new URLSearchParams(xNowRouteMatches).get(ISR_URL_PARAM)
+    : reqParams.get(ISR_URL_PARAM);
+  if (!isrURL) return;
+
+  // Preserve `allowQuery` params, which Vercel forwards onto the rewritten
+  // request URL. `x-now-route-matches` is intentionally not merged in: it
+  // carries the route regex capture groups (named like `slug`, numeric like
+  // `0`), not user query, and merging them would pollute the render and the
+  // shared ISR cache entry.
+  reqParams.delete(ISR_URL_PARAM);
+  return [decodeURIComponent(isrURL), reqParams.toString()];
 }

--- a/src/presets/vercel/runtime/isr.ts
+++ b/src/presets/vercel/runtime/isr.ts
@@ -10,6 +10,8 @@ export function isrRouteRewrite(
 
   // The ISR routing param is carried by `x-now-route-matches` when Vercel
   // rewrites via the route regex, otherwise it lives on the request URL.
+  // `URLSearchParams` already percent-decodes the value once; decoding again
+  // would over-decode encoded slugs and throw `URIError` on a literal `%`.
   const isrURL = xNowRouteMatches
     ? new URLSearchParams(xNowRouteMatches).get(ISR_URL_PARAM)
     : reqParams.get(ISR_URL_PARAM);
@@ -21,5 +23,5 @@ export function isrRouteRewrite(
   // `0`), not user query, and merging them would pollute the render and the
   // shared ISR cache entry.
   reqParams.delete(ISR_URL_PARAM);
-  return [decodeURIComponent(isrURL), reqParams.toString()];
+  return [isrURL, reqParams.toString()];
 }

--- a/src/presets/vercel/runtime/isr.ts
+++ b/src/presets/vercel/runtime/isr.ts
@@ -4,20 +4,35 @@ export function isrRouteRewrite(
   reqUrl: string,
   xNowRouteMatches: string | null
 ): [pathname: string, search: string] | undefined {
+  const queryIndex = reqUrl.indexOf("?");
   if (xNowRouteMatches) {
-    const isrURL = new URLSearchParams(xNowRouteMatches).get(ISR_URL_PARAM);
+    const matches = new URLSearchParams(xNowRouteMatches);
+    const isrURL = matches.get(ISR_URL_PARAM);
     if (isrURL) {
-      return [decodeURIComponent(isrURL), ""];
-    }
-  } else {
-    const queryIndex = reqUrl.indexOf("?");
-    if (queryIndex !== -1) {
-      const params = new URLSearchParams(reqUrl.slice(queryIndex + 1));
-      const isrURL = params.get(ISR_URL_PARAM);
-      if (isrURL) {
-        params.delete(ISR_URL_PARAM);
-        return [decodeURIComponent(isrURL), params.toString()];
+      // Rebuild the query from both `x-now-route-matches` and the rewritten
+      // request URL, skipping the ISR routing param and Vercel's numeric
+      // regex-capture groups (`0`, `1`, ...). Without this, `allowQuery`
+      // params (e.g. `?lang`) are dropped and the ISR cache stores the
+      // bare-path document under the query-keyed entry.
+      const sources =
+        queryIndex === -1
+          ? [matches]
+          : [matches, new URLSearchParams(reqUrl.slice(queryIndex + 1))];
+      const params = new URLSearchParams();
+      for (const source of sources) {
+        for (const [key, value] of source) {
+          if (key === ISR_URL_PARAM || /^\d+$/.test(key)) continue;
+          if (!params.has(key)) params.set(key, value);
+        }
       }
+      return [decodeURIComponent(isrURL), params.toString()];
+    }
+  } else if (queryIndex !== -1) {
+    const reqParams = new URLSearchParams(reqUrl.slice(queryIndex + 1));
+    const isrURL = reqParams.get(ISR_URL_PARAM);
+    if (isrURL) {
+      reqParams.delete(ISR_URL_PARAM);
+      return [decodeURIComponent(isrURL), reqParams.toString()];
     }
   }
 }

--- a/test/unit/vercel-isr.test.ts
+++ b/test/unit/vercel-isr.test.ts
@@ -46,5 +46,24 @@ describe("isrRouteRewrite", () => {
         )
       ).toEqual(["/posts/hello", "lang=es"]);
     });
+
+    // Regression: named route capture groups (e.g. `slug` for `/posts/:slug`)
+    // are emitted by normalizeRouteSrc and echoed in `x-now-route-matches`.
+    // They must not leak into the preserved query.
+    it("skips Vercel named regex-capture groups", () => {
+      expect(
+        isrRouteRewrite(
+          "/posts/hello-isr?__isr_route=%2Fposts%2Fhello&lang=es",
+          "slug=hello&__isr_route=%2Fposts%2Fhello&lang=es"
+        )
+      ).toEqual(["/posts/hello", "lang=es"]);
+    });
+
+    it("preserves repeated (array-style) query params", () => {
+      expect(isrRouteRewrite("/index-isr?__isr_route=%2F&tag=a&tag=b", "__isr_route=%2F")).toEqual([
+        "/",
+        "tag=a&tag=b",
+      ]);
+    });
   });
 });

--- a/test/unit/vercel-isr.test.ts
+++ b/test/unit/vercel-isr.test.ts
@@ -66,4 +66,33 @@ describe("isrRouteRewrite", () => {
       ]);
     });
   });
+
+  // Regression: the routing param is already percent-decoded once by
+  // `URLSearchParams`, so it must NOT be decoded a second time. A redundant
+  // `decodeURIComponent` over-decodes encoded slugs and throws `URIError` on a
+  // literal `%` (e.g. `/posts/100%off`), crashing the function.
+  describe("percent-encoded routes are decoded exactly once", () => {
+    it("does not throw on a route containing a literal percent", () => {
+      // Vercel delivers slug `100%off` as `__isr_route=%2Fposts%2F100%25off`.
+      expect(isrRouteRewrite("/x?__isr_route=%2Fposts%2F100%25off", null)).toEqual([
+        "/posts/100%off",
+        "",
+      ]);
+    });
+
+    it("does not over-decode an encoded sequence in the route", () => {
+      // Slug `a%2520b` arrives as `__isr_route=%2Fposts%2Fa%252520b`.
+      expect(isrRouteRewrite("/x?__isr_route=%2Fposts%2Fa%252520b", null)).toEqual([
+        "/posts/a%2520b",
+        "",
+      ]);
+    });
+
+    it("decodes the header branch exactly once too", () => {
+      expect(isrRouteRewrite("/x", "__isr_route=%2Fposts%2F100%25off")).toEqual([
+        "/posts/100%off",
+        "",
+      ]);
+    });
+  });
 });

--- a/test/unit/vercel-isr.test.ts
+++ b/test/unit/vercel-isr.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isrRouteRewrite } from "../../src/presets/vercel/runtime/isr.ts";
+
+describe("isrRouteRewrite", () => {
+  it("returns undefined when there is no ISR routing param", () => {
+    expect(isrRouteRewrite("/index-isr", null)).toBeUndefined();
+    expect(isrRouteRewrite("/index-isr?foo=bar", null)).toBeUndefined();
+    expect(isrRouteRewrite("/index-isr", "foo=bar")).toBeUndefined();
+  });
+
+  describe("header-less branch (query on request URL)", () => {
+    it("rewrites to the ISR route and drops the routing param", () => {
+      expect(isrRouteRewrite("/index-isr?__isr_route=%2F", null)).toEqual(["/", ""]);
+    });
+
+    it("preserves other query params", () => {
+      expect(isrRouteRewrite("/index-isr?__isr_route=%2F&lang=es", null)).toEqual(["/", "lang=es"]);
+    });
+  });
+
+  describe("x-now-route-matches branch", () => {
+    it("rewrites to the ISR route", () => {
+      expect(isrRouteRewrite("/index-isr?__isr_route=%2F", "__isr_route=%2F")).toEqual(["/", ""]);
+    });
+
+    // Regression: https://github.com/nitrojs/nitro/issues/4408
+    // The query string (allowQuery/passQuery params) must reach the render.
+    it("preserves allowQuery params from x-now-route-matches", () => {
+      expect(
+        isrRouteRewrite("/index-isr?__isr_route=%2F&lang=es", "__isr_route=%2F&lang=es")
+      ).toEqual(["/", "lang=es"]);
+    });
+
+    it("preserves allowQuery params from the request URL", () => {
+      expect(isrRouteRewrite("/index-isr?__isr_route=%2F&lang=es", "__isr_route=%2F")).toEqual([
+        "/",
+        "lang=es",
+      ]);
+    });
+
+    it("skips Vercel numeric regex-capture groups", () => {
+      expect(
+        isrRouteRewrite(
+          "/posts/hello-isr?__isr_route=%2Fposts%2Fhello&lang=es",
+          "0=%2Fposts%2Fhello&__isr_route=%2Fposts%2Fhello&lang=es"
+        )
+      ).toEqual(["/posts/hello", "lang=es"]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #4408

This PR fixes two bugs in the Vercel ISR route rewrite (`isrRouteRewrite`), both verified end-to-end on a live Vercel deployment.

## Bug 1 — dropped query string (#4408)

`isrRouteRewrite` handled its two branches asymmetrically. The `x-now-route-matches` branch — the path taken for Vercel prerender-function invocations — returned an **empty** query string, discarding every `allowQuery`/`passQuery` param:

```ts
if (xNowRouteMatches) {
  const isrURL = new URLSearchParams(xNowRouteMatches).get(ISR_URL_PARAM);
  if (isrURL) {
    return [decodeURIComponent(isrURL), ""]; // ← whole query dropped
  }
}
```

The header-less branch already preserved the query (deleting only `__isr_route`). So with a rule like `{ isr: { allowQuery: ["lang"], passQuery: true } }`, Vercel correctly keys the cache by `?lang` and forwards the query to the function, but the runtime threw it away — SSR rendered the bare path and the ISR cache stored that document under the query-keyed entry (e.g. English HTML served/cached at `?lang=es`).

### Fix

Source the preserved query **solely from the rewritten request URL** (dropping only `__isr_route`), and use `x-now-route-matches` only to read the ISR routing param.

`allowQuery`/`passQuery` params are forwarded by Vercel onto the rewritten request URL, so the request URL is the authoritative source. `x-now-route-matches` is intentionally **not** merged into the query: it carries the route regex capture groups — named (e.g. `slug` for `/posts/:slug`, generated by `normalizeRouteSrc`) as well as numeric (`0`, `1`, …) — which are routing internals, not user query. Merging them would leak `?slug=…` into the render and pollute the shared ISR cache entry.

This keeps both branches consistent and, as a side effect, preserves repeated (array-style) query params and never lets a header value override a real request-URL param.

## Bug 2 — route param decoded twice (crash on `%`)

`URLSearchParams.get()` already percent-decodes the ISR routing param once. The extra `decodeURIComponent(isrURL)` decoded it a **second time**:

- A slug containing a literal `%` (e.g. `/posts/100%off`) → after the first decode the string contains a bare `%`, and the second `decodeURIComponent` throws `URIError: URI malformed` → the function **crashes with a 400** (`FUNCTION_INVOCATION_FAILED`).
- A slug containing an encoded sequence (e.g. `a%2520b`) → silently **over-decoded** to `a%20b`, so ISR renders and caches under the wrong path.

This is masked for plain-ASCII paths (the once-decoded value has no `%`, so the second decode is a no-op), which is why it went unnoticed. It is pre-existing — the original header-less branch already double-decoded — and independent of #4408.

### Fix

Drop the redundant `decodeURIComponent`; the `URLSearchParams` decode is exactly the right amount.

## Testing

Added `test/unit/vercel-isr.test.ts` (12 cases). Query-preservation cases fail on `main`; the double-decode cases fail on `main` with `URIError: URI malformed`. Coverage:

- header-less and header branches drop `__isr_route` and preserve other params
- Vercel **numeric** (`0`) and **named** (`slug`) regex-capture groups are not leaked
- repeated (array-style) query params are preserved
- ISR route param is percent-decoded exactly once (literal `%`, encoded sequences, both branches)

### End-to-end (live Vercel)

Built the `playground/` app with an ISR route and deployed via `vercel deploy --prebuilt`:

- `/?lang=es` → renders **Hola** and caches under the `?lang=es` entry (`/` still renders **Hello**) — confirms Bug 1 fixed and no cross-entry cache pollution. Non-`allowQuery` params (`?foo=bar`) are correctly stripped.
- `/posts/100%25off` → **200** with the after fix (was **400** before), and encoded paths (`a%2520b`, `caf%C3%A9`, `hello%20world`) now match non-ISR behaviour — confirms Bug 2 fixed.

Credit to the reporter of #4408 for the diagnosis and original patch.
