### PR TITLE
docs: document custom storage drivers

### DIFF
--- a/docs/1.docs/8.storage.md
+++ b/docs/1.docs/8.storage.md
@@ -105,41 +105,60 @@ You can find the driver list on [unstorage documentation](https://unstorage.unjs
 
 The `driver` field accepts a built-in driver name (for example `"redis"`) or a **path** to a custom driver module. You cannot pass a driver function or object directly in config — Nitro imports drivers as separate modules so your config stays separate from runtime code.
 
-Create a driver file that default-exports a driver created with `defineDriver`:
+Create a driver file that **default-exports** a driver factory from `defineDriver`. To build a driver from scratch, implement the [unstorage driver interface](https://unstorage.unjs.io/guide/custom-driver) (`hasItem`, `getItem`, `setItem`, and so on):
 
-```ts [drivers/upstash.ts]
+```ts [drivers/kv.ts]
 import { defineDriver } from "unstorage";
-import { upstashDriver } from "unstorage/drivers/upstash";
 
-export default defineDriver((opts = {}) => {
-  const driver = upstashDriver(opts);
+export default defineDriver((opts: { prefix?: string } = {}) => {
+  const data = new Map<string, string>();
+  const prefix = opts.prefix || "";
+
   return {
-    ...driver,
-    async setItem(key, value, opts) {
-      const ttl = opts?.ttl ? { ...opts, ttl: Math.ceil(opts.ttl / 1000) } : opts;
-      return driver.setItem!(key, value, ttl);
+    name: "kv",
+    options: opts,
+    hasItem(key) {
+      return data.has(prefix + key);
+    },
+    getItem(key) {
+      return data.get(prefix + key) ?? null;
+    },
+    setItem(key, value) {
+      data.set(prefix + key, value);
+    },
+    removeItem(key) {
+      data.delete(prefix + key);
+    },
+    getKeys() {
+      return [...data.keys()].map((k) =>
+        prefix ? k.slice(prefix.length) : k,
+      );
+    },
+    clear() {
+      data.clear();
     },
   };
 });
 ```
 
-Reference it by path in your Nitro config:
+Reference it by path in your Nitro config (options besides `driver` are passed into the factory):
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";
 
 export default defineConfig({
   storage: {
-    upstash: {
-      driver: "./drivers/upstash.ts",
-      url: process.env.KV_REST_API_URL,
-      token: process.env.KV_REST_API_TOKEN,
+    kv: {
+      driver: "./drivers/kv.ts",
+      prefix: "app:",
     },
   },
 });
 ```
 
 Use a path relative to your project root (or an absolute path). Nitro bundles the driver for the server runtime.
+
+To **patch** an existing unstorage driver instead of writing one from scratch, wrap it inside `defineDriver`, spread the base driver, and override only the methods you need.
 
 :read-more{to="https://unstorage.unjs.io/guide/custom-driver" title="unstorage custom driver guide"}
 

--- a/docs/1.docs/8.storage.md
+++ b/docs/1.docs/8.storage.md
@@ -101,6 +101,48 @@ Then, you can use the redis storage using the `useStorage("redis")` function.
 You can find the driver list on [unstorage documentation](https://unstorage.unjs.io/) with their configuration.
 ::
 
+### Custom drivers
+
+The `driver` field accepts a built-in driver name (for example `"redis"`) or a **path** to a custom driver module. You cannot pass a driver function or object directly in config — Nitro imports drivers as separate modules so your config stays separate from runtime code.
+
+Create a driver file that default-exports a driver created with `defineDriver`:
+
+```ts [drivers/upstash.ts]
+import { defineDriver } from "unstorage";
+import { upstashDriver } from "unstorage/drivers/upstash";
+
+export default defineDriver((opts = {}) => {
+  const driver = upstashDriver(opts);
+  return {
+    ...driver,
+    async setItem(key, value, opts) {
+      const ttl = opts?.ttl ? { ...opts, ttl: Math.ceil(opts.ttl / 1000) } : opts;
+      return driver.setItem!(key, value, ttl);
+    },
+  };
+});
+```
+
+Reference it by path in your Nitro config:
+
+```ts [nitro.config.ts]
+import { defineConfig } from "nitro";
+
+export default defineConfig({
+  storage: {
+    upstash: {
+      driver: "./drivers/upstash.ts",
+      url: process.env.KV_REST_API_URL,
+      token: process.env.KV_REST_API_TOKEN,
+    },
+  },
+});
+```
+
+Use a path relative to your project root (or an absolute path). Nitro bundles the driver for the server runtime.
+
+:read-more{to="https://unstorage.unjs.io/guide/custom-driver" title="unstorage custom driver guide"}
+
 ### Development storage
 
 You can use the `devStorage` option to override storage configuration during development and prerendering.


### PR DESCRIPTION
## Summary

Closes #3847.

Documents how to register custom unstorage drivers via a file path in nitro.config, with an example based on maintainer guidance.

## Test plan

- [x] Docs-only change

Made with [Cursor](https://cursor.com)