### PR TITLE
docs: use event.url.pathname in lifecycle hook examples

### DIFF
--- a/docs/1.docs/50.lifecycle.md
+++ b/docs/1.docs/50.lifecycle.md
@@ -21,7 +21,7 @@ import { definePlugin } from "nitro";
 
 export default definePlugin((nitroApp) => {
   nitroApp.hooks.hook("request", (event) => {
-    console.log(`Incoming request on ${event.path}`);
+    console.log(`Incoming request on ${event.url.pathname}`);
   });
 });
 ```
@@ -123,7 +123,7 @@ import { definePlugin } from "nitro";
 
 export default definePlugin((nitroApp) => {
   nitroApp.hooks.hook("response", (res, event) => {
-    console.log(`Response ${res.status} for ${event.path}`);
+    console.log(`Response ${res.status} for ${event.url.pathname}`);
   });
 });
 ```


### PR DESCRIPTION
## Summary
The `request` and `response` hooks receive an `HTTPEvent`, which does not have a `path` property.
Update the lifecycle docs examples to use `event.url.pathname` instead.

Fixes #4375

## Notes
- Docs-only change
- Intentionally does not touch routing/middleware/`defineHandler` examples
- Related prior PR #4384 was closed after broader middleware-path edits; this PR keeps the scope to the HTTPEvent hook examples only