### PR TITLE
feat(vite): add `vite:before:close` hook

### DIFF
--- a/src/build/vite/prod.ts
+++ b/src/build/vite/prod.ts
@@ -103,6 +103,9 @@ export async function buildEnvironments(ctx: NitroPluginContext, builder: ViteBu
   // Prerender routes if configured
   await prerender(nitro);
 
+  // Call vite:before:close hook
+  await nitro.hooks.callHook("vite:before:close", nitro);
+
   // Build the Nitro server bundle
   const output = (await builder.build(builder.environments.nitro)) as RolldownOutput;
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -10,6 +10,10 @@ export interface NitroHooks {
   "types:extend": (types: NitroTypes) => HookResult;
   "build:before": (nitro: Nitro) => HookResult;
   "rollup:before": (nitro: Nitro, config: RollupConfig) => HookResult;
+  /**
+   * Called before Nitro instance is closed during Vite build but after prerender process.
+   */
+  "vite:before:close": (nitro: Nitro) => HookResult;
   compiled: (nitro: Nitro) => HookResult;
   "dev:reload": (payload?: { entry?: string; workerData?: EnvRunnerData }) => HookResult;
   "dev:start": () => HookResult;


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
resolves #4428

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Vite builder differs a lot from Rolldown/Rollup builders, the new hook is only for Vite builder and for build.

Once Nitro is closed, any asset written to the output public folder won't be added to the routes (404 when requesting assets generated at `compiled` hook)

We should add a custom entry for hooks like Nuxt docs, the config entry only mentons hookable and links to lifecycle that seems unrelated to Nitro hooks.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
