### PR TITLE
fix(dev): keep lazy handlers code-split so import-time errors surface correctly (v2)

### DIFF
--- a/src/presets/_nitro/nitro-dev.ts
+++ b/src/presets/_nitro/nitro-dev.ts
@@ -10,7 +10,15 @@ const nitroDev = defineNitroPreset(
     },
     externals: { trace: false },
     serveStatic: true,
-    inlineDynamicImports: true, // externals plugin limitation
+    // Keep lazy handlers as real, code-split dynamic imports in dev. When this
+    // is `true`, Rollup inlines every lazy handler into a single `index.mjs`
+    // and evaluates each server module eagerly at that module's top level, so
+    // one module throwing at import time aborts the whole bundle's evaluation
+    // and leaves unrelated `const`s (e.g. `renderer`) in the temporal dead
+    // zone. Every request then fails with a misleading
+    // `Cannot access '<x>' before initialization` instead of the real error.
+    // See nitrojs/nitro#1670, nuxt/nuxt#20576.
+    inlineDynamicImports: false,
     sourceMap: true,
   },
   {

--- a/test/fixtures/dev-import-error/routes/boom.get.ts
+++ b/test/fixtures/dev-import-error/routes/boom.get.ts
@@ -1,0 +1,8 @@
+// This module throws while it is being *evaluated* (import time), not inside
+// the handler. Regression guard for the dev server surfacing the real error
+// instead of an unrelated `Cannot access '<x>' before initialization` TDZ.
+throw new Error("boom_import_time_error");
+
+export default defineEventHandler(() => {
+  return { unreachable: true };
+});

--- a/test/fixtures/dev-import-error/routes/ok.get.ts
+++ b/test/fixtures/dev-import-error/routes/ok.get.ts
@@ -1,0 +1,5 @@
+// A perfectly healthy route that has nothing to do with the throwing one.
+// It must keep working even when a sibling route throws at import time.
+export default defineEventHandler(() => {
+  return { ok: true };
+});

--- a/test/unit/dev-import-error.test.ts
+++ b/test/unit/dev-import-error.test.ts
@@ -1,0 +1,67 @@
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Listener } from "listhen";
+import { build, createDevServer, createNitro, prepare } from "nitropack/core";
+import { fetch } from "ofetch";
+import { joinURL } from "ufo";
+
+// Regression test for the dev server reporting a misleading
+// `Cannot access '<x>' before initialization` when one server module throws at
+// import (evaluation) time. See nitrojs/nitro#1670, nuxt/nuxt#20576.
+//
+// The fixture has two routes:
+//   - /ok    healthy
+//   - /boom  throws `boom_import_time_error` at module top level
+//
+// Expected dev behaviour:
+//   - hitting the unrelated /ok route keeps working (the throwing module is
+//     only evaluated when its own route is requested);
+//   - hitting /boom fails with the *real* error, not a TDZ error about an
+//     unrelated internal symbol.
+describe("dev: import-time error in one server module", () => {
+  const rootDir = fileURLToPath(
+    new URL("../fixtures/dev-import-error", import.meta.url)
+  );
+  let nitro: Awaited<ReturnType<typeof createNitro>>;
+  let server: Listener;
+
+  beforeAll(async () => {
+    nitro = await createNitro(
+      { dev: true, preset: "nitro-dev", rootDir },
+      { compatibilityDate: "latest" }
+    );
+    const devServer = createDevServer(nitro);
+    server = await devServer.listen({});
+    await prepare(nitro);
+    const ready = new Promise<void>((resolve) => {
+      nitro.hooks.hook("dev:reload", () => resolve());
+    });
+    await build(nitro);
+    await ready;
+  }, 120_000);
+
+  afterAll(async () => {
+    await server?.close();
+    await nitro?.close();
+  });
+
+  const call = (path: string) =>
+    fetch(joinURL(server.url, path.slice(1)), {
+      redirect: "manual",
+    }).then(async (res) => ({ status: res.status, body: await res.text() }));
+
+  it("keeps unrelated routes working", async () => {
+    const res = await call("/ok");
+    expect(res.body).not.toContain("before initialization");
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("ok");
+  });
+
+  it("surfaces the real error for the throwing route", async () => {
+    const res = await call("/boom");
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    // The real cause must be reported, not an unrelated TDZ symbol.
+    expect(res.body).not.toContain("before initialization");
+    expect(res.body).toContain("boom_import_time_error");
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #4435 (for **v2**).

### 📚 Description

In dev, the `nitro-dev` preset sets Rollup `inlineDynamicImports: true`, which inlines every
lazy server handler into the single `.nitro/dev/index.mjs` and evaluates each handler module
**eagerly** at that bundle's top level. When one server module throws at **import
(evaluation) time**, evaluation aborts *after* `server.listen()` has already run, leaving
unrelated later `const`s (e.g. `renderer`) permanently in the temporal dead zone. Every
request then fails with a misleading `Cannot access '<x>' before initialization`, while the
real error is only logged once at startup as an `uncaughtException`.

This has caused a long tail of reports that were closed as "circular dependency in user
code": #1670, nuxt/nuxt#20576, sidebase/nuxt-auth#271.

**Fix:** set `inlineDynamicImports: false` for the `nitro-dev` preset so lazy handlers stay
genuinely code-split in dev. An import-time failure is then isolated to its own route and
surfaces the real error instead of poisoning unrelated ones.

Behaviour, before → after (minimal repro: a healthy `/ok` route + a `/boom` route that throws
at import time):

| request | before | after |
|---|---|---|
| `GET /ok` (unrelated) | `500 Cannot access 'ok_get$1' before initialization` | `200 {"ok":true}` |
| `GET /boom` | `500 Cannot access 'ok_get$1' before initialization` | `500` with the real error at `routes/boom.get.ts` |

### 🧪 Verification / scope note

- Adds a regression test (`test/unit/dev-import-error.test.ts` + fixture) that **fails before /
  passes after** this change.
- Full suite unchanged: the existing suite stays at **641 passed, 0 failures** (same as
  baseline — zero regressions); with the added test the branch runs **643 / 0**.
- I verified the `// externals plugin limitation` concern doesn't reproduce in the current
  suite with code-splitting on, but I'd welcome a maintainer's read on whether there are
  externals scenarios the fixture doesn't cover.

**Why this targets `v2` and not `main`:** the misleading-TDZ behaviour is v2-specific. I
verified on `main` (v3) that the bug does **not** reproduce — with the default rolldown dev
builder an import-time throw is already isolated (`/ok` → 200) and reports the real error, and
with the rollup builder the dev worker fails fast with the real error (503), never the TDZ. On
v3 this same `inlineDynamicImports: false` change is a no-op for rolldown and actually breaks
the rollup build (`Cannot read properties of null (reading 'getVariableForExportName')`). So
the fix belongs on v2, where users on current Nuxt (`@nuxt/nitro-server` → `nitropack@^2`)
actually hit it. (Context on the parallel v3 PR: #4436.)
