### PR TITLE
fix(preset): keep lazy handlers code-split in dev

### DIFF
--- a/src/presets/_nitro/nitro-dev.ts
+++ b/src/presets/_nitro/nitro-dev.ts
@@ -19,7 +19,7 @@ const nitroDev = defineNitroPreset(
     ],
     externals: { noTrace: true },
     serveStatic: true,
-    inlineDynamicImports: true, // externals plugin limitation
+    inlineDynamicImports: false,
     sourcemap: true,
   },
   {

--- a/src/presets/_nitro/nitro-dev.ts
+++ b/src/presets/_nitro/nitro-dev.ts
@@ -1,30 +1,30 @@
-import { runtimeDir } from "nitro/meta";
-import { defineNitroPreset } from "../_utils/preset.ts";
-import { join } from "pathe";
+import { defineNitroPreset } from "nitropack/kit";
 
 const nitroDev = defineNitroPreset(
   {
-    entry: "./_nitro/runtime/nitro-dev",
+    entry: "./runtime/nitro-dev",
     output: {
       dir: "{{ buildDir }}/dev",
       serverDir: "{{ buildDir }}/dev",
       publicDir: "{{ buildDir }}/dev",
     },
-    handlers: [
-      {
-        route: "/_nitro/tasks/**",
-        lazy: true,
-        handler: join(runtimeDir, "internal/routes/dev-tasks"),
-      },
-    ],
-    externals: { noTrace: true },
+    externals: { trace: false },
     serveStatic: true,
+    // Keep lazy handlers as real, code-split dynamic imports in dev. When this
+    // is `true`, Rollup inlines every lazy handler into a single `index.mjs`
+    // and evaluates each server module eagerly at that module's top level, so
+    // one module throwing at import time aborts the whole bundle's evaluation
+    // and leaves unrelated `const`s (e.g. `renderer`) in the temporal dead
+    // zone. Every request then fails with a misleading
+    // `Cannot access '<x>' before initialization` instead of the real error.
+    // See nitrojs/nitro#1670, nuxt/nuxt#20576.
     inlineDynamicImports: false,
-    sourcemap: true,
+    sourceMap: true,
   },
   {
     name: "nitro-dev" as const,
     dev: true,
+    url: import.meta.url,
   }
 );
 

--- a/test/fixtures/dev-import-error/routes/boom.get.ts
+++ b/test/fixtures/dev-import-error/routes/boom.get.ts
@@ -1,0 +1,8 @@
+// This module throws while it is being *evaluated* (import time), not inside
+// the handler. Regression guard for the dev server surfacing the real error
+// instead of an unrelated `Cannot access '<x>' before initialization` TDZ.
+throw new Error("boom_import_time_error");
+
+export default defineEventHandler(() => {
+  return { unreachable: true };
+});

--- a/test/fixtures/dev-import-error/routes/ok.get.ts
+++ b/test/fixtures/dev-import-error/routes/ok.get.ts
@@ -1,0 +1,5 @@
+// A perfectly healthy route that has nothing to do with the throwing one.
+// It must keep working even when a sibling route throws at import time.
+export default defineEventHandler(() => {
+  return { ok: true };
+});

--- a/test/unit/dev-import-error.test.ts
+++ b/test/unit/dev-import-error.test.ts
@@ -1,0 +1,67 @@
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Listener } from "listhen";
+import { build, createDevServer, createNitro, prepare } from "nitropack/core";
+import { fetch } from "ofetch";
+import { joinURL } from "ufo";
+
+// Regression test for the dev server reporting a misleading
+// `Cannot access '<x>' before initialization` when one server module throws at
+// import (evaluation) time. See nitrojs/nitro#1670, nuxt/nuxt#20576.
+//
+// The fixture has two routes:
+//   - /ok    healthy
+//   - /boom  throws `boom_import_time_error` at module top level
+//
+// Expected dev behaviour:
+//   - hitting the unrelated /ok route keeps working (the throwing module is
+//     only evaluated when its own route is requested);
+//   - hitting /boom fails with the *real* error, not a TDZ error about an
+//     unrelated internal symbol.
+describe("dev: import-time error in one server module", () => {
+  const rootDir = fileURLToPath(
+    new URL("../fixtures/dev-import-error", import.meta.url)
+  );
+  let nitro: Awaited<ReturnType<typeof createNitro>>;
+  let server: Listener;
+
+  beforeAll(async () => {
+    nitro = await createNitro(
+      { dev: true, preset: "nitro-dev", rootDir },
+      { compatibilityDate: "latest" }
+    );
+    const devServer = createDevServer(nitro);
+    server = await devServer.listen({});
+    await prepare(nitro);
+    const ready = new Promise<void>((resolve) => {
+      nitro.hooks.hook("dev:reload", () => resolve());
+    });
+    await build(nitro);
+    await ready;
+  }, 120_000);
+
+  afterAll(async () => {
+    await server?.close();
+    await nitro?.close();
+  });
+
+  const call = (path: string) =>
+    fetch(joinURL(server.url, path.slice(1)), {
+      redirect: "manual",
+    }).then(async (res) => ({ status: res.status, body: await res.text() }));
+
+  it("keeps unrelated routes working", async () => {
+    const res = await call("/ok");
+    expect(res.body).not.toContain("before initialization");
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("ok");
+  });
+
+  it("surfaces the real error for the throwing route", async () => {
+    const res = await call("/boom");
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    // The real cause must be reported, not an unrelated TDZ symbol.
+    expect(res.body).not.toContain("before initialization");
+    expect(res.body).toContain("boom_import_time_error");
+  });
+});


### PR DESCRIPTION
### Description

This PR fixes an issue where an import-time error in a single lazy route handler takes down the entire dev server and breaks unrelated routes with a misleading `Cannot access '<x>' before initialization` error.

**Cause:** 
The `nitro-dev` preset was setting `inlineDynamicImports: true`. This caused Rollup to inline all lazy handler bodies into the single `index.mjs` startup bundle. An error evaluating one route would abort the execution of the bundle, leaving subsequent routes permanently in the Temporal Dead Zone (TDZ).

**Fix:** 
We've set `inlineDynamicImports: false` in the `nitro-dev` preset. This ensures lazy handlers remain code-split during local development, so an import-time failure in one module will not disrupt the evaluation of the rest of the server or other routes. When a broken route is accessed, the dev server will now accurately report the original initialization error.

Fixes #4435
