### PR TITLE
docs: document minify: false for debugging workers

### DIFF
--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -983,9 +983,17 @@ export default defineConfig({
 
 Minify bundle.
 
+Some presets (especially worker runtimes) enable minification by default. Set `minify: false` when debugging production, worker, or edge builds so stack traces stay readable. This is also helpful on Vercel Edge.
+
 ```ts
 export default defineConfig({
   minify: true, // minify production bundle
+});
+```
+
+```ts
+export default defineConfig({
+  minify: false, // easier to debug workers / edge bundles
 });
 ```
 

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -983,7 +983,7 @@ export default defineConfig({
 
 Minify bundle.
 
-Some presets (especially worker runtimes) enable minification by default. Set `minify: false` when debugging production, worker, or edge builds so stack traces stay readable. This is also helpful on Vercel Edge.
+Some presets (especially worker runtimes) enable minification by default. Set `minify: false` when debugging production, worker, or edge builds so stack traces stay readable. 
 
 ```ts
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Document that some presets (especially worker runtimes) enable minify by default
- Note that setting `minify: false` keeps stack traces readable when debugging production, worker, or edge builds (including Vercel Edge)

Fixes #415

## Test plan

- [ ] Confirm the minify section in config docs reads clearly
- [ ] No code changes — docs only