### PR TITLE
docs: fix link navigation

### DIFF
--- a/docs/.docs/components/AppHeroLinks.vue
+++ b/docs/.docs/components/AppHeroLinks.vue
@@ -21,7 +21,7 @@
       :href="`${baseURL}llms.txt`"
       target="_blank"
       class="basis-full text-sm text-muted hover:text-default transition-colors inline-flex items-center justify-center gap-1"
-      @click.prevent="copyPrompt"
+      @click="copyPrompt"
     >
       <UIcon :name="copied ? 'i-lucide-clipboard-check' : 'i-lucide-bot'" />
       Docs for AI


### PR DESCRIPTION
I think when we click on `Docs for AI` in the home page, we do not get anything. But the link should move to `/llms.txt`. I think what I have done fix the issue.

https://nitro.build/