### PR TITLE
docs: add compatibility date changelog

### DIFF
--- a/automd.config.ts
+++ b/automd.config.ts
@@ -192,19 +192,18 @@ export default {
     compatDate: {
       name: "compatDate",
       async generate(ctx) {
-        // const { compatibilityChanges } = await import("./lib/meta.mjs");
+        const { compatibilityChanges } = await import("./lib/meta.mjs");
 
-        // const table = [
-        //   "| Compatibility date | Platform | Description |",
-        //   "|------|----------|-------------|",
-        //   ...compatibilityChanges.map(
-        //     (change) =>
-        //       `| **≥ ${change.from}** | ${change.platform} | ${change.description} |`
-        //   ),
-        // ];
+        const table = [
+          "| Compatibility date | Platform | Description |",
+          "|------|----------|-------------|",
+          ...compatibilityChanges.map(
+            (change) =>
+              `| **≥ ${change.from}** | ${change.platform} | ${change.description} |`
+          ),
+        ];
         return {
-          // contents: table.join("\n"),
-          contents: "",
+          contents: table.join("\n"),
         };
       },
     },

--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -660,9 +660,19 @@ export default defineConfig({
 });
 ```
 
+Prerendered routes are generated once at build time and served as static files. They are not revalidated at runtime.
+
+::warning
+Do not combine `prerender` and `isr` on the same route. Prerendering takes precedence, so `isr` is ignored and the page will not be regenerated after deployment. Use `isr` alone when you need incremental regeneration on supported platforms.
+::
+
 ### ISR (Vercel)
 
 Configure Incremental Static Regeneration for Vercel deployments:
+
+::note
+ISR generates pages on demand and revalidates them according to the expiration you set. It is an alternative to build-time `prerender`, not something you combine with it on the same route.
+::
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";

--- a/docs/2.deploy/0.index.md
+++ b/docs/2.deploy/0.index.md
@@ -59,14 +59,22 @@ export default defineConfig({
 
 Deployment providers regularly update their runtime behavior. Nitro presets are updated to support these new features.
 
-To prevent breaking existing deployments, Nitro uses compatibility dates. These dates let you lock in behavior at the project creation time. You can also opt in to future updates when ready.
+To prevent breaking existing deployments, Nitro uses **compatibility dates**. A compatibility date locks in preset behavior at the time you set it. When you are ready, bump the date to opt in to newer preset output.
 
-When you create a new project, the `compatibilityDate` is set to the current date. This setting is saved in your project's configuration.
+When you create a new project, `compatibilityDate` is set to the current date and saved in your configuration. You can also set per-provider dates (for example `compatibilityDate.cloudflare`) when one platform should move forward before others.
 
-You should update the compatibility date periodically. Always test your deployment thoroughly after updating. Below is a list of key dates and their effects.
+You should update the compatibility date periodically. Always test your deployment thoroughly after updating. Below is a changelog of key dates and the behavior they enable.
+
+:read-more{to="/config#compatibilitydate"}
 
 <!-- automd:compatDate -->
 
-
+| Compatibility date | Platform | Description |
+|------|----------|-------------|
+| **≥ 2024-05-07** | netlify | Netlify Functions v2 output format |
+| **≥ 2024-09-19** | cloudflare | Static assets support for the `cloudflare-module` preset |
+| **≥ 2025-01-30** | deno | Deno v2 Node.js compatibility for `deno-server` |
+| **≥ 2025-07-13** | cloudflare | `cloudflare-dev` preset with Miniflare-based local development |
+| **≥ 2025-07-15** | vercel | Observability route configuration in the Vercel build output |
 
 <!-- /automd -->

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -78,17 +78,21 @@ export default defineConfig({
 
 ### `compatibilityDate`
 
-Deployment providers introduce new features that Nitro presets can leverage, but some of them need to be explicitly opted into.
+Deployment providers introduce new features that Nitro presets can leverage, but some of them need to be explicitly opted into via a compatibility date.
 
-Set it to latest tested date in `YYYY-MM-DD` format to leverage latest preset features.
+Set it to the latest tested date in `YYYY-MM-DD` format to enable newer preset behavior. You can also set per-provider dates when a platform should move forward independently.
 
-If this configuration is not provided, Nitro will use `"latest"` behavior by default.
+If this configuration is not provided, Nitro uses `"latest"` behavior by default.
 
 ```ts
 export default defineConfig({
   compatibilityDate: "2025-01-01",
+  // Or per provider:
+  // compatibilityDate: { default: "2025-01-01", cloudflare: "2025-07-13" },
 });
 ```
+
+:read-more{to="/deploy#compatibility-date" title="Compatibility date changelog"}
 
 ### `static`
 

--- a/lib/meta.mjs
+++ b/lib/meta.mjs
@@ -1,0 +1,31 @@
+import packageJson from "../package.json" with { type: "json" };
+
+export const version = packageJson.version;
+
+export const compatibilityChanges = [
+  {
+    from: "2024-05-07",
+    platform: "netlify",
+    description: "Netlify Functions v2 output format",
+  },
+  {
+    from: "2024-09-19",
+    platform: "cloudflare",
+    description: "Static assets support for the `cloudflare-module` preset",
+  },
+  {
+    from: "2025-01-30",
+    platform: "deno",
+    description: "Deno v2 Node.js compatibility for `deno-server`",
+  },
+  {
+    from: "2025-07-13",
+    platform: "cloudflare",
+    description: "`cloudflare-dev` preset with Miniflare-based local development",
+  },
+  {
+    from: "2025-07-15",
+    platform: "vercel",
+    description: "Observability route configuration in the Vercel build output",
+  },
+];

--- a/src/types/route-rules.ts
+++ b/src/types/route-rules.ts
@@ -55,6 +55,9 @@ declare module "h3-rules" {
      * Only handled by presets with native support (e.g. Vercel, Netlify).
      * Ignored on platforms without ISR support.
      *
+     * Do not combine with `prerender` on the same route — prerendered pages are
+     * generated at build time and ISR will not apply.
+     *
      * @see https://nitro.build/docs/routing#isr-vercel
      */
     isr?: number /* expiration */ | boolean | VercelISRConfig;


### PR DESCRIPTION
## Summary

Closes #3139.

Restores the compatibility date changelog (lib/meta.mjs + automd generator) and expands deploy/config docs explaining what compatibility dates are and how to use per-provider dates.

## Test plan

- [x] Dates verified against preset source and issue #3139
- [x] Docs-only change

Made with [Cursor](https://cursor.com)