### PR TITLE
fix(bun): restore idle timeout environment variable

### DIFF
--- a/docs/2.deploy/10.runtimes/bun.md
+++ b/docs/2.deploy/10.runtimes/bun.md
@@ -16,4 +16,12 @@ After building with bun preset using `bun` as preset, you can run server in prod
 bun run ./.output/server/index.mjs
 ```
 
+## Idle Timeout
+
+Set `NITRO_BUN_IDLE_TIMEOUT` to change Bun's server idle timeout. The value is in seconds and must be between `0` and `255`. Setting it to `0` disables the idle timeout.
+
+```bash
+NITRO_BUN_IDLE_TIMEOUT=30 bun run ./.output/server/index.mjs
+```
+
 :read-more{to="https://bun.sh"}

--- a/docs/2.deploy/10.runtimes/bun.md
+++ b/docs/2.deploy/10.runtimes/bun.md
@@ -16,4 +16,12 @@ After building with the `bun` preset, start the production server with:
 bun run ./.output/server/index.mjs
 ```
 
+## Idle Timeout
+
+Set `NITRO_BUN_IDLE_TIMEOUT` to change Bun's server idle timeout. The value is in seconds and must be between `0` and `255`. Setting it to `0` disables the idle timeout.
+
+```bash
+NITRO_BUN_IDLE_TIMEOUT=30 bun run ./.output/server/index.mjs
+```
+
 :read-more{to="https://bun.sh"}

--- a/docs/2.deploy/10.runtimes/bun.md
+++ b/docs/2.deploy/10.runtimes/bun.md
@@ -16,9 +16,11 @@ After building with the `bun` preset, start the production server with:
 bun run ./.output/server/index.mjs
 ```
 
-## Idle Timeout
+## Environment Variables
 
-Set `NITRO_BUN_IDLE_TIMEOUT` to change Bun's server idle timeout. The value is in seconds and must be between `0` and `255`. Setting it to `0` disables the idle timeout.
+You can customize server behavior with the following environment variables:
+
+- `NITRO_BUN_IDLE_TIMEOUT` - Bun's server [idleTimeout](https://bun.sh/docs/api/http#idletimeout) in seconds. Must be between `0` and `255`, where `0` disables the timeout. Invalid values are ignored and Bun's default is used.
 
 ```bash
 NITRO_BUN_IDLE_TIMEOUT=30 bun run ./.output/server/index.mjs

--- a/src/presets/bun/runtime/_utils.ts
+++ b/src/presets/bun/runtime/_utils.ts
@@ -1,0 +1,8 @@
+export function parseBunIdleTimeout(value: string | undefined) {
+  if (!/^\d+$/.test(value || "")) {
+    return undefined;
+  }
+
+  const timeout = Number(value);
+  return timeout >= 0 && timeout <= 255 ? timeout : undefined;
+}

--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -8,11 +8,13 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { tracingSrvxPlugins } from "#nitro/virtual/tracing";
+import { parseBunIdleTimeout } from "./_utils.ts";
 const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 const host = process.env.NITRO_HOST || process.env.HOST;
 const cert = process.env.NITRO_SSL_CERT;
 const key = process.env.NITRO_SSL_KEY;
+const idleTimeout = parseBunIdleTimeout(process.env.NITRO_BUN_IDLE_TIMEOUT);
 // const socketPath = process.env.NITRO_UNIX_SOCKET; // TODO
 
 const nitroApp = useNitroApp();
@@ -36,6 +38,7 @@ const server = serve({
   tls: cert && key ? { cert, key } : undefined,
   fetch: _fetch,
   bun: {
+    idleTimeout,
     websocket: import.meta._websocket ? ws?.websocket : undefined,
   },
   plugins: [...tracingSrvxPlugins],

--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -9,11 +9,13 @@ import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { tracingSrvxPlugins } from "#nitro/virtual/tracing";
 import { setupCloseHooks } from "#nitro/runtime/shutdown";
+import { parseBunIdleTimeout } from "./_utils.ts";
 const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 const host = process.env.NITRO_HOST || process.env.HOST;
 const cert = process.env.NITRO_SSL_CERT;
 const key = process.env.NITRO_SSL_KEY;
+const idleTimeout = parseBunIdleTimeout(process.env.NITRO_BUN_IDLE_TIMEOUT);
 // const socketPath = process.env.NITRO_UNIX_SOCKET; // TODO
 
 const nitroApp = useNitroApp();
@@ -37,6 +39,7 @@ const server = serve({
   tls: cert && key ? { cert, key } : undefined,
   fetch: _fetch,
   bun: {
+    idleTimeout,
     websocket: import.meta._websocket ? ws?.websocket : undefined,
   },
   plugins: [...tracingSrvxPlugins],

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -1,7 +1,7 @@
 import { execa, execaCommandSync } from "execa";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { resolve } from "pathe";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
 
 const hasBun = execaCommandSync("bun --version", { stdio: "ignore", reject: false }).exitCode === 0;
@@ -11,13 +11,21 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
   testNitro(ctx, async () => {
     const port = await getRandomPort();
     process.env.PORT = String(port);
-    execa("bun", [resolve(ctx.outDir, "server/index.mjs")], {
-      stdio: "inherit",
-    });
+    process.env.NITRO_BUN_IDLE_TIMEOUT = "1";
+    const p = execa(
+      "bun",
+      [
+        "--preload",
+        resolve(import.meta.dirname, "fixtures/bun-preload.ts"),
+        resolve(ctx.outDir, "server/index.mjs"),
+      ],
+      { stdio: "inherit", reject: false }
+    );
     ctx.server = {
       url: `http://127.0.0.1:${port}`,
-      close: () => {
-        // p.kill()
+      close: async () => {
+        p.kill();
+        await p;
       },
     } as any;
     await waitForPort(port);
@@ -25,5 +33,10 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       const res = await ctx.fetch(url, opts);
       return res;
     };
+  });
+
+  it("forwards the idle timeout to Bun", async () => {
+    const response = await fetch(`${ctx.server!.url}/_bun/idle-timeout`);
+    expect(await response.text()).toBe("1");
   });
 });

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -1,7 +1,7 @@
 import { execa, execaSync } from "execa";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { resolve } from "pathe";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
 import { testCloseHook } from "./_close-hook.ts";
 
@@ -12,10 +12,19 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
   testNitro(ctx, async () => {
     const port = await getRandomPort();
     process.env.PORT = String(port);
-    const p = execa("bun", [resolve(ctx.outDir, "server/index.mjs")], {
-      stdio: process.env.TEST_DEBUG ? "inherit" : "ignore",
-      reject: false,
-    });
+    process.env.NITRO_BUN_IDLE_TIMEOUT = "1";
+    const p = execa(
+      "bun",
+      [
+        "--preload",
+        resolve(import.meta.dirname, "fixtures/bun-preload.ts"),
+        resolve(ctx.outDir, "server/index.mjs"),
+      ],
+      {
+        stdio: process.env.TEST_DEBUG ? "inherit" : "ignore",
+        reject: false,
+      }
+    );
     ctx.server = {
       url: `http://127.0.0.1:${port}`,
       close: async () => {
@@ -27,6 +36,11 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       const res = await ctx.fetch(url, opts);
       return res;
     };
+  });
+
+  it("forwards the idle timeout to Bun", async () => {
+    const response = await fetch(`${ctx.server!.url}/_bun/idle-timeout`);
+    expect(await response.text()).toBe("1");
   });
 
   testCloseHook(ctx, { command: "bun", args: (entry) => [entry] });

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -7,12 +7,15 @@ import { testCloseHook } from "./_close-hook.ts";
 
 const hasBun = execaSync("bun", ["--version"], { stdio: "ignore", reject: false }).exitCode === 0;
 
+// Not Bun's default (10s), so the assertion cannot pass by accident, and high
+// enough to not drop idle keep-alive connections between test requests.
+const idleTimeout = "42";
+
 describe.runIf(hasBun)("nitro:preset:bun", async () => {
   const ctx = await setupTest("bun");
   testNitro(ctx, async () => {
     const port = await getRandomPort();
     process.env.PORT = String(port);
-    process.env.NITRO_BUN_IDLE_TIMEOUT = "1";
     const p = execa(
       "bun",
       [
@@ -23,6 +26,7 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       {
         stdio: process.env.TEST_DEBUG ? "inherit" : "ignore",
         reject: false,
+        env: { NITRO_BUN_IDLE_TIMEOUT: idleTimeout },
       }
     );
     ctx.server = {
@@ -40,7 +44,7 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
 
   it("forwards the idle timeout to Bun", async () => {
     const response = await fetch(`${ctx.server!.url}/_bun/idle-timeout`);
-    expect(await response.text()).toBe("1");
+    expect(await response.text()).toBe(idleTimeout);
   });
 
   testCloseHook(ctx, { command: "bun", args: (entry) => [entry] });

--- a/test/presets/fixtures/bun-preload.ts
+++ b/test/presets/fixtures/bun-preload.ts
@@ -1,0 +1,22 @@
+type BunServeOptions = {
+  idleTimeout?: number;
+  fetch: (request: Request, server: unknown) => Response | Promise<Response>;
+};
+
+const bun = (
+  globalThis as typeof globalThis & {
+    Bun: { serve: (options: BunServeOptions) => unknown };
+  }
+).Bun;
+const bunServe = bun.serve;
+
+bun.serve = (options) => {
+  const fetch = options.fetch;
+  options.fetch = (request, server) => {
+    if (new URL(request.url).pathname === "/_bun/idle-timeout") {
+      return new Response(String(options.idleTimeout));
+    }
+    return fetch(request, server);
+  };
+  return bunServe(options);
+};

--- a/test/unit/bun-preset.test.ts
+++ b/test/unit/bun-preset.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { parseBunIdleTimeout } from "../../src/presets/bun/runtime/_utils.ts";
+
+describe("bun preset", () => {
+  it.each([
+    ["0", 0],
+    ["255", 255],
+  ])("accepts an idle timeout of %s", (value, expected) => {
+    expect(parseBunIdleTimeout(value)).toBe(expected);
+  });
+
+  it.each([undefined, "", "abc", "-1", "256"])("ignores an invalid idle timeout of %s", (value) => {
+    expect(parseBunIdleTimeout(value)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Restores `NITRO_BUN_IDLE_TIMEOUT` support for the Bun preset after it was lost during the move to `srvx`.

Values from `0` to `255` are forwarded to `Bun.serve`, including `0` to disable the timeout. Invalid values are ignored.

Includes unit coverage, a Bun preset regression test, and updated runtime documentation.

Fixes #3454