### PR TITLE
feat(vercel): support immutable static files (v2)

### DIFF
--- a/src/presets/vercel/immutable.ts
+++ b/src/presets/vercel/immutable.ts
@@ -1,0 +1,73 @@
+import { globby } from "globby";
+import { writeFile } from "nitropack/kit";
+import type { Nitro } from "nitropack/types";
+import { resolve } from "pathe";
+import { joinURL, withLeadingSlash } from "ufo";
+
+// Immutable Static Files
+//
+// https://vercel.com/docs/build-output-api/primitives
+//
+// Immutable static files are content-addressed and shared across deployments which improves cross-deployment
+// caching.
+//
+// Newer deployments must never overwrite an existing file with different content, so the file names embed a content hash.
+//
+// Alongside `.vercel/output/static`, we emit a `.vercel/output/immutable.json`
+// manifest mapping each immutable static file to its full content hash (the file
+// name may only contain a truncated hash).
+
+const IMMUTABLE_MANIFEST = "immutable.json";
+
+interface ImmutableManifest {
+  version: 1;
+  hashes: Record<string, string>;
+}
+
+export async function generateImmutableManifest(nitro: Nitro) {
+  // Skip unless immutable static files are enabled (`vercel.immutableStaticFiles`).
+  if (!nitro.options.vercel?.immutableStaticFiles) {
+    return;
+  }
+
+  const publicDir = nitro.options.output.publicDir;
+  const files = await globby(`${nitro.options.buildAssetsDir}/**`, {
+    cwd: publicDir,
+    absolute: false,
+    dot: true,
+  });
+
+  const manifest: ImmutableManifest = {
+    version: 1,
+    hashes: Object.fromEntries(
+      files.map((file) => {
+        const pathname = withLeadingSlash(file);
+        const url = joinURL(nitro.options.baseURL, pathname);
+        return [url, url];
+      })
+    ),
+  };
+
+  await writeFile(
+    resolve(nitro.options.output.dir, IMMUTABLE_MANIFEST),
+    JSON.stringify(manifest, null, 2)
+  );
+
+  nitro.logger
+    .withTag("vercel")
+    .info(
+      `Generated immutable manifest (${Object.keys(manifest.hashes).length} files).`
+    );
+}
+
+// Reserved Vercel namespace under which immutable static files are served.
+// Used as the client `buildAssetsDir` so content-addressed assets are emitted
+// and referenced here. The path is namespaced by an optional hash salt and the
+// framework name to avoid cross-framework collisions.
+export function immutableDir(nitro: Nitro) {
+  return joinURL(
+    "_vercel/immutable",
+    process.env.VERCEL_HASH_SALT || "",
+    nitro.options.framework.name || ""
+  );
+}

--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -6,6 +6,7 @@ import {
   generateFunctionFiles,
   generateStaticFiles,
 } from "./utils";
+import { immutableDir, generateImmutableManifest } from "./immutable";
 import { builtnNodeModules } from "../_unenv/node-compat/vercel";
 
 export type { VercelOptions as PresetOptions } from "./types";
@@ -18,6 +19,7 @@ const vercel = defineNitroPreset(
     entry: "./runtime/vercel",
     vercel: {
       skewProtection: !!process.env.VERCEL_SKEW_PROTECTION_ENABLED,
+      immutableStaticFiles: !!process.env.VERCEL_IMMUTABLE_STATIC_FILES_ENABLED,
     },
     output: {
       dir: "{{ rootDir }}/.vercel/output",
@@ -29,11 +31,20 @@ const vercel = defineNitroPreset(
       deploy: "npx vercel deploy --prebuilt",
     },
     hooks: {
+      "build:before": (nitro: Nitro) => {
+        // Immutable static files: emit content-addressed build assets under the
+        // reserved `_vercel/immutable` base so they can be shared across
+        // deployments.
+        if (nitro.options.vercel?.immutableStaticFiles) {
+          nitro.options.buildAssetsDir = immutableDir(nitro);
+        }
+      },
       "rollup:before": (nitro: Nitro) => {
         deprecateSWR(nitro);
       },
       async compiled(nitro: Nitro) {
         await generateFunctionFiles(nitro);
+        await generateImmutableManifest(nitro);
       },
     },
   },
@@ -98,6 +109,7 @@ const vercelStatic = defineNitroPreset(
     extends: "static",
     vercel: {
       skewProtection: !!process.env.VERCEL_SKEW_PROTECTION_ENABLED,
+      immutableStaticFiles: !!process.env.VERCEL_IMMUTABLE_STATIC_FILES_ENABLED,
     },
     output: {
       dir: "{{ rootDir }}/.vercel/output",
@@ -108,11 +120,17 @@ const vercelStatic = defineNitroPreset(
       deploy: "npx vercel deploy --prebuilt",
     },
     hooks: {
+      "build:before": (nitro: Nitro) => {
+        if (nitro.options.vercel?.immutableStaticFiles) {
+          nitro.options.buildAssetsDir = immutableDir(nitro);
+        }
+      },
       "rollup:before": (nitro: Nitro) => {
         deprecateSWR(nitro);
       },
       async compiled(nitro: Nitro) {
         await generateStaticFiles(nitro);
+        await generateImmutableManifest(nitro);
       },
     },
   },

--- a/src/presets/vercel/types.ts
+++ b/src/presets/vercel/types.ts
@@ -121,6 +121,20 @@ export interface VercelOptions {
   skewProtection?: boolean;
 
   /**
+   * Emit content-addressed build assets as [immutable static files](https://vercel.com/docs/skew-protection).
+   *
+   * Immutable assets are served from the reserved `/_vercel/immutable/` base
+   * (without the deployment-scoped `?dpl` query), so they can be shared across
+   * deployments to improve cross-deployment caching. Nitro also writes an
+   * `immutable.json` manifest mapping each file to its full content hash.
+   *
+   * Can also be enabled with the `VERCEL_IMMUTABLE_STATIC_FILES_ENABLED` environment variable.
+   *
+   * @default false
+   */
+  immutableStaticFiles?: boolean;
+
+  /**
    * If you are using `vercel-edge`, you can specify the region(s) for your edge function.
    * @see https://vercel.com/docs/concepts/functions/edge-functions#edge-function-regions
    */

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -81,6 +81,16 @@ export interface NitroOptions extends PresetOptions {
     publicDir: string;
   };
 
+  /**
+   * Directory (relative to the served base) for generated build assets.
+   *
+   * Applied as the bundler `assetsDir` for client and SSR environments, so
+   * generated assets are emitted and referenced under this path. Presets can
+   * use it to relocate content-addressed assets (e.g. Vercel immutable static
+   * files under `_vercel/immutable`).
+   */
+  buildAssetsDir?: string;
+
   // Features
   storage: StorageMounts;
   devStorage: StorageMounts;

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -130,6 +130,9 @@ export default defineNitroConfig({
   scheduledTasks: {
     "* * * * *": "test",
   },
+  vercel: {
+    immutableStaticFiles: true,
+  },
   cloudflare: {
     pages: {
       routes: {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -1,10 +1,26 @@
 import { promises as fsp } from "node:fs";
 import { resolve, join, basename } from "pathe";
+import { joinURL } from "ufo";
 import { describe, expect, it, afterAll } from "vitest";
 import { setupTest, startServer, testNitro, fixtureDir } from "../tests";
 
 describe("nitro:preset:vercel", async () => {
+  const TEST_HASH_SALT = "initial";
+
+  // Example salt used to exercise `VERCEL_HASH_SALT` namespacing of immutable
+  // static files. Set around the (build-time) `setupTest` below and restored
+  // immediately after so it does not leak into other builds.
+  const prevHashSalt = process.env.VERCEL_HASH_SALT;
+  process.env.VERCEL_HASH_SALT = TEST_HASH_SALT;
+
   const ctx = await setupTest("vercel");
+
+  if (prevHashSalt === undefined) {
+    delete process.env.VERCEL_HASH_SALT;
+  } else {
+    process.env.VERCEL_HASH_SALT = prevHashSalt;
+  }
+
   testNitro(
     ctx,
     async () => {
@@ -424,6 +440,26 @@ describe("nitro:preset:vercel", async () => {
             "version": 3,
           }
         `);
+      });
+
+      it("should apply immutable buildAssetsDir and write manifest", async () => {
+        // `vercel.immutableStaticFiles` relocates build assets under the
+        // reserved `_vercel/immutable` base (namespaced by the optional
+        // `VERCEL_HASH_SALT` and the framework name) and emits an
+        // `immutable.json` manifest mapping each file to its full content hash.
+        const expectedDir = joinURL(
+          "_vercel/immutable",
+          TEST_HASH_SALT,
+          ctx.nitro!.options.framework.name || ""
+        );
+        expect(ctx.nitro!.options.buildAssetsDir).toBe(expectedDir);
+        expect(expectedDir).toBe(`_vercel/immutable/${TEST_HASH_SALT}/nitro`);
+
+        const manifest = await fsp
+          .readFile(resolve(ctx.outDir, "immutable.json"), "utf8")
+          .then((r) => JSON.parse(r));
+        expect(manifest.version).toBe(1);
+        expect(manifest.hashes).toBeTypeOf("object");
       });
 
       it("should generate prerender config", async () => {


### PR DESCRIPTION
backport draft of #4432 for v2 

undocumented and mainly for current nuxt v4 with manual integration with new `options.buildAssetsDir` (config name might change)

pending until #4432 lands, released and well-tested on real projects.

preview pkg for e2e testing:

```json
{
  "nitro": "https://pkg.pr.new/nitropack@4434"
}
```