### PR TITLE
fix(externals): only force-trace observed native imports

### DIFF
--- a/src/build/plugins/externals.ts
+++ b/src/build/plugins/externals.ts
@@ -61,6 +61,11 @@ export function externals(opts: ExternalsOptions): Plugin {
 
   const tracedPaths = new Set<string>();
 
+  // Names to force-trace by name. Seeded with user-declared `traceDeps`; builtin
+  // native packages are added here only when observed as (unresolvable) imports
+  // during resolution, never wholesale (see `resolveTraceDeps`).
+  const forcedTraceIncludes = new Set<string>(resolved?.traceInclude);
+
   if (opts.trace && !resolved?.includePattern) {
     return {
       name: PLUGIN_NAME,
@@ -108,6 +113,8 @@ export function externals(opts: ExternalsOptions): Plugin {
         if (!resolved?.id) {
           const importId = opts.trace ? toImport(id) : undefined;
           if (importId && include?.some((r) => r.test(importId))) {
+            // Observed but unresolvable native import: force-trace it by name.
+            forcedTraceIncludes.add(importId);
             return {
               resolvedBy: PLUGIN_NAME,
               external: true,
@@ -172,13 +179,17 @@ export function externals(opts: ExternalsOptions): Plugin {
         const traceTime = Date.now();
         let traceFilesCount = 0;
         let tracedPkgsCount = 0;
+        // Only the names actually observed as imports (plus user `traceDeps`) are
+        // force-traced — never the full builtin DB, which would drag build-time
+        // tooling into the output.
+        const traceInclude = forcedTraceIncludes.size ? [...forcedTraceIncludes] : undefined;
         // Roots from which `traceInclude` names may be resolved when they are not
         // reachable from `rootDir` (pnpm's non-hoisted nested layout): packages
         // bundled into this environment's graph, plus the app's direct deps. A
         // framework dep can be bundled in an upstream build environment (absent
         // from this graph) yet still declare native deps (e.g. `sharp`) that must
         // be traced from its real location.
-        const traceIncludeRoots = resolved?.traceInclude
+        const traceIncludeRoots = traceInclude
           ? [
               ...new Set([
                 ...(typeof this.getModuleIds === "function"
@@ -191,7 +202,7 @@ export function externals(opts: ExternalsOptions): Plugin {
         await traceNodeModules([...tracedPaths], {
           ...traceOpts,
           fullTraceInclude: resolved?.fullTraceInclude,
-          traceInclude: resolved?.traceInclude,
+          traceInclude,
           traceIncludeRoots: traceIncludeRoots?.length ? traceIncludeRoots : undefined,
           conditions: opts.conditions,
           rootDir: opts.rootDir,
@@ -263,12 +274,19 @@ export function resolveTraceDeps(
   const fullTraceInclude = [...new Set([...builtinFullTrace, ...userFullTrace])].filter(
     (d) => !negated.has(d)
   );
-  // Named (non-RegExp) deps to force-trace by name. nft cannot statically detect
-  // packages that are loaded dynamically (e.g. native bindings), so they are
-  // resolved and traced explicitly by `traceNodeModules`. This also makes them
-  // work under pnpm, where a nested dependency is not hoisted and only resolves
-  // from the dependent package's real `.pnpm` location.
-  const traceInclude = resolved.filter((d): d is string => typeof d === "string");
+  // User-declared named deps to always force-trace by name. Builtin native
+  // packages are intentionally NOT force-traced wholesale: many of them are
+  // build-time-only tooling (e.g. `rolldown`/`rollup`/`vite`, declared as deps
+  // by `nitro` itself) that must never be copied into the runtime output. A
+  // builtin is force-traced only when it is actually observed as an
+  // (unresolvable) import during the build — nft cannot statically detect
+  // dynamically-loaded native bindings, so those observed names are collected at
+  // resolve time and traced explicitly. Force-tracing by name also fixes pnpm,
+  // where a nested dependency only resolves from the dependent package's real
+  // `.pnpm` location.
+  const traceInclude = userTraceDeps.filter(
+    (d): d is string => typeof d === "string" && !negated.has(d)
+  );
   return {
     includePattern: tracePattern
       ? new RegExp(`(?:^|[/\\\\]node_modules[/\\\\])(?:${tracePattern})(?:[/\\\\]|$)`)

--- a/src/build/plugins/externals.ts
+++ b/src/build/plugins/externals.ts
@@ -114,7 +114,9 @@ export function externals(opts: ExternalsOptions): Plugin {
           const importId = opts.trace ? toImport(id) : undefined;
           if (importId && include?.some((r) => r.test(importId))) {
             // Observed but unresolvable native import: force-trace it by name.
-            forcedTraceIncludes.add(importId);
+            // nf3 matches `traceInclude` entries against bare dependency names,
+            // so strip any subpath (`pkg/sub` → `pkg`).
+            forcedTraceIncludes.add(IMPORT_RE.exec(importId)?.groups?.name ?? importId);
             return {
               resolvedBy: PLUGIN_NAME,
               external: true,
@@ -171,7 +173,7 @@ export function externals(opts: ExternalsOptions): Plugin {
     buildEnd: {
       order: "post",
       async handler() {
-        if (!opts.trace || tracedPaths.size === 0) {
+        if (!opts.trace || (tracedPaths.size === 0 && forcedTraceIncludes.size === 0)) {
           return;
         }
         const { hooks: userHooks, ...traceOpts } = opts.trace;

--- a/test/unit/trace-deps.test.ts
+++ b/test/unit/trace-deps.test.ts
@@ -1,13 +1,15 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   collectDirectDepRoots,
   collectPackageRoots,
   externals,
   resolveTraceDeps,
 } from "../../src/build/plugins/externals.ts";
+
+vi.mock("nf3", () => ({ traceNodeModules: vi.fn(() => Promise.resolve()) }));
 
 const defaults = {
   builtinPackages: ["sharp", "canvas"],
@@ -255,5 +257,29 @@ describe("externals resolveId (unresolvable native deps)", () => {
   it("does not externalize an unresolvable dep that is not in the include set", async () => {
     const result = await handler("left-pad", "/app/.nitro/services/ssr/index.js", {});
     expect(result).toBeNull();
+  });
+});
+
+describe("externals buildEnd (forced trace includes)", () => {
+  it("force-traces observed imports by bare package name, even with no traced paths", async () => {
+    const plugin = externals({
+      rootDir: "/app",
+      conditions: ["node"],
+      exclude: [],
+      include: [],
+      trace: {},
+    });
+    const handler = (plugin.resolveId as any).handler.bind({ resolve: async () => null });
+    // Subpath import of a builtin native dep, unresolvable (pnpm nested).
+    await handler("sharp/wasm", "/app/.nitro/services/ssr/index.js", {});
+    await (plugin.buildEnd as any).handler.call({});
+    const { traceNodeModules } = await import("nf3");
+    // Trace must run for observed imports even when nothing else was traced.
+    expect(traceNodeModules).toHaveBeenCalledTimes(1);
+    // nf3 matches `traceInclude` entries against bare dependency names, so the
+    // subpath must be stripped — `sharp/wasm` would never match a declarer.
+    const traceOpts = vi.mocked(traceNodeModules).mock.calls[0][1];
+    expect(traceOpts.traceInclude).toContain("sharp");
+    expect(traceOpts.traceInclude).not.toContain("sharp/wasm");
   });
 });

--- a/test/unit/trace-deps.test.ts
+++ b/test/unit/trace-deps.test.ts
@@ -48,23 +48,24 @@ describe("resolveTraceDeps", () => {
     expect(result.fullTraceInclude).toContain("prisma");
   });
 
-  it("returns named deps as traceInclude (builtins + user, RegExp excluded)", () => {
+  it("force-traces only user-declared named deps, not builtins (RegExp excluded)", () => {
     const result = resolveTraceDeps(["my-pkg", /my-.*-pkg/], defaults);
-    expect(result.traceInclude).toContain("sharp");
-    expect(result.traceInclude).toContain("canvas");
-    expect(result.traceInclude).toContain("my-pkg");
+    expect(result.traceInclude).toEqual(["my-pkg"]);
+    // Builtins are never force-traced wholesale — they would drag build-time
+    // tooling (rolldown/rollup/vite, declared by nitro) into the output.
+    expect(result.traceInclude).not.toContain("sharp");
+    expect(result.traceInclude).not.toContain("canvas");
     // RegExp entries cannot be resolved by name and must be excluded
     expect(result.traceInclude!.every((d) => typeof d === "string")).toBe(true);
   });
 
-  it("excludes negated packages from traceInclude", () => {
-    const result = resolveTraceDeps(["!sharp"], defaults);
-    expect(result.traceInclude).not.toContain("sharp");
-    expect(result.traceInclude).toContain("canvas");
+  it("returns undefined traceInclude when no user deps are declared", () => {
+    const result = resolveTraceDeps([], defaults);
+    expect(result.traceInclude).toBeUndefined();
   });
 
-  it("returns undefined traceInclude when all deps are negated", () => {
-    const result = resolveTraceDeps(["!sharp", "!canvas"], defaults);
+  it("excludes negated user deps from traceInclude", () => {
+    const result = resolveTraceDeps(["my-pkg", "!my-pkg"], defaults);
     expect(result.traceInclude).toBeUndefined();
   });
 


### PR DESCRIPTION
## Problem

Tracing dependencies drags the entire **build toolchain** (`rolldown`, `rollup`, `vite`, `esbuild`, `oxlint`, `oxfmt`, `lightningcss`, `youch`, …) into **every** production output — not just apps using native deps. The [`examples/takumi`](https://github.com/nitrojs/nitro/tree/main/examples/takumi) build made it obvious: **82.4 MB** output, **38** traced packages, **5.1s** trace time.

## Root cause

Regression from #4391 (+ unjs/nf3#50). `resolveTraceDeps` returns the **entire builtin native/non-bundleable DB (~155 packages)** as the force-trace-by-name (`traceInclude`) set. nf3 then force-copies any of those names that is merely **declared as a dependency** by a reachable root.

Two facts combine:

1. The builtin DB classifies the bundler toolchain as "native" (`rolldown`/`rollup`/`vite`/`esbuild`/`oxlint`/…).
2. `nitro`'s own `package.json` declares `rolldown` (dep) + `rollup`/`vite` (peerDeps). `nitro` is a declarer root on every build — reached both via `collectDirectDepRoots` (direct devDependency) and `collectPackageRoots(moduleIds)` (its runtime is bundled).

So the toolchain (and its transitive deps) is force-copied into every output. This is **universal, not example-specific**.

## Fix

Force-trace by name **only** packages actually *observed as imports* during the build (the imported-but-unresolvable resolve branch, e.g. pnpm-nested `sharp` / `@takumi-rs/core`) plus the user's explicit `traceDeps`. Never the full builtin DB — a package the runtime never imports can no longer be force-copied. Observed names are collected at resolve time into a `forcedTraceIncludes` set; `resolveTraceDeps().traceInclude` now returns only user-declared deps.

## Verification (`examples/takumi`)

| | before | after |
|---|---|---|
| traced deps | 38 (307 files) | **3** (6 files) — just `@takumi-rs/*` |
| output size | 82.4 MB | **6.6 MB** |
| trace time | 5124 ms | **115 ms** |

The `@takumi-rs/core` native `.node` binding is still traced, and `/og.png` boots and serves a valid 1200×630 PNG (HTTP 200). Unit tests updated (they previously encoded the buggy wholesale behavior); typecheck + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)