### PR TITLE
fix(vite): respect `apply` and dedupe when registering nitro modules from vite plugins

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -77,6 +77,19 @@ function nitroInit(ctx: NitroPluginContext): VitePlugin {
       }
     },
 
+    configResolved(config) {
+      // Vite resolves its plugin list *before* running config hooks, so a plugin added by
+      // another plugin's `config` hook is discovered by Nitro but silently ignored by Vite.
+      for (const plugin of ctx._pluginModules || []) {
+        if (!config.plugins.some((p) => p === plugin || p.nitro === plugin.nitro)) {
+          useNitro(ctx).logger.warn(
+            `Vite plugin \`${plugin.name}\` registers a Nitro module but is not applied by Vite. ` +
+              `Plugins added from a \`config\` hook are ignored by Vite; add it to \`plugins\` instead.`
+          );
+        }
+      }
+    },
+
     applyToEnvironment(env) {
       if (env.name === "nitro" && ctx.nitro?.options.dev) {
         debug("[init] Adding rollup plugins for dev");
@@ -347,12 +360,8 @@ async function setupNitroContext(
   };
 
   // Register Nitro modules from Vite plugins
-  const pluginModules: NitroModule[] = [];
-  for (const plugin of await flattenPlugins(userConfig, configEnv)) {
-    if (plugin.nitro) {
-      pluginModules.push(plugin.nitro);
-    }
-  }
+  ctx._pluginModules = (await flattenPlugins(userConfig, configEnv)).filter((p) => p.nitro);
+  const pluginModules = ctx._pluginModules.map((p) => p.nitro!);
   nitroConfig.modules = [...(nitroConfig.modules || []), ...pluginModules];
 
   // Register service entries VFS

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -10,6 +10,7 @@ import type { InputOption } from "rollup";
 import type { NitroPluginConfig, NitroPluginContext } from "./types.ts";
 import { resolve, join } from "pathe";
 import { createNitro, prepare, writeTypes } from "../../builder.ts";
+import { installModules } from "../../module.ts";
 import { getBundlerConfig } from "./bundler.ts";
 import { buildEnvironments } from "./prod.ts";
 import {
@@ -26,7 +27,7 @@ import { prettyPath } from "../../utils/fs.ts";
 import { NitroDevApp } from "../../dev/app.ts";
 import { nitroPreviewPlugin } from "./preview.ts";
 import assetsPlugin from "@hiogawa/vite-plugin-fullstack/assets";
-import type { NitroConfig } from "nitro/types";
+import type { NitroConfig, NitroModule } from "nitro/types";
 import { nitroDevServiceProxy, viteServicesTemplate } from "./services.ts";
 
 // https://vite.dev/guide/api-environment-plugins
@@ -346,13 +347,13 @@ async function setupNitroContext(
   };
 
   // Register Nitro modules from Vite plugins
-  nitroConfig.modules ??= [];
-  for (const plugin of flattenPlugins(userConfig.plugins || [])) {
+  const pluginModules: NitroModule[] = [];
+  for (const plugin of await flattenPlugins(userConfig, configEnv)) {
     if (plugin.nitro) {
-      nitroConfig.modules.push(plugin.nitro);
-      // TODO: install modules on existing providedNitro
+      pluginModules.push(plugin.nitro);
     }
   }
+  nitroConfig.modules = [...(nitroConfig.modules || []), ...pluginModules];
 
   // Register service entries VFS
   const vServicesId = "#nitro/virtual/vite-services";
@@ -371,6 +372,12 @@ async function setupNitroContext(
   // Initialize a new Nitro instance
   ctx.nitro =
     providedNitro || (await createNitro(nitroConfig, { dotenv: { fileName: dotenvFileNames } }));
+
+  // Install Vite plugin modules on the provided instance (`nitro build`)
+  if (providedNitro && pluginModules.length > 0) {
+    providedNitro.options.modules = nitroConfig.modules;
+    await installModules(providedNitro, pluginModules);
+  }
 
   // Config ssr env as a fetchable ssr service
   if (!ctx.services?.ssr) {
@@ -467,8 +474,34 @@ function getEntry(input: InputOption | undefined): string | undefined {
   }
 }
 
-function flattenPlugins(plugins: PluginOption[]): VitePlugin[] {
-  return plugins
-    .flatMap((plugin) => (Array.isArray(plugin) ? flattenPlugins(plugin) : [plugin]))
-    .filter((p) => p && !(p instanceof Promise)) as VitePlugin[];
+// Flatten and filter user plugins with the same semantics Vite uses to resolve them.
+// (Vite filters by `apply` before calling config hooks but keeps `config.plugins` unfiltered)
+// https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts
+async function flattenPlugins(userConfig: UserConfig, configEnv: ConfigEnv): Promise<VitePlugin[]> {
+  const flat = async (plugins: PluginOption[]): Promise<VitePlugin[]> => {
+    const resolved = await Promise.all(plugins);
+    const result: VitePlugin[] = [];
+    for (const plugin of resolved) {
+      if (!plugin) {
+        continue;
+      }
+      if (Array.isArray(plugin)) {
+        result.push(...(await flat(plugin)));
+      } else {
+        result.push(plugin as VitePlugin);
+      }
+    }
+    return result;
+  };
+
+  const plugins = await flat(userConfig.plugins || []);
+
+  return plugins.filter((plugin) => {
+    if (!plugin.apply) {
+      return true;
+    }
+    return typeof plugin.apply === "function"
+      ? plugin.apply({ ...userConfig, mode: configEnv.mode }, configEnv)
+      : plugin.apply === configEnv.command;
+  });
 }

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -1,4 +1,4 @@
-import type { TransformResult } from "vite";
+import type { TransformResult, Plugin as VitePlugin } from "vite";
 import type { getBundlerConfig } from "./bundler.ts";
 import type { Nitro, NitroConfig, NitroModule } from "nitro/types";
 import type { RunnerManager } from "env-runner";
@@ -66,4 +66,5 @@ export interface NitroPluginContext {
   _transformRequest?: (id: string) => Promise<TransformResult | null | undefined>;
   _publicDistDir?: string;
   _entryPoints: Record<string, string>;
+  _pluginModules?: VitePlugin[];
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,17 +1,25 @@
 import type { Nitro, NitroModule, NitroModuleInput } from "nitro/types";
 import { resolveModuleURL } from "exsolve";
 
-export async function installModules(nitro: Nitro) {
-  const _modules = [...(nitro.options.modules || [])];
+// Modules already installed for a Nitro instance, keyed by resolved URL (string inputs)
+// or by `setup` identity (inline modules) to keep `installModules` idempotent.
+// (config loading clones module objects, but keeps the `setup` reference)
+const installedModules = new WeakMap<Nitro, Set<unknown>>();
+
+export async function installModules(nitro: Nitro, moduleInputs?: NitroModuleInput[]) {
+  const _modules = [...(moduleInputs ?? nitro.options.modules ?? [])];
   const modules = await Promise.all(_modules.map((mod) => _resolveNitroModule(mod, nitro.options)));
-  const _installedURLs = new Set<string>();
+  let _installed = installedModules.get(nitro);
+  if (!_installed) {
+    _installed = new Set();
+    installedModules.set(nitro, _installed);
+  }
   for (const mod of modules) {
-    if (mod._url) {
-      if (_installedURLs.has(mod._url)) {
-        continue;
-      }
-      _installedURLs.add(mod._url);
+    const key = mod._url ?? mod.setup;
+    if (_installed.has(key)) {
+      continue;
     }
+    _installed.add(key);
     await mod.setup(nitro);
   }
 }

--- a/test/vite/plugin-modules.test.ts
+++ b/test/vite/plugin-modules.test.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import type { Plugin, PluginOption } from "vite";
 import type { Nitro } from "nitro/types";
 import { afterEach, describe, expect, test } from "vitest";
+import { consola } from "consola";
 import { nitro } from "../../src/vite.ts";
 
 const { resolveConfig } = (await import(
@@ -73,5 +74,32 @@ describe("vite: nitro modules from vite plugins", () => {
     const shared = modulePlugin("shared");
     await resolve([shared, shared, [shared]]);
     expect(installed).toEqual(["shared"]);
+  });
+
+  test("warns about plugins that Vite does not apply", async () => {
+    const warnings: string[] = [];
+    const reporter = {
+      log: (logObj: { type: string; args: unknown[] }) => {
+        if (logObj.type === "warn") {
+          warnings.push(logObj.args.join(" "));
+        }
+      },
+    };
+    consola.addReporter(reporter);
+
+    // Vite resolves its plugin list before running config hooks, so plugins added
+    // from a `config` hook are ignored by Vite (but visible to Nitro's discovery).
+    // Vite's types forbid this (`Omit<UserConfig, "plugins">`), hence the cast.
+    const injector: Plugin = {
+      name: "injector",
+      enforce: "pre",
+      config: () => ({ plugins: [modulePlugin("injected")] }) as any,
+    };
+    await resolve([injector, modulePlugin("applied")]);
+    consola.removeReporter(reporter);
+
+    expect(installed).toEqual(["applied", "injected"]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("`injected` registers a Nitro module but is not applied by Vite");
   });
 });

--- a/test/vite/plugin-modules.test.ts
+++ b/test/vite/plugin-modules.test.ts
@@ -1,0 +1,77 @@
+import { fileURLToPath } from "node:url";
+import type { Plugin, PluginOption } from "vite";
+import type { Nitro } from "nitro/types";
+import { afterEach, describe, expect, test } from "vitest";
+import { nitro } from "../../src/vite.ts";
+
+const { resolveConfig } = (await import(
+  process.env.NITRO_VITE_PKG || "vite"
+)) as typeof import("vite");
+
+const rootDir = fileURLToPath(new URL("./app-fixture", import.meta.url));
+
+describe("vite: nitro modules from vite plugins", () => {
+  const instances: Nitro[] = [];
+  let installed: string[] = [];
+
+  afterEach(async () => {
+    installed = [];
+    await Promise.all(instances.splice(0).map((instance) => instance.close()));
+  });
+
+  const modulePlugin = (name: string, options: Partial<Plugin> = {}): Plugin => ({
+    name,
+    ...options,
+    nitro: {
+      setup(instance) {
+        instances.push(instance);
+        installed.push(name);
+      },
+    },
+  });
+
+  const resolve = (plugins: PluginOption[], command: "build" | "serve" = "build") =>
+    resolveConfig(
+      { root: rootDir, configFile: false, plugins: [nitro({ serverDir: "./" }), ...plugins] },
+      command
+    );
+
+  test("registers modules of vite plugins", async () => {
+    await resolve([modulePlugin("plugin-a"), modulePlugin("plugin-b")]);
+    expect(installed).toEqual(["plugin-a", "plugin-b"]);
+  });
+
+  test("registers modules of nested and async vite plugins", async () => {
+    await resolve([[modulePlugin("nested")], Promise.resolve(modulePlugin("async"))]);
+    expect(installed).toEqual(["nested", "async"]);
+  });
+
+  test("skips plugins filtered out by `apply`", async () => {
+    await resolve(
+      [
+        modulePlugin("build-only", { apply: "build" }),
+        modulePlugin("serve-only", { apply: "serve" }),
+        modulePlugin("apply-fn", { apply: (_config, env) => env.command === "serve" }),
+      ],
+      "build"
+    );
+    expect(installed).toEqual(["build-only"]);
+  });
+
+  test("skips plugins filtered out by `apply` in dev", async () => {
+    await resolve(
+      [
+        modulePlugin("build-only", { apply: "build" }),
+        modulePlugin("serve-only", { apply: "serve" }),
+      ],
+      "serve"
+    );
+    expect(installed).toEqual(["serve-only"]);
+  });
+
+  test("installs a shared plugin module only once", async () => {
+    const shared = modulePlugin("shared");
+    await resolve([shared, shared, [shared]]);
+    expect(installed).toEqual(["shared"]);
+  });
+});


### PR DESCRIPTION
Resolves #4429

## Context

Reproduced #4429 in `playground/` with a vite plugin mirroring the one in the issue (`apply: 'build'`, `sharedDuringBuild`, `applyToEnvironment: client`, exposing a `nitro` module). It turned out to be **three** separate bugs.

### 1. `apply` is ignored

Nitro discovers `plugin.nitro` modules by scanning `userConfig.plugins` from inside its own `config` hook. Vite filters plugins by `apply` **before** running config hooks, but never rewrites `config.plugins` — so we were reading plugins Vite had already discarded. A plugin with `apply: 'build'` had its nitro module installed during `vite dev`, even though Vite never called any of that plugin's own hooks.

### 2. Modules from vite plugins are dropped entirely by `nitro build`

The `// TODO: install modules on existing providedNitro` case. When a nitro instance is pre-created (the CLI path), modules collected from vite plugins were pushed into a config object `createNitro()` never sees, so they were silently dropped. Same project, same plugin: installed under `vite build`, never installed under `nitro build`.

### 3. Promise plugins are dropped

`flattenPlugins()` had `.filter((p) => p && !(p instanceof Promise))`, so a plugin returned as a promise (a valid `PluginOption`) lost its nitro module.

The "registered twice" symptom from the issue was **not** reproducible with plain nitro + vite (`setup` and `compiled` each fired exactly once), so that one is likely config being resolved twice on the consumer side. `installModules()` had no dedupe for inline modules regardless — only for string module URLs — so a shared plugin instance listed twice was installed twice. Now guarded.

## Changes

- `flattenPlugins()` mirrors Vite's own resolution: awaits promises, flattens nested arrays, and applies the same `apply` check Vite uses (string compare against `command`, or the function form called with `{...config, mode}` and `configEnv`).
- Plugin modules are installed on a provided nitro instance too, so `nitro build` and `vite build` behave identically.
- `installModules()` is idempotent per nitro instance, keyed by resolved URL for string modules and by `setup` identity for inline ones. It keys on `setup` rather than object identity because config loading deep-clones module objects — the clone preserves function references but breaks object identity.
- Warn when a plugin registering a nitro module is not applied by Vite (see below).

### On the discovery timing

Worth recording, since it's counter-intuitive: Vite computes its plugin list **before** running any `config` hook, and builds `resolved.plugins` from that same pre-computed list. A plugin added by another plugin's `config` hook is therefore ignored by Vite outright — none of its hooks ever run — and its types forbid it (`config` returns `Omit<UserConfig, "plugins">`).

That means a *deferred* second discovery pass at `configResolved` could never find a module that phase 1 missed; the resolved set is a strict subset. It also means the leak runs the other way: because Vite accumulates config-hook results, the `config.plugins` we scan can contain injected plugins that Vite then discards, and we would install their nitro modules anyway — a module mutating `nitro.options` on behalf of a plugin Vite never runs. We now warn in that case rather than installing it silently.

## For plugin authors (cc @userquin)

With this, `apply: 'build'` does what you'd expect, which covers the "only register my nitro module at build time" need. `nitro.options.dev` distinguishes serve from build, and in `vite preview` nitro's init plugin doesn't apply at all, so modules are never installed there. Note that `applyToEnvironment` has no effect on nitro module registration — nitro modules are instance-global, not environment-scoped. The manual "already registered?" guard is no longer needed for a shared plugin instance.

## Not addressed here

The remaining limitation is **lifecycle**, not discovery: `build:before` and the bundler config are resolved during Vite's `config` hook, so no nitro module can observe a resolved Vite config (the `command` / `isPreview` / resolved-outDir asks in the issue thread). Moving them later is blocked today because `nitro:main`'s `config` hook needs `ctx.bundlerConfig` to supply `resolve.alias` at config time. Worth discussing separately.

## Test plan

`test/vite/plugin-modules.test.ts` covers registration, nested/async plugins, `apply` filtering in both `build` and `serve`, dedupe, and the not-applied warning. The first four fail on the pre-fix source. Full suite green (981 passed), lint + typecheck clean.

---

🤖 This PR was authored with [Claude Code](https://claude.com/claude-code) and reviewed by @pi0.