### PR TITLE
fix(dev): keep lazy handlers code-split in dev

### DIFF
--- a/src/presets/_nitro/nitro-dev.ts
+++ b/src/presets/_nitro/nitro-dev.ts
@@ -10,7 +10,7 @@ const nitroDev = defineNitroPreset(
     },
     externals: { trace: false },
     serveStatic: true,
-    inlineDynamicImports: true, // externals plugin limitation
+    inlineDynamicImports: false, // externals plugin limitation
     sourceMap: true,
   },
   {


### PR DESCRIPTION
  Linked issue

Fixes #4435 

###  Type of change

-  Documentation (updates to the documentation, readme, or JSdoc annotations)
-  Bug fix (a non-breaking change that fixes an issue)
-  Enhancement (improving an existing functionality like performance)
-  New feature (a non-breaking change that adds functionality)
-  Chore (updates to the build process or auxiliary tools and libraries)
- Breaking change (fix or feature that would cause existing functionality to change)

Description

This fixes a bug in the `nitro-dev` preset where an import-time error in a single lazy route handler takes down the entire dev server and breaks unrelated routes with a misleading `Cannot access '<x>' before initialization` error.

**Cause:**
The `nitro-dev` preset was setting `inlineDynamicImports: true`. This caused Rollup to inline all lazy handler bodies into the single `index.mjs` startup bundle. An error evaluating one route would abort the execution of the bundle, leaving subsequent routes permanently in the Temporal Dead Zone (TDZ).

**Fix:**
Set `inlineDynamicImports: false` in the `nitro-dev` preset. This ensures lazy handlers remain code-split during local development, so an import-time failure in one module will not disrupt the evaluation of the rest of the server or other routes. When a broken route is accessed, the dev server will now accurately report the original initialization error.

*(Note: This PR is functionally equivalent to #4436 and #4458, but properly targets the `v2` branch where this issue actually affects users.)*
