### PR TITLE
docs: clarify noExternals path patterns

### DIFF
--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -1065,13 +1065,45 @@ export default defineConfig({
 
 - Default: `false`{lang=ts}
 
-Prevent specific packages from being externalized. Set to `true` to bundle all dependencies, or pass an array of package names/patterns.
+By default, Nitro externalizes dependencies from `node_modules` for faster builds. Inlined modules are bundled into the output and can use your `alias` configuration.
+
+Set `noExternals` to `true` to bundle **all** dependencies, or pass an array of patterns to inline specific modules only.
 
 ```ts
 export default defineConfig({
   noExternals: true, // bundle all dependencies
 });
 ```
+
+#### Inlining specific packages
+
+When you pass an array, each entry is converted to a path regular expression and matched against the **resolved absolute module path** (the `id` Rollup sees after resolution). Patterns are **not** matched against bare import specifiers such as `@scope/pkg` or `lodash`.
+
+Use this when:
+
+- A workspace or monorepo package must be bundled so it can resolve your Nitro `alias` paths
+- A dependency under `node_modules` imports files that rely on your aliases
+
+```ts
+export default defineConfig({
+  alias: {
+    "@shared": "./shared",
+  },
+  noExternals: [
+    // Match the package in both monorepo dev and installed node_modules layouts
+    /packages[\\/]my-lib/,
+    /node_modules[\\/]@scope[\\/]my-lib/,
+  ],
+});
+```
+
+A path segment that appears in both layouts (for example `/my-lib/`) can also work, but prefer explicit `packages/` and `node_modules/` patterns when possible.
+
+`RegExp` values are used as-is. String values are escaped and treated as path substrings. Use `[\\/]` in regexes so patterns work on Windows and POSIX paths.
+
+::note
+**Nitro 2:** the same patterns were configured as `externals.inline` in `defineNitroConfig`. In Nitro 3, use `noExternals` instead.
+::
 
 ### `traceDeps`
 

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -1125,13 +1125,45 @@ export default defineConfig({
 
 - Default: `false`{lang=ts}
 
-Prevent specific packages from being externalized. Set to `true` to bundle all dependencies, or pass an array of package names/patterns.
+By default, Nitro externalizes dependencies from `node_modules` for faster builds. Inlined modules are bundled into the output and can use your `alias` configuration.
+
+Set `noExternals` to `true` to bundle **all** dependencies, or pass an array of patterns to inline specific modules only.
 
 ```ts
 export default defineConfig({
   noExternals: true, // bundle all dependencies
 });
 ```
+
+#### Inlining specific packages
+
+When you pass an array, each entry is converted to a path regular expression and matched against the **resolved absolute module path** (the `id` Rollup sees after resolution). Patterns are **not** matched against bare import specifiers such as `@scope/pkg` or `lodash`.
+
+Use this when:
+
+- A workspace or monorepo package must be bundled so it can resolve your Nitro `alias` paths
+- A dependency under `node_modules` imports files that rely on your aliases
+
+```ts
+export default defineConfig({
+  alias: {
+    "@shared": "./shared",
+  },
+  noExternals: [
+    // Match the package in both monorepo dev and installed node_modules layouts
+    /packages[\\/]my-lib/,
+    /node_modules[\\/]@scope[\\/]my-lib/,
+  ],
+});
+```
+
+A path segment that appears in both layouts (for example `/my-lib/`) can also work, but prefer explicit `packages/` and `node_modules/` patterns when possible.
+
+`RegExp` values are used as-is. String values are escaped and treated as path substrings. Use `[\\/]` in regexes so patterns work on Windows and POSIX paths.
+
+::note
+**Nitro 2:** the same patterns were configured as `externals.inline` in `defineNitroConfig`. In Nitro 3, use `noExternals` instead.
+::
 
 ### `traceDeps`
 

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -1125,9 +1125,11 @@ export default defineConfig({
 
 - Default: `false`{lang=ts}
 
-By default, Nitro externalizes dependencies from `node_modules` for faster builds. Inlined modules are bundled into the output and can use your `alias` configuration.
+Prevent packages from being externalized. Externalized packages are imported at runtime instead of being bundled, so they do not see your `alias` configuration.
 
-Set `noExternals` to `true` to bundle **all** dependencies, or pass an array of patterns to inline specific modules only.
+In a production build Nitro already bundles almost everything: only native or otherwise non-bundleable packages and the ones listed in [`traceDeps`](#tracedeps) stay external. In development, dependencies inside `node_modules` are kept external for speed, which is where this option matters most.
+
+Set it to `true` to bundle everything, including packages that are normally kept external:
 
 ```ts
 export default defineConfig({
@@ -1137,32 +1139,31 @@ export default defineConfig({
 
 #### Inlining specific packages
 
-When you pass an array, each entry is converted to a path regular expression and matched against the **resolved absolute module path** (the `id` Rollup sees after resolution). Patterns are **not** matched against bare import specifiers such as `@scope/pkg` or `lodash`.
+Pass an array to inline only some modules. `RegExp` entries are used as-is; string entries are escaped and matched as a path substring.
 
-Use this when:
-
-- A workspace or monorepo package must be bundled so it can resolve your Nitro `alias` paths
-- A dependency under `node_modules` imports files that rely on your aliases
+Each pattern is tested against the import specifier as written (for example `@scope/my-lib`) and against the resolved absolute file path (for example `/…/node_modules/@scope/my-lib/dist/index.mjs`). A match on either one keeps the module bundled, so a plain package name is usually all you need:
 
 ```ts
 export default defineConfig({
   alias: {
     "@shared": "./shared",
   },
-  noExternals: [
-    // Match the package in both monorepo dev and installed node_modules layouts
-    /packages[\\/]my-lib/,
-    /node_modules[\\/]@scope[\\/]my-lib/,
-  ],
+  noExternals: ["@scope/my-lib"],
 });
 ```
 
-A path segment that appears in both layouts (for example `/my-lib/`) can also work, but prefer explicit `packages/` and `node_modules/` patterns when possible.
+Use a path pattern when you need to be more precise, for example to inline one package in a monorepo without matching a similarly named one:
 
-`RegExp` values are used as-is. String values are escaped and treated as path substrings. Use `[\\/]` in regexes so patterns work on Windows and POSIX paths.
+```ts
+export default defineConfig({
+  noExternals: [/packages[\\/]my-lib/],
+});
+```
+
+Write `[\\/]` instead of `/` in such patterns so they also match Windows paths.
 
 ::note
-**Nitro 2:** the same patterns were configured as `externals.inline` in `defineNitroConfig`. In Nitro 3, use `noExternals` instead.
+In Nitro 2 this option was `externals.inline`.
 ::
 
 ### `traceDeps`

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -832,8 +832,8 @@ export interface NitroOptions extends PresetOptions {
   /**
    * Prevent packages from being externalized.
    *
-   * Set to `true` to bundle all dependencies, or pass an array of
-   * package names or patterns.
+   * Set to `true` to bundle all dependencies, or pass an array of path
+   * patterns matched against resolved module IDs (not bare import specifiers).
    *
    * @see https://nitro.build/config#noexternals
    */

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -831,8 +831,8 @@ export interface NitroOptions extends PresetOptions {
   /**
    * Prevent packages from being externalized.
    *
-   * Set to `true` to bundle all dependencies, or pass an array of path
-   * patterns matched against resolved module IDs (not bare import specifiers).
+   * Set to `true` to bundle all dependencies, or pass an array of patterns
+   * matched against both the import specifier and the resolved module path.
    *
    * @see https://nitro.build/config#noexternals
    */

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -831,8 +831,8 @@ export interface NitroOptions extends PresetOptions {
   /**
    * Prevent packages from being externalized.
    *
-   * Set to `true` to bundle all dependencies, or pass an array of
-   * package names or patterns.
+   * Set to `true` to bundle all dependencies, or pass an array of path
+   * patterns matched against resolved module IDs (not bare import specifiers).
    *
    * @see https://nitro.build/config#noexternals
    */


### PR DESCRIPTION
## Summary

Closes #3269.

Documents how `noExternals` array patterns work: they match resolved absolute module paths, not bare import specifiers. Adds monorepo and `node_modules` examples and a Nitro 2 `externals.inline` migration note.

Also updates the `noExternals` JSDoc in `src/types/config.ts` to match.

## Test plan

- [x] Verified against `src/build/config.ts` and `src/build/plugins/externals.ts`
- [x] Docs-only change (plus JSDoc)