### PR TITLE
docs: clarify database connection options shape

### DIFF
--- a/docs/1.docs/50.database.md
+++ b/docs/1.docs/50.database.md
@@ -123,7 +123,9 @@ const result = await stmt.bind("1001").all();
 
 ## Configuration
 
-You can configure database connections using `database` config:
+You can configure database connections using `database` config.
+
+Each connection is a `DatabaseConnectionConfig` with a `connector` name and an optional `options` object. Connector-specific settings (such as `url`, `host`, or `name`) belong under `options` — not at the top level of the connection config.
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";
@@ -132,17 +134,29 @@ export default defineConfig({
   database: {
     default: {
       connector: "sqlite",
-      options: { name: "db" }
+      options: { name: "db" },
     },
     users: {
       connector: "postgresql",
       options: {
-        url: "postgresql://username:password@hostname:port/database_name"
+        url: "postgresql://username:password@hostname:port/database_name",
+      },
+    },
+    analytics: {
+      connector: "mysql2",
+      options: {
+        host: "localhost",
+        port: 3306,
+        user: "root",
+        password: "password",
+        database: "analytics",
       },
     },
   },
 });
 ```
+
+See the [db0 connector docs](https://db0.unjs.io/connectors) for the `options` each connector accepts.
 
 ### Development Database
 


### PR DESCRIPTION
## Summary

Closes #2898.

Clarifies that database connector settings belong under options, not at the top level. Adds a mysql2 configuration example.

## Test plan

- [x] Docs-only change