### PR TITLE
docs: clarify prerender and isr route rules

### DIFF
--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -660,9 +660,19 @@ export default defineConfig({
 });
 ```
 
+Prerendered routes are generated once at build time and served as static files. They are not revalidated at runtime.
+
+::warning
+Do not combine `prerender` and `isr` on the same route. Prerendering takes precedence, so `isr` is ignored and the page will not be regenerated after deployment. Use `isr` alone when you need incremental regeneration on supported platforms.
+::
+
 ### ISR (Vercel)
 
 Configure Incremental Static Regeneration for Vercel deployments:
+
+::note
+ISR generates pages on demand and revalidates them according to the expiration you set. It is an alternative to build-time `prerender`, not something you combine with it on the same route.
+::
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";

--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -655,9 +655,19 @@ export default defineConfig({
 });
 ```
 
+Prerendered routes are generated once at build time and served as static files. They are not revalidated at runtime.
+
+::warning
+Do not combine `prerender` and `isr` on the same route. Prerendering takes precedence, so `isr` is ignored and the page will not be regenerated after deployment. Use `isr` alone when you need incremental regeneration on supported platforms.
+::
+
 ### ISR (Vercel)
 
 Configure Incremental Static Regeneration for Vercel deployments:
+
+::note
+ISR generates pages on demand and revalidates them according to the expiration you set. It is an alternative to build-time `prerender`, not something you combine with it on the same route.
+::
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";

--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -665,10 +665,6 @@ Do not combine `prerender` and `isr` on the same route. Prerendering takes prece
 
 Configure Incremental Static Regeneration for Vercel deployments:
 
-::note
-ISR generates pages on demand and revalidates them according to the expiration you set. It is an alternative to build-time `prerender`, not something you combine with it on the same route.
-::
-
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";
 
@@ -686,6 +682,10 @@ export default defineConfig({
   }
 });
 ```
+
+::note
+ISR generates pages on demand and revalidates them according to the expiration you set. It is an alternative to build-time `prerender`, not something you combine with it on the same route.
+::
 
 ### Route rules reference
 

--- a/docs/2.deploy/20.providers/vercel.md
+++ b/docs/2.deploy/20.providers/vercel.md
@@ -336,6 +336,10 @@ Additional options are available under the `vercel` key in your Nitro config:
 
 On-demand revalidation lets you purge the cache for an ISR route whenever you want, without waiting for the interval used by background revalidation.
 
+::warning
+Do not combine the `isr` and `prerender` route rules on the same route. Prerendered pages are written as static files at build time and Vercel serves them from the filesystem before the ISR function is reached, so `isr` never applies. Use `isr` alone when you need regeneration after deployment.
+::
+
 To revalidate a page on demand:
 
 1. Create an environment variable to store a revalidation secret

--- a/src/types/route-rules.ts
+++ b/src/types/route-rules.ts
@@ -55,6 +55,9 @@ declare module "h3-rules" {
      * Only handled by presets with native support (e.g. Vercel, Netlify).
      * Ignored on platforms without ISR support.
      *
+     * Do not combine with `prerender` on the same route — prerendered pages are
+     * generated at build time and ISR will not apply.
+     *
      * @see https://nitro.build/docs/routing#isr-vercel
      */
     isr?: number /* expiration */ | boolean | VercelISRConfig;

--- a/src/types/route-rules.ts
+++ b/src/types/route-rules.ts
@@ -57,6 +57,9 @@ declare module "h3/rules" {
      * Only handled by presets with native support (e.g. Vercel, Netlify).
      * Ignored on platforms without ISR support.
      *
+     * Do not combine with `prerender` on the same route — prerendered pages are
+     * generated at build time and ISR will not apply.
+     *
      * @see https://nitro.build/docs/routing#isr-vercel
      */
     isr?: number /* expiration */ | boolean | VercelISRConfig;


### PR DESCRIPTION
## Summary

Closes #4041.

Documents that `prerender` and `isr` must not be combined on the same route — prerendered pages are generated at build time and ISR is ignored. Adds routing guide warnings and updates the `isr` JSDoc.

## Test plan

- [x] Docs-only change (plus JSDoc)
- [x] Wording aligned with maintainer clarification on the issue