### PR TITLE
fix(runtime): harden routeRules proxy path normalization to keep wildcard scope

### DIFF
--- a/src/runtime/internal/route-rules.ts
+++ b/src/runtime/internal/route-rules.ts
@@ -5,9 +5,9 @@ import {
   requireBasicAuth,
   resolveDotSegments,
 } from "h3";
-import type { BasicAuthOptions, EventHandler, Middleware } from "h3";
+import type { BasicAuthOptions, EventHandler, H3Event, Middleware } from "h3";
 import type { MatchedRouteRule, NitroRouteRules } from "nitro/types";
-import { joinURL, withQuery, withoutBase } from "ufo";
+import { joinURL, parseURL, withQuery, withoutBase } from "ufo";
 import { defineCachedHandler } from "./cache.ts";
 
 // Note: Remember to update RuntimeRouteRules in src/build/virtual/routing.ts when adding new route rules
@@ -32,23 +32,7 @@ export const redirect: RouteRuleCtor<"redirect"> = ((m) =>
       return;
     }
     if (target.endsWith("/**")) {
-      // Forward `event.url.pathname`: encoded separators (`%2f`/`%5c`) stay
-      // opaque, so the target receives the original separators and resolves the
-      // resource the client requested — like nginx `proxy_pass $request_uri`,
-      // not the path-decoding `proxy_pass <uri>/` form. The scope check below
-      // canonicalizes (decodes `%2f`/`%5c`, resolves `..`) to reject traversal
-      // that only surfaces once the downstream decodes those separators.
-      let targetPath = event.url.pathname + event.url.search;
-      const strpBase = (m.options as any)._redirectStripBase;
-      if (strpBase) {
-        if (!isPathInScope(event.url.pathname, strpBase)) {
-          throw new HTTPError({ status: 400 });
-        }
-        targetPath = withoutBase(targetPath, strpBase);
-      } else if (targetPath.startsWith("//")) {
-        targetPath = targetPath.replace(/^\/+/, "/");
-      }
-      target = joinURL(target.slice(0, -3), targetPath);
+      target = resolveWildcardTarget(event, target, (m.options as any)._redirectStripBase);
     } else if (event.url.search) {
       target = withQuery(target, Object.fromEntries(event.url.searchParams));
     }
@@ -63,23 +47,7 @@ export const proxy: RouteRuleCtor<"proxy"> = ((m) =>
       return;
     }
     if (target.endsWith("/**")) {
-      // Forward `event.url.pathname`: encoded separators (`%2f`/`%5c`) stay
-      // opaque, so the upstream receives the original separators and resolves
-      // the resource the client requested — like nginx `proxy_pass $request_uri`,
-      // not the path-decoding `proxy_pass <uri>/` form. The scope check below
-      // canonicalizes (decodes `%2f`/`%5c`, resolves `..`) to reject traversal
-      // that only surfaces once the upstream decodes those separators.
-      let targetPath = event.url.pathname + event.url.search;
-      const strpBase = (m.options as any)._proxyStripBase;
-      if (strpBase) {
-        if (!isPathInScope(event.url.pathname, strpBase)) {
-          throw new HTTPError({ status: 400 });
-        }
-        targetPath = withoutBase(targetPath, strpBase);
-      } else if (targetPath.startsWith("//")) {
-        targetPath = targetPath.replace(/^\/+/, "/");
-      }
-      target = joinURL(target.slice(0, -3), targetPath);
+      target = resolveWildcardTarget(event, target, (m.options as any)._proxyStripBase);
     } else if (event.url.search) {
       target = withQuery(target, Object.fromEntries(event.url.searchParams));
     }
@@ -149,4 +117,39 @@ export function isPathInScope(pathname: string, base: string): boolean {
 
 function isCanonicalInScope(canonical: string, base: string): boolean {
   return !base || canonical === base || canonical.startsWith(base + "/");
+}
+
+// Resolve a `/**` wildcard proxy/redirect `to`: append the matched remainder to
+// the target base and enforce that the resolved upstream path stays within that
+// base. Encoded separators (`%2f`/`%5c`) are forwarded opaque — like nginx
+// `proxy_pass $request_uri`, not the path-decoding `proxy_pass <uri>/` form — so
+// the upstream resolves the resource the client requested.
+//
+// Scope is enforced on the *final* target, not just the incoming path: the
+// remainder is appended (which collapses `//`, empty and `/.` segments) and only
+// then canonicalized (decode `%2f`/`%5c`, resolve `..`). Checking the bytes we
+// actually forward closes the gap where semantically equivalent inputs (repeated
+// or leading slashes, `/./`, mixed-case or double-encoded separators) normalize
+// differently before vs. after the remainder is joined to the base.
+export function resolveWildcardTarget(event: H3Event, to: string, stripBase?: string): string {
+  const baseTarget = to.slice(0, -3); // drop the trailing "/**"
+  let remainder = event.url.pathname + event.url.search;
+  if (stripBase) {
+    // Reject requests that escape the matched rule scope before stripping (also
+    // guards the naive prefix strip against sibling prefixes like `/ordersX`).
+    if (!isPathInScope(event.url.pathname, stripBase)) {
+      throw new HTTPError({ status: 400 });
+    }
+    remainder = withoutBase(remainder, stripBase);
+  }
+  const target = joinURL(baseTarget, remainder);
+  // Base path of the `to` (the part before `/**`); `/` means an unscoped root.
+  let basePath = parseURL(baseTarget).pathname;
+  if (basePath.endsWith("/")) {
+    basePath = basePath.slice(0, -1);
+  }
+  if (!isPathInScope(parseURL(target).pathname, basePath)) {
+    throw new HTTPError({ status: 400 });
+  }
+  return target;
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -679,6 +679,22 @@ export function testNitro(
     expect(data).toBe("a%2fb");
   });
 
+  it("runtime proxy keeps wildcard scope against encoded traversal", async () => {
+    // Hardening: encoded traversal in the wildcard remainder must not escape the
+    // configured upstream base once a downstream decodes it — in any equivalent
+    // path shape. The request is rejected before the upstream is contacted.
+    for (const url of [
+      "/rules/proxy/legacy/..%2fadmin", // single slash
+      "/rules/proxy/legacy//..%2fadmin", // doubled slash
+      "/rules/proxy/legacy/..%2Fadmin", // mixed-case %2F
+      "/rules/proxy/legacy//..%252fadmin", // doubled + double-encoded
+    ]) {
+      const { status, data } = await callHandler({ url });
+      expect(status).toBe(400);
+      expect(data).not.toBe("admin");
+    }
+  });
+
   it("external proxy", async () => {
     const { data, headers, status } = await callHandler({
       url: "/cdn/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js",

--- a/test/unit/route-rules.test.ts
+++ b/test/unit/route-rules.test.ts
@@ -135,7 +135,10 @@ describe("resolveWildcardTarget", () => {
     try {
       resolve(rawPath);
     } catch (error: any) {
-      return error?.status === 400;
+      if (error?.status === 400) {
+        return true;
+      }
+      throw error; // surface unexpected failures instead of reporting "not blocked"
     }
     return false;
   };

--- a/test/unit/route-rules.test.ts
+++ b/test/unit/route-rules.test.ts
@@ -1,6 +1,11 @@
+import type { H3Event } from "h3";
 import { describe, expect, it } from "vitest";
 import { normalizeRouteRules } from "../../src/config/resolvers/route-rules.ts";
-import { canonicalPath, isPathInScope } from "../../src/runtime/internal/route-rules.ts";
+import {
+  canonicalPath,
+  isPathInScope,
+  resolveWildcardTarget,
+} from "../../src/runtime/internal/route-rules.ts";
 
 describe("normalizeRouteRules - swr", () => {
   it("swr: true enables SWR", () => {
@@ -113,5 +118,64 @@ describe("canonicalPath", () => {
 
   it("keeps non-separator reserved encodings opaque", () => {
     expect(canonicalPath("/a%3Ab")).toBe("/a%3Ab");
+  });
+});
+
+// Hardening: a `/**` proxy/redirect target must keep the forwarded upstream
+// request within the configured upstream base, regardless of how the incoming
+// path is shaped (repeated/leading slashes, `/./`, mixed-case or double-encoded
+// separators). The scope check runs on the final resolved target, so equivalent
+// inputs cannot diverge from what actually gets forwarded.
+describe("resolveWildcardTarget", () => {
+  const to = "http://upstream/orders/**";
+  const base = "/api/orders";
+  const evt = (rawPath: string) => ({ url: new URL("http://localhost" + rawPath) }) as H3Event;
+  const resolve = (rawPath: string) => resolveWildcardTarget(evt(rawPath), to, base);
+  const blocked = (rawPath: string) => {
+    try {
+      resolve(rawPath);
+    } catch (error: any) {
+      return error?.status === 400;
+    }
+    return false;
+  };
+
+  it("forwards benign in-scope requests unchanged", () => {
+    expect(resolve("/api/orders/list.json")).toBe("http://upstream/orders/list.json");
+    expect(new URL(resolve("/api/orders/123?x=1")).pathname).toBe("/orders/123");
+    // an encoded separator inside a segment stays opaque and in-scope
+    expect(resolve("/api/orders/foo%2f..%2fbar")).toBe("http://upstream/orders/foo%2f..%2fbar");
+  });
+
+  it("blocks encoded traversal in every equivalent shape", () => {
+    expect(blocked("/api/orders/..%2fadmin%2fconfig.json")).toBe(true); // single slash
+    expect(blocked("/api/orders//..%2fadmin%2fconfig.json")).toBe(true); // doubled slash
+    expect(blocked("/api/orders/..%2Fadmin")).toBe(true); // mixed-case %2F
+    expect(blocked("/api/orders//..%252fadmin")).toBe(true); // doubled + double-encoded
+    expect(blocked("/api/orders/%2e%2e%2fadmin")).toBe(true); // encoded dot-segment
+  });
+
+  it("never resolves a /** target outside the configured base", () => {
+    const payloads = [
+      "/api/orders/list.json",
+      "/api/orders/",
+      "/api/orders//..%2fadmin",
+      "/api/orders//..%2f..%2fetc%2fpasswd",
+      "/api/orders/foo%2f..%2fbar",
+      "/api/orders/a//b%2f..%2f..%2fc",
+      "/api/orders//..%255c..%255cwin",
+      "/api/orders/%2e%2e%2f%2e%2e%2froot",
+    ];
+    for (const p of payloads) {
+      let target: string | undefined;
+      try {
+        target = resolve(p);
+      } catch (error: any) {
+        expect(error?.status).toBe(400); // out-of-scope inputs are rejected
+        continue;
+      }
+      // whatever is forwarded must canonicalize within the upstream base
+      expect(isPathInScope(new URL(target).pathname, "/orders")).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## What

Harden `routeRules` proxy and redirect path handling for `/**` wildcard rules so the forwarded upstream path stays inside the configured base, regardless of how the incoming path is shaped.

Previously the scope check ran only on the incoming request path. Equivalent inputs (repeated/leading slashes, `/./`, empty segments, mixed-case or double-encoded separators) could normalize differently before vs. after the remainder was appended, letting a request escape the intended base once the upstream decoded it.

The fix validates the **final resolved target** (the bytes actually forwarded), not just the incoming path. Proxy and redirect now share one `resolveWildcardTarget` helper.

## Flow

Rule: `"/api/orders/**": { proxy: { to: "http://upstream/orders/**" } }`

Happy path

- `GET /api/orders/list.json` stays in scope, forwarded to `http://upstream/orders/list.json`.
- `GET /api/orders/foo%2f..%2fbar` resolves within `/orders`, forwarded unchanged.
- Query strings are preserved.

Unhappy path (rejected with 400, upstream never contacted)

- `GET /api/orders/..%2fadmin%2fconfig.json`
- `GET /api/orders//..%2fadmin%2fconfig.json` (doubled slash)
- `GET /api/orders/..%2Fadmin` (mixed-case)
- `GET /api/orders//..%252fadmin` (double-encoded)

## Tests

- Unit tests for `resolveWildcardTarget`: benign passthrough, every equivalent traversal shape blocked, and a regression assert that a `/**` target can never resolve outside the base.
- Runtime test asserting encoded traversal is rejected before the upstream is reached.
