### PR TITLE
docs(readme): remove duplicated verb before Contribution Guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add server routes, deploy across multiple platforms, and enjoy a **zero-config**
 
 ## Contributing
 
-See Check out the [Contribution Guide](./CONTRIBUTING.md) to get started.
+Check out the [Contribution Guide](./CONTRIBUTING.md) to get started.
 
 ## License
 


### PR DESCRIPTION
## Summary

`README.md` line 16 has a duplicated verb:

```diff
- See Check out the [Contribution Guide](./CONTRIBUTING.md) to get started.
+ Check out the [Contribution Guide](./CONTRIBUTING.md) to get started.
```

Small editing artifact — both "See" and "Check out" open a sentence, so together they're ungrammatical. Removing the "See " gives the intended imperative.

## Verified

- [x] One-line diff, README-only.
- [x] Renders as-expected on the fork's README preview.