### PR TITLE
fix(aws-lambda): terminate streaming responses that have no body

### DIFF
--- a/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
+++ b/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
@@ -1,6 +1,7 @@
 import "#nitro/virtual/polyfills";
 import { useNitroApp } from "nitro/app";
 import { awsRequest, awsResponseHeaders } from "./_utils.ts";
+import { planAwsLambdaStreamingEmit } from "./streaming-body.ts";
 
 import type { StreamingResponse } from "@netlify/functions";
 import type { Readable } from "node:stream";
@@ -19,22 +20,36 @@ export const handler = awslambda.streamifyResponse(
       ...awsResponseHeaders(response),
     };
 
-    if (!httpResponseMetadata.headers!["transfer-encoding"]) {
-      httpResponseMetadata.headers!["transfer-encoding"] = "chunked";
+    const plan = planAwsLambdaStreamingEmit(response);
+
+    // Bodyless responses (redirects, 204/304, empty handlers): write the
+    // status+headers prelude and end immediately. Forcing chunked TE and
+    // enqueueing a zero-length chunk hangs the stream behind CloudFront
+    // (~Lambda timeout) even though the handler itself finishes quickly.
+    if (plan.kind === "bodyless") {
+      if (
+        !httpResponseMetadata.headers!["content-length"] &&
+        !httpResponseMetadata.headers!["Content-Length"]
+      ) {
+        httpResponseMetadata.headers!["content-length"] = plan.contentLength;
+      }
+      const writer = awslambda.HttpResponseStream.from(
+        responseStream,
+        httpResponseMetadata
+      );
+      writer.end();
+      return;
     }
 
-    const body =
-      response.body ??
-      new ReadableStream<string>({
-        start(controller) {
-          controller.enqueue("");
-          controller.close();
-        },
-      });
+    if (plan.transferEncoding) {
+      if (!httpResponseMetadata.headers!["transfer-encoding"]) {
+        httpResponseMetadata.headers!["transfer-encoding"] = plan.transferEncoding;
+      }
+    }
 
     const writer = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata);
 
-    const reader = body.getReader();
+    const reader = response.body!.getReader();
     await streamToNodeStream(reader, responseStream);
     writer.end();
   }

--- a/src/presets/aws-lambda/runtime/streaming-body.ts
+++ b/src/presets/aws-lambda/runtime/streaming-body.ts
@@ -1,0 +1,27 @@
+/**
+ * Decide how the aws-lambda streaming handler should emit a fetch Response.
+ *
+ * Bodyless responses (redirects, 204/304, handlers that return `new Response(null)`)
+ * must write status+headers and end the stream immediately. Forcing
+ * `transfer-encoding: chunked` and writing a zero-length chunk hangs the
+ * response behind CloudFront until the Lambda times out.
+ */
+export type StreamingEmitPlan =
+  | { kind: "bodyless"; contentLength: "0" }
+  | { kind: "stream"; transferEncoding: "chunked" | undefined };
+
+export function planAwsLambdaStreamingEmit(response: {
+  body: ReadableStream | null;
+  headers?: { get?(name: string): string | null };
+}): StreamingEmitPlan {
+  if (!response.body) {
+    return { kind: "bodyless", contentLength: "0" };
+  }
+  const existingTE =
+    response.headers?.get?.("transfer-encoding") ||
+    response.headers?.get?.("Transfer-Encoding");
+  return {
+    kind: "stream",
+    transferEncoding: existingTE ? undefined : "chunked",
+  };
+}

--- a/test/unit/aws-lambda-streaming-body.test.ts
+++ b/test/unit/aws-lambda-streaming-body.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { planAwsLambdaStreamingEmit } from "../../src/presets/aws-lambda/runtime/streaming-body.ts";
+
+describe("planAwsLambdaStreamingEmit", () => {
+  it("treats null body (redirects / 204) as bodyless with content-length 0", () => {
+    expect(planAwsLambdaStreamingEmit({ body: null })).toEqual({
+      kind: "bodyless",
+      contentLength: "0",
+    });
+  });
+
+  it("streams responses that have a body with chunked TE by default", () => {
+    const body = new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("hi"));
+        c.close();
+      },
+    });
+    expect(planAwsLambdaStreamingEmit({ body })).toEqual({
+      kind: "stream",
+      transferEncoding: "chunked",
+    });
+  });
+
+  it("does not force chunked TE when the response already sets it", () => {
+    const body = new ReadableStream({
+      start(c) {
+        c.close();
+      },
+    });
+    const headers = new Headers({ "transfer-encoding": "chunked" });
+    expect(planAwsLambdaStreamingEmit({ body, headers })).toEqual({
+      kind: "stream",
+      transferEncoding: undefined,
+    });
+  });
+});


### PR DESCRIPTION
bodyless responses (redirects, 204, `Response(null)`) on the aws-lambda streaming preset were hanging the stream behind CloudFront until the Lambda timeout. the handler forced `transfer-encoding: chunked` and wrote a zero-length chunk for empty bodies, which never cleanly closed the stream.

when `response.body` is null we now write the status/headers prelude and end immediately (`content-length: 0`), and only use the chunked streaming path when there is a real body. unit tests cover the emit plan (3/3).

Fixes #4417.