### PR TITLE
fix(vite): route asset-tagged requests to opaque catch-alls in dev

### DIFF
--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -178,7 +178,9 @@ a real Vite dev server and `fetch()`es with hand-set headers.
   inspection), `HTTPError` propagation, navigations, storage/config sharing.
 - `server-entry.test.ts` (`server-entry-fixture/`) — #4252 custom `server.ts`
   H3 app: asset-extensioned routes reachable under `image`/absent/`script`
-  dests (including a no-content-type string return), missing-asset 404
+  dests (including a no-content-type string return), JSON sourcemap
+  (`/generated.js.map`) passes through, `POST` to an asset-extensioned route
+  reaches its handler (non-GET/HEAD are never assets), missing-asset 404
   contract, navigation.
 - `root-wildcard.test.ts` — transparent root catch-all `/**:path`: must never
   200 for `/entry-client.ts` under `script`/`style`/`image`/absent dests

--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -17,8 +17,8 @@ both ends:
 
 | Registration | Site | Runs | Role |
 |---|---|---|---|
-| `nitroDevMiddlewarePre` (`const` form) | `dev.ts:293` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
-| `nitroDevMiddleware` | `dev.ts:380`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
+| `nitroDevMiddlewarePre` (`const` form) | `dev.ts:284` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
+| `nitroDevMiddleware` | `dev.ts:371`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
 
 **Why two, and why pre?** Without the pre-pass, Vite's static/transform
 middleware serves files from the project root and would answer server routes
@@ -84,7 +84,7 @@ classified **a priori** — `/image.png` may be a real custom-entry route (#4252
 or a genuinely missing asset that a naive SSR `/**` would render as a 200 page
 (#4234). It *can* be classified from the **response**: after Vite declines and
 the post catch-all dispatches to Nitro, a 2xx with a `text/html` content-type
-(`PAGE_CONTENT_RE`, `dev.ts:34`) means the catch-all rendered a page for a
+(inline check in the post middleware) means the catch-all rendered a page for a
 missing asset → the response is discarded via `next()` (connect `finalhandler`
 404, same as before). Anything else — real asset types, JSON, `text/plain`, no
 content-type, non-2xx (framework 404 pages, redirects) — passes through
@@ -201,8 +201,8 @@ a real Vite dev server and `fetch()`es with hand-set headers.
   cause).
 - Extension detection must stay path-only (strip `?#`) and `ASSET_EXT_RE` must
   stay narrow, or dotted Nitro params regress (#4108).
-- `PAGE_CONTENT_RE` must not grow `text/plain` (bridge default for string
-  returns) and inspection must only apply to `envRes.ok` — framework 404 pages
+- The inspection's html-only check must not grow `text/plain` (bridge default
+  for string returns) or `application/json` (deliberate API serves, #7403), and it must only apply to `envRes.ok` — framework 404 pages
   and redirects pass through verbatim.
 - The websocket `upgrade` handler is a separate concern sharing the "Vite's or
   Nitro's?" theme.

--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -17,8 +17,8 @@ both ends:
 
 | Registration | Site | Runs | Role |
 |---|---|---|---|
-| `nitroDevMiddlewarePre` (`const` form) | `dev.ts:290` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
-| `nitroDevMiddleware` | `dev.ts:375`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
+| `nitroDevMiddlewarePre` (`const` form) | `dev.ts:293` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
+| `nitroDevMiddleware` | `dev.ts:380`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
 
 **Why two, and why pre?** Without the pre-pass, Vite's static/transform
 middleware serves files from the project root and would answer server routes
@@ -67,6 +67,8 @@ Set `Vary: sec-fetch-dest, accept`, then:
 - **Absent or `empty`**: fall back to extension — `ASSET_EXT_RE.test(ext)`
   **and** no `text/html` in `Accept` ⇒ asset. (`empty` = fetch/XHR is ambiguous:
   it tags both API calls and `fetch()`ed assets.)
+- **Only `GET`/`HEAD` can be assets at all** — a `POST /upload.png` is never a
+  browser asset load, so other methods bypass the heuristic entirely.
 - Non-asset + (matched or extensionless) → Nitro immediately (pre-Vite).
 
 Two regexes to keep intact:
@@ -92,17 +94,29 @@ Deny-list rationale (all verified empirically):
 
 - `application/json` is included because a naive SSR entry can swallow with
   JSON, not just HTML (the `app-fixture` entry does exactly that).
+- Exception: for `.map` URLs only `text/html` counts as a swallow — sourcemaps
+  are legitimately `application/json` and must pass through.
 - `text/plain` is excluded because a bare string returned from an h3 handler
-  has **no** content-type at the h3 layer but crosses the worker bridge as a
-  `Response` with the fetch-spec default `text/plain;charset=UTF-8` — it must
+  has **no** content-type at the h3 layer but arrives as `text/plain;
+  charset=UTF-8` — srvx's node-adapter default applied on the worker's HTTP hop
+  (`srvx/dist/adapters/node.mjs`; runner-dependent but converges) — and must
   pass through (custom-entry handlers returning strings).
 - Transparent (user-file) catch-alls can **not** use inspection instead of the
   divert: their string 200s arrive with no distinguishing content-type.
 
 This keeps everything zero-config, host-side only (no runtime/bundle change,
-no production behavior change). Known leftover: **production** SSR still
-renders 200 HTML for missing-asset URLs — pre-existing behavior; changing it
-is a separate, deliberate breaking-change discussion.
+no production behavior change). Known leftovers:
+
+- **Production** SSR still renders 200 HTML for missing-asset URLs —
+  pre-existing behavior; changing it is a separate, deliberate breaking-change
+  discussion.
+- Opaque semantics require registration via `renderer` / `serverEntry`. A `/**`
+  catch-all added through `routes:` / `handlers:` config or a module is
+  classified **transparent** and stays pre-empted for asset-tagged requests
+  (#4252-class limitation) — a framework integrating its renderer that way
+  should use `renderer` instead.
+- Dev-only cost: a missing asset matching an opaque catch-all triggers a full
+  (discarded) SSR render before the 404.
 
 ## 5. Issue / PR lineage (chronological)
 

--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -18,7 +18,7 @@ both ends:
 | Registration | Site | Runs | Role |
 |---|---|---|---|
 | `nitroDevMiddlewarePre` (`const` form) | `dev.ts:284` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
-| `nitroDevMiddleware` | `dev.ts:371`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
+| `nitroDevMiddleware` | defined at `dev.ts:213`, registered inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
 
 **Why two, and why pre?** Without the pre-pass, Vite's static/transform
 middleware serves files from the project root and would answer server routes
@@ -26,8 +26,9 @@ before Nitro sees them (see upstream **vitejs/vite#20866**, which made Vite
 consult `sec-fetch-dest` to let document requests fall through — the same
 header Nitro's classifier leans on).
 
-Facts about Vite's side (verified against vite@8.1.4): Nitro forces
-`appType: "custom"` (`plugin.ts:199`), so Vite registers none of
+Facts about Vite's side (verified against vite@8.1.4): Nitro defaults
+`appType` to `"custom"` (`plugin.ts:199` — user-overridable; the reasoning
+below assumes the default), so Vite registers none of
 `htmlFallback`/`indexHtml`/`notFound` middlewares, and **every plain miss
 `next()`s** (sirv and transformMiddleware never self-emit a 404 for a missing
 file/module). The only terminal 404 is connect's `finalhandler`, which sits

--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -83,19 +83,23 @@ An asset-tagged request that only an opaque catch-all could handle cannot be
 classified **a priori** — `/image.png` may be a real custom-entry route (#4252)
 or a genuinely missing asset that a naive SSR `/**` would render as a 200 page
 (#4234). It *can* be classified from the **response**: after Vite declines and
-the post catch-all dispatches to Nitro, a 2xx with a page-ish content-type
-(`PAGE_CONTENT_RE`, `dev.ts:33`: `text/html` | `application/json`) means the
-catch-all swallowed a missing asset → the response is discarded via `next()`
-(connect `finalhandler` 404, same as before). Anything else — real asset types,
-`text/plain`, no content-type, non-2xx (framework 404 pages, redirects) —
-passes through verbatim.
+the post catch-all dispatches to Nitro, a 2xx with a `text/html` content-type
+(`PAGE_CONTENT_RE`, `dev.ts:34`) means the catch-all rendered a page for a
+missing asset → the response is discarded via `next()` (connect `finalhandler`
+404, same as before). Anything else — real asset types, JSON, `text/plain`, no
+content-type, non-2xx (framework 404 pages, redirects) — passes through
+verbatim.
 
 Deny-list rationale (all verified empirically):
 
-- `application/json` is included because a naive SSR entry can swallow with
-  JSON, not just HTML (the `app-fixture` entry does exactly that).
-- Exception: for `.map` URLs only `text/html` counts as a swallow — sourcemaps
-  are legitimately `application/json` and must pass through.
+- Only `text/html` counts as a swallow. `application/json` was originally
+  denied too, but that broke real opaque frameworks: TanStack Start answers
+  API routes tagged as asset loads with JSON on purpose
+  (`<img src="/api/.../thumbnail">`, TanStack/router#7403, nitro PR #4274),
+  and sourcemaps (`.map` ∈ `ASSET_EXT_RE`) are legitimately JSON. The
+  accepted trade-off: an SSR entry that swallows missing assets with *JSON*
+  (pathological — real naive SSR renders HTML) now returns 200 JSON instead
+  of 404 in dev.
 - `text/plain` is excluded because a bare string returned from an h3 handler
   has **no** content-type at the h3 layer but arrives as `text/plain;
   charset=UTF-8` — srvx's node-adapter default applied on the worker's HTTP hop
@@ -168,7 +172,8 @@ a real Vite dev server and `fetch()`es with hand-set headers.
 
 - `app.test.ts` (`app-fixture/`) — SSR `/**` path. #4234 swallow contracts
   (missing `.css`/`.js` under `style`/absent/`empty` dests must not 200 — the
-  fixture entry swallows with **JSON**, keeping the deny-list honest), #4252
+  fixture entry renders an HTML page for extensioned misses), JSON API routes
+  under `sec-fetch-dest: image` pass through (TanStack/router#7403), #4252
   deliberate asset serve (`/dynamic-asset.png` → `image/png` passes
   inspection), `HTTPError` propagation, navigations, storage/config sharing.
 - `server-entry.test.ts` (`server-entry-fixture/`) — #4252 custom `server.ts`

--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -1,0 +1,187 @@
+# Vite Dev Middleware — Request Routing
+
+> Scope: the request-routing logic in `src/build/vite/dev.ts` — the two
+> `server.middlewares.use(...)` registrations (`nitroDevMiddlewarePre` and the
+> catch-all `nitroDevMiddleware`): why the current design looks the way it does.
+
+## 1. Where it lives & how it is wired
+
+- Logic: `src/build/vite/dev.ts` → `configureViteDevServer(ctx, server)`.
+- Entry: `src/build/vite/plugin.ts:266` — the plugin's `configureServer` hook
+  `return`s the result of `configureViteDevServer`.
+
+Vite's `configureServer` contract: middleware registered **synchronously**
+inside the hook runs **before** Vite's internal middlewares; a function
+**returned** from the hook runs **after** them (the "post" hook). Nitro uses
+both ends:
+
+| Registration | Site | Runs | Role |
+|---|---|---|---|
+| `nitroDevMiddlewarePre` (`function` form) | `dev.ts:281` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
+| `nitroDevMiddleware` | `dev.ts:374`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
+
+**Why two, and why pre?** Without the pre-pass, Vite's static/transform
+middleware serves files from the project root and would answer server routes
+before Nitro sees them (see upstream **vitejs/vite#20866**, which made Vite
+consult `sec-fetch-dest` to let document requests fall through — the same
+header Nitro's classifier leans on).
+
+Facts about Vite's side (verified against vite@8.1.4): Nitro forces
+`appType: "custom"` (`plugin.ts:199`), so Vite registers none of
+`htmlFallback`/`indexHtml`/`notFound` middlewares, and **every plain miss
+`next()`s** (sirv and transformMiddleware never self-emit a 404 for a missing
+file/module). The only terminal 404 is connect's `finalhandler`, which sits
+**after** the Nitro post-hook. So Vite genuinely hands off every request it
+cannot serve — the post catch-all is the last handler before `finalhandler`.
+
+## 2. Classification
+
+`nitro.routing.routes` in an SSR app **always** contains a catch-all `/**`, so
+"does a Nitro route match?" is nearly always *yes*. The design distinguishes:
+
+- **Explicit route** — `route` set, `!== "/**"`, not `startsWith("/**:")` (a
+  prefixed splat like `/api/photos/**` is explicit). Deterministic → **always
+  Nitro**, no heuristic may override (#4108, #4241, #4252, #4270).
+- **Explicit public asset** — a public-asset dir under a non-root `baseURL`
+  with `fallthrough: false` owns its subtree → Nitro, like an explicit route.
+- **Transparent catch-all** — a *user route file* at root level
+  (`routes/[...].ts` → `/**`, `routes/[...slug].ts` → `/**:slug`). Nitro sees
+  everything it can handle, so Vite stays the definitive asset handler: an
+  asset-tagged request is marked `_nitroHandled` and a Vite miss must **not**
+  fall back into it (#4234/#4266).
+- **Opaque catch-all** — the SSR renderer `/**` or a custom `serverEntry` `/**`
+  (both registered in `routing.ts` with identifiable `handler` paths). Their
+  *real* routes are invisible to the host (`server.ts` H3 app routes, framework
+  routers like TanStack Start), so an asset-tagged miss from Vite must still be
+  **dispatched** — marked `_nitroAssetCheck`, decided by response inspection.
+- **None** — no match. Extensionless → page navigation → Nitro; asset-tagged →
+  same as opaque (`_nitroAssetCheck`, dispatch after Vite).
+
+## 3. The asset heuristic (catch-all / none case only)
+
+Set `Vary: sec-fetch-dest, accept`, then:
+
+- **`Sec-Fetch-Dest` present & concrete** (not `empty`): `document`/`iframe`/
+  `frame` = navigation → Nitro; anything else (`image`, `video`, `style`, …) =
+  asset.
+- **Absent or `empty`**: fall back to extension — `ASSET_EXT_RE.test(ext)`
+  **and** no `text/html` in `Accept` ⇒ asset. (`empty` = fetch/XHR is ambiguous:
+  it tags both API calls and `fetch()`ed assets.)
+- Non-asset + (matched or extensionless) → Nitro immediately (pre-Vite).
+
+Two regexes to keep intact:
+- `ASSET_EXT_RE` (`dev.ts:24`) — narrow on purpose, so dotted Nitro params like
+  `/foo.bar.1` still reach Nitro (#4108).
+- Extension is extracted from the path only (query/hash stripped) so
+  `?file=bar.png` does not misclassify.
+
+## 4. Response inspection (`_nitroAssetCheck`)
+
+An asset-tagged request that only an opaque catch-all could handle cannot be
+classified **a priori** — `/image.png` may be a real custom-entry route (#4252)
+or a genuinely missing asset that a naive SSR `/**` would render as a 200 page
+(#4234). It *can* be classified from the **response**: after Vite declines and
+the post catch-all dispatches to Nitro, a 2xx with a page-ish content-type
+(`PAGE_CONTENT_RE`, `dev.ts:33`: `text/html` | `application/json`) means the
+catch-all swallowed a missing asset → the response is discarded via `next()`
+(connect `finalhandler` 404, same as before). Anything else — real asset types,
+`text/plain`, no content-type, non-2xx (framework 404 pages, redirects) —
+passes through verbatim.
+
+Deny-list rationale (all verified empirically):
+
+- `application/json` is included because a naive SSR entry can swallow with
+  JSON, not just HTML (the `app-fixture` entry does exactly that).
+- `text/plain` is excluded because a bare string returned from an h3 handler
+  has **no** content-type at the h3 layer but crosses the worker bridge as a
+  `Response` with the fetch-spec default `text/plain;charset=UTF-8` — it must
+  pass through (custom-entry handlers returning strings).
+- Transparent (user-file) catch-alls can **not** use inspection instead of the
+  divert: their string 200s arrive with no distinguishing content-type.
+
+This keeps everything zero-config, host-side only (no runtime/bundle change,
+no production behavior change). Known leftover: **production** SSR still
+renders 200 HTML for missing-asset URLs — pre-existing behavior; changing it
+is a separate, deliberate breaking-change discussion.
+
+## 5. Issue / PR lineage (chronological)
+
+- **#3649** first crude "has extension ⇒ Vite" rule; **#3804/#3805/#3817**
+  middleware improvements, mounted-path skip, internal-prefix skip (survives as
+  the `^\/(?:__|@)` guard); **#4098** `sec-websocket-protocol` to tell Vite HMR
+  sockets from Nitro websockets (the `upgrade` handler).
+- **#4108** baseURL-aware matching for dotted Nitro routes
+  (TanStack/router#6903).
+- **#4234** non-loopback plain-HTTP origins omit `Sec-Fetch-*` → splat swallowed
+  `<script src>` loads. Fixed by **#4238**: `Accept` + `ASSET_EXT_RE` fallback +
+  the `_nitroHandled` marker.
+- **#4241** #4238 over-eager: `sec-fetch-dest: image` on a real route
+  (`/api/image`) sent to Vite → 404. Fixed by `7d49dcae` + `08f2ec69`
+  (query-string stripped before extension matching).
+- **#4252 / #4270** even explicit routes lost when the URL had an asset
+  extension. Fixed by **#4272** (`5b7e152b`): explicit vs catch-all vs none
+  classification — **an explicit route is a deterministic win no heuristic can
+  touch**.
+- `7765bcb7` added `isExplicitPublicAsset`.
+- **#4252 follow-ups** (katywings, jantimon/TanStack/router#7403): routes the
+  classifier cannot see — a custom `server.ts` H3 app serving `/image.png`, or
+  an SSR framework serving assets — were pre-empted by `_nitroHandled` and
+  could never run. Fixed by the opaque-catch-all + response-inspection design
+  above (§2, §4): the pre-emption now applies only to transparent user-file
+  catch-alls, and opaque dispatches are judged by their response content-type.
+
+## 6. Runtime dispatch flow
+
+The catch-all `nitroDevMiddleware` dispatches in two stages:
+
+1. **`ctx.devApp.fetch(req)`** — `NitroDevApp` (`src/dev/app.ts`), host-side:
+   `devHandlers`, `/_vfs/**`, `/_nitro/tasks`, public asset dirs, `devProxy`.
+   No catch-all → a 404 means "not mine, hand off"; any non-404 is returned
+   directly (never inspected — deterministic host serves are authoritative).
+2. **`nitroEnv.dispatchFetch(req)`** → env-runner → worker → `nitroApp.fetch` →
+   full route table, middleware, catch-alls.
+
+Catch-all registration (`src/routing.ts`): a custom `serverEntry` is pushed as
+`/**` with `handler = nitro.options.serverEntry.handler`; the SSR renderer as
+`/**` with `handler = nitro.options.renderer.handler` (set by `plugin.ts`
+`configResolved` to `internal/vite/ssr-renderer` when an `ssr` service exists).
+These handler paths are how the pre-pass identifies opaque catch-alls.
+
+## 7. Test coverage map
+
+All under `test/vite/`; run via `test:rollup` and `test:rolldown`. Each starts
+a real Vite dev server and `fetch()`es with hand-set headers.
+
+- `app.test.ts` (`app-fixture/`) — SSR `/**` path. #4234 swallow contracts
+  (missing `.css`/`.js` under `style`/absent/`empty` dests must not 200 — the
+  fixture entry swallows with **JSON**, keeping the deny-list honest), #4252
+  deliberate asset serve (`/dynamic-asset.png` → `image/png` passes
+  inspection), `HTTPError` propagation, navigations, storage/config sharing.
+- `server-entry.test.ts` (`server-entry-fixture/`) — #4252 custom `server.ts`
+  H3 app: asset-extensioned routes reachable under `image`/absent/`script`
+  dests (including a no-content-type string return), missing-asset 404
+  contract, navigation.
+- `root-wildcard.test.ts` — transparent root catch-all `/**:path`: must never
+  200 for `/entry-client.ts` under `script`/`style`/`image`/absent dests
+  (#4234/#4266), navigations still reach it.
+- `baseurl-dotted-param.test.ts` — explicit splat routes under `baseURL:
+  /subdir/`: #4241, #4252, #4270, query-string extension, unmatched asset →
+  Vite.
+- Tangential: `hmr.test.ts` (existing module served by Vite under `script`
+  dest), `openapi.test.ts` (explicit routes), others (build/env, not routing).
+
+## 8. Gotchas
+
+- The `server.middlewares.stack` scan in `nitroDevMiddleware` skips requests
+  whose URL starts with any other middleware's mounted `base` (#3805).
+- `_nitroHandled` is a one-way latch set by the pre-pass (transparent
+  catch-all asset) and by the post catch-all itself (re-entry guard). Never set
+  it for a request a real or opaque handler should still see (#4252 root
+  cause).
+- Extension detection must stay path-only (strip `?#`) and `ASSET_EXT_RE` must
+  stay narrow, or dotted Nitro params regress (#4108).
+- `PAGE_CONTENT_RE` must not grow `text/plain` (bridge default for string
+  returns) and inspection must only apply to `envRes.ok` — framework 404 pages
+  and redirects pass through verbatim.
+- The websocket `upgrade` handler is a separate concern sharing the "Vite's or
+  Nitro's?" theme.

--- a/.agents/vite-dev.md
+++ b/.agents/vite-dev.md
@@ -17,8 +17,8 @@ both ends:
 
 | Registration | Site | Runs | Role |
 |---|---|---|---|
-| `nitroDevMiddlewarePre` (`function` form) | `dev.ts:281` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
-| `nitroDevMiddleware` | `dev.ts:374`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
+| `nitroDevMiddlewarePre` (`const` form) | `dev.ts:290` | **before** Vite static/transform | Classifier. Route explicit-Nitro + definite navigations to Nitro immediately; let definite assets fall through to Vite, marking them `_nitroHandled` (transparent catch-all) or `_nitroAssetCheck` (opaque catch-all / no match). |
+| `nitroDevMiddleware` | `dev.ts:375`, inside the returned `() => { ... }` | **after** Vite static/transform | Catch-all fallback. Wraps req as web `Request`, tries `ctx.devApp.fetch` then `nitroEnv.dispatchFetch`, honoring `baseURL`; inspects the response for `_nitroAssetCheck` requests. Skipped for `_nitroHandled`. |
 
 **Why two, and why pre?** Without the pre-pass, Vite's static/transform
 middleware serves files from the project root and would answer server routes

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -24,13 +24,14 @@ import { getEnvRunner } from "./env.ts";
 const ASSET_EXT_RE =
   /^(?:[jt]sx?|mjs|cjs|css|s[ac]ss|less|styl|vue|svelte|astro|mdx?|map|wasm|png|jpe?g|gif|svg|webp|avif|ico|bmp|woff2?|ttf|otf|eot|mp[34]|webm|wav|ogg|m4a)$/i;
 
-// Content types that mean "a page/data response was rendered" rather than "an asset was served".
-// When an asset-tagged request that only an opaque catch-all (SSR renderer / custom server entry)
-// could handle comes back with one of these, the catch-all swallowed a genuinely missing asset
-// (#4234) and the response is discarded in favor of a plain 404. `text/plain` is deliberately
-// not included: a bare string returned from a handler arrives with the fetch-spec default
-// `text/plain;charset=UTF-8` and must pass through.
-const PAGE_CONTENT_RE = /^(?:text\/html|application\/json)\b/i;
+// The content type that means "a page was rendered" rather than "an asset was served". When an
+// asset-tagged request that only an opaque catch-all (SSR renderer / custom server entry) could
+// handle comes back as HTML, the catch-all swallowed a genuinely missing asset (#4234) and the
+// response is discarded in favor of a plain 404. Only `text/html` counts: JSON is how opaque
+// frameworks deliberately answer API routes tagged as asset loads (`<img src="/api/thumbnail">`,
+// TanStack/router#7403) and sourcemaps, and `text/plain` is the bridge default for bare string
+// returns — both must pass through.
+const PAGE_CONTENT_RE = /^text\/html\b/i;
 
 // workerd built-in module namespaces (`cloudflare:workers`, `cloudflare:sockets`, `workerd:...`).
 // These are provided natively by the runtime and have no host-side representation, so they must be
@@ -258,19 +259,16 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
         return;
       }
       // An asset-tagged request Vite already declined that only an opaque catch-all could
-      // handle: a page/data response means the catch-all swallowed a missing asset (#4234) —
-      // fall through to the 404 instead. A deliberate asset serve (any other or no
-      // content-type) passes through untouched (#4252). Sourcemaps are legitimately
-      // `application/json`, so for `.map` URLs only an HTML page counts as a swallow.
-      if (nodeReq._nitroAssetCheck && envRes.ok) {
-        const contentType = envRes.headers.get("content-type") || "";
-        const isPageContent = nodeReq.url!.split(/[?#]/, 1)[0].endsWith(".map")
-          ? /^text\/html\b/i.test(contentType)
-          : PAGE_CONTENT_RE.test(contentType);
-        if (isPageContent) {
-          await envRes.body?.cancel();
-          return next();
-        }
+      // handle: an HTML page means the catch-all swallowed a missing asset (#4234) — fall
+      // through to the 404 instead. A deliberate serve (any other or no content-type) passes
+      // through untouched (#4252, TanStack/router#7403).
+      if (
+        nodeReq._nitroAssetCheck &&
+        envRes.ok &&
+        PAGE_CONTENT_RE.test(envRes.headers.get("content-type") || "")
+      ) {
+        await envRes.body?.cancel();
+        return next();
       }
       return await sendNodeResponse(nodeRes, envRes);
     } catch (error) {

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -24,6 +24,14 @@ import { getEnvRunner } from "./env.ts";
 const ASSET_EXT_RE =
   /^(?:[jt]sx?|mjs|cjs|css|s[ac]ss|less|styl|vue|svelte|astro|mdx?|map|wasm|png|jpe?g|gif|svg|webp|avif|ico|bmp|woff2?|ttf|otf|eot|mp[34]|webm|wav|ogg|m4a)$/i;
 
+// Content types that mean "a page/data response was rendered" rather than "an asset was served".
+// When an asset-tagged request that only an opaque catch-all (SSR renderer / custom server entry)
+// could handle comes back with one of these, the catch-all swallowed a genuinely missing asset
+// (#4234) and the response is discarded in favor of a plain 404. `text/plain` is deliberately
+// not included: a bare string returned from a handler arrives with the fetch-spec default
+// `text/plain;charset=UTF-8` and must pass through.
+const PAGE_CONTENT_RE = /^(?:text\/html|application\/json)\b/i;
+
 // workerd built-in module namespaces (`cloudflare:workers`, `cloudflare:sockets`, `workerd:...`).
 // These are provided natively by the runtime and have no host-side representation, so they must be
 // externalized for the in-worker module runner to `import()` them directly instead of being fetched
@@ -206,7 +214,7 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   });
 
   const nitroDevMiddleware = async (
-    nodeReq: IncomingMessage & { _nitroHandled?: boolean },
+    nodeReq: IncomingMessage & { _nitroHandled?: boolean; _nitroAssetCheck?: boolean },
     nodeRes: ServerResponse,
     next: (error?: unknown) => void
   ) => {
@@ -245,6 +253,18 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
       const envRes = await nitroEnv.dispatchFetch(req);
       if (nodeRes.writableEnded || nodeRes.headersSent) {
         return;
+      }
+      // An asset-tagged request Vite already declined that only an opaque catch-all could
+      // handle: a page/data response means the catch-all swallowed a missing asset (#4234) —
+      // fall through to the 404 instead. A deliberate asset serve (any other or no
+      // content-type) passes through untouched (#4252).
+      if (
+        nodeReq._nitroAssetCheck &&
+        envRes.ok &&
+        PAGE_CONTENT_RE.test(envRes.headers.get("content-type") || "")
+      ) {
+        await envRes.body?.cancel();
+        return next();
       }
       return await sendNodeResponse(nodeRes, envRes);
     } catch (error) {
@@ -323,9 +343,29 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     }
 
     if (isAsset) {
-      // Vite is the definitive handler — mark the request so the catch-all `nitroDevMiddleware`
-      // registered after Vite doesn't fall back into a splat Nitro route on a 404.
-      (req as IncomingMessage & { _nitroHandled?: boolean })._nitroHandled = true;
+      // Opaque catch-alls (the SSR renderer and a custom server entry) route requests Nitro
+      // cannot see in `nitro.routing.routes` (#4252), so an asset-tagged miss from Vite must
+      // still be dispatched — the response content-type then decides (`_nitroAssetCheck`).
+      // A user-file root catch-all is transparent: Nitro sees everything it can handle, so
+      // Vite stays the definitive asset handler and a Vite miss must not fall back into it.
+      const opaqueHandlers = new Set(
+        [
+          nitro.options.renderer?.handler,
+          nitro.options.serverEntry && nitro.options.serverEntry.handler,
+        ].filter(Boolean)
+      );
+      const onlyOpaqueCatchAll = matchedHandlers.every(
+        (h) => h?.handler && opaqueHandlers.has(h.handler)
+      );
+      const nodeReq = req as IncomingMessage & {
+        _nitroHandled?: boolean;
+        _nitroAssetCheck?: boolean;
+      };
+      if (onlyOpaqueCatchAll) {
+        nodeReq._nitroAssetCheck = true;
+      } else {
+        nodeReq._nitroHandled = true;
+      }
     }
     next();
   });

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -24,15 +24,6 @@ import { getEnvRunner } from "./env.ts";
 const ASSET_EXT_RE =
   /^(?:[jt]sx?|mjs|cjs|css|s[ac]ss|less|styl|vue|svelte|astro|mdx?|map|wasm|png|jpe?g|gif|svg|webp|avif|ico|bmp|woff2?|ttf|otf|eot|mp[34]|webm|wav|ogg|m4a)$/i;
 
-// The content type that means "a page was rendered" rather than "an asset was served". When an
-// asset-tagged request that only an opaque catch-all (SSR renderer / custom server entry) could
-// handle comes back as HTML, the catch-all swallowed a genuinely missing asset (#4234) and the
-// response is discarded in favor of a plain 404. Only `text/html` counts: JSON is how opaque
-// frameworks deliberately answer API routes tagged as asset loads (`<img src="/api/thumbnail">`,
-// TanStack/router#7403) and sourcemaps, and `text/plain` is the bridge default for bare string
-// returns — both must pass through.
-const PAGE_CONTENT_RE = /^text\/html\b/i;
-
 // workerd built-in module namespaces (`cloudflare:workers`, `cloudflare:sockets`, `workerd:...`).
 // These are provided natively by the runtime and have no host-side representation, so they must be
 // externalized for the in-worker module runner to `import()` them directly instead of being fetched
@@ -259,13 +250,15 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
         return;
       }
       // An asset-tagged request Vite already declined that only an opaque catch-all could
-      // handle: an HTML page means the catch-all swallowed a missing asset (#4234) — fall
-      // through to the 404 instead. A deliberate serve (any other or no content-type) passes
-      // through untouched (#4252, TanStack/router#7403).
+      // handle: a 2xx `text/html` page means the catch-all swallowed a missing asset (#4234) —
+      // fall through to the 404 instead. Anything else passes through untouched: JSON is how
+      // opaque frameworks deliberately answer API routes tagged as asset loads and sourcemaps
+      // (#4252, TanStack/router#7403), and `text/plain` is the bridge default for bare string
+      // returns.
       if (
         nodeReq._nitroAssetCheck &&
         envRes.ok &&
-        PAGE_CONTENT_RE.test(envRes.headers.get("content-type") || "")
+        /^text\/html\b/i.test(envRes.headers.get("content-type") || "")
       ) {
         await envRes.body?.cancel();
         return next();

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -260,14 +260,17 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
       // An asset-tagged request Vite already declined that only an opaque catch-all could
       // handle: a page/data response means the catch-all swallowed a missing asset (#4234) —
       // fall through to the 404 instead. A deliberate asset serve (any other or no
-      // content-type) passes through untouched (#4252).
-      if (
-        nodeReq._nitroAssetCheck &&
-        envRes.ok &&
-        PAGE_CONTENT_RE.test(envRes.headers.get("content-type") || "")
-      ) {
-        await envRes.body?.cancel();
-        return next();
+      // content-type) passes through untouched (#4252). Sourcemaps are legitimately
+      // `application/json`, so for `.map` URLs only an HTML page counts as a swallow.
+      if (nodeReq._nitroAssetCheck && envRes.ok) {
+        const contentType = envRes.headers.get("content-type") || "";
+        const isPageContent = nodeReq.url!.split(/[?#]/, 1)[0].endsWith(".map")
+          ? /^text\/html\b/i.test(contentType)
+          : PAGE_CONTENT_RE.test(contentType);
+        if (isPageContent) {
+          await envRes.body?.cancel();
+          return next();
+        }
       }
       return await sendNodeResponse(nodeRes, envRes);
     } catch (error) {
@@ -342,11 +345,13 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
       !!ext && ASSET_EXT_RE.test(ext) && !/\btext\/html\b/.test(req.headers["accept"] || "");
 
     // `document`/`iframe`/`frame` are definite navigations; any other concrete `Sec-Fetch-Dest`
-    // (`image`, `video`, `style`, ...) is a definite asset load.
+    // (`image`, `video`, `style`, ...) is a definite asset load. Only `GET`/`HEAD` can be
+    // browser asset loads at all — other methods are never assets.
     const isAsset =
-      typeof fetchDest === "string" && fetchDest !== "empty"
+      (!req.method || req.method === "GET" || req.method === "HEAD") &&
+      (typeof fetchDest === "string" && fetchDest !== "empty"
         ? !/^(?:document|iframe|frame)$/.test(fetchDest)
-        : isAssetByExt;
+        : isAssetByExt);
 
     // Non-asset requests go to Nitro: the catch-all (`matchedHandlers` are all catch-all here,
     // since explicit routes already returned) renders them, and bare (extensionless) unmatched

--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -42,6 +42,11 @@ const WORKERD_BUILTIN_RE = /^(?:cloudflare|workerd):/;
 
 export type FetchHandler = (req: Request) => Promise<Response>;
 
+type NitroDevRequest = IncomingMessage & {
+  _nitroHandled?: boolean;
+  _nitroAssetCheck?: boolean;
+};
+
 export interface DevServer extends RunnerRPCHooks {
   fetch: FetchHandler;
   init?: () => void | Promise<void>;
@@ -214,7 +219,7 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
   });
 
   const nitroDevMiddleware = async (
-    nodeReq: IncomingMessage & { _nitroHandled?: boolean; _nitroAssetCheck?: boolean },
+    nodeReq: NitroDevRequest,
     nodeRes: ServerResponse,
     next: (error?: unknown) => void
   ) => {
@@ -223,9 +228,7 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
       !nodeReq.url ||
       /^\/@(?:vite|fs|id)\//.test(nodeReq.url) ||
       nodeReq._nitroHandled ||
-      server.middlewares.stack
-        .map((mw) => mw.route)
-        .some((base) => base && nodeReq.url!.startsWith(base))
+      server.middlewares.stack.some((mw) => mw.route && nodeReq.url!.startsWith(mw.route))
     ) {
       return next();
     }
@@ -276,9 +279,19 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     }
   };
 
+  // Opaque catch-alls: the SSR renderer and a custom server entry (see .agents/vite-dev.md §2).
+  const isOpaqueHandler = (h?: { handler?: string }) =>
+    !!h?.handler &&
+    (h.handler === nitro.options.renderer?.handler ||
+      h.handler === (nitro.options.serverEntry && nitro.options.serverEntry.handler));
+
   // Handle server routes first to avoid conflicts with static assets served by Vite from the root
   // https://github.com/vitejs/vite/pull/20866
-  server.middlewares.use(function nitroDevMiddlewarePre(req, res, next) {
+  const nitroDevMiddlewarePre = (
+    req: NitroDevRequest,
+    res: ServerResponse,
+    next: (error?: unknown) => void
+  ) => {
     // Vite-internal prefixes (/@vite/client, /__vue-router/auto-routes, ...) are never Nitro's.
     if (/^\/(?:__|@)/.test(req.url!)) {
       return next();
@@ -348,27 +361,15 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
       // still be dispatched — the response content-type then decides (`_nitroAssetCheck`).
       // A user-file root catch-all is transparent: Nitro sees everything it can handle, so
       // Vite stays the definitive asset handler and a Vite miss must not fall back into it.
-      const opaqueHandlers = new Set(
-        [
-          nitro.options.renderer?.handler,
-          nitro.options.serverEntry && nitro.options.serverEntry.handler,
-        ].filter(Boolean)
-      );
-      const onlyOpaqueCatchAll = matchedHandlers.every(
-        (h) => h?.handler && opaqueHandlers.has(h.handler)
-      );
-      const nodeReq = req as IncomingMessage & {
-        _nitroHandled?: boolean;
-        _nitroAssetCheck?: boolean;
-      };
-      if (onlyOpaqueCatchAll) {
-        nodeReq._nitroAssetCheck = true;
+      if (matchedHandlers.every(isOpaqueHandler)) {
+        req._nitroAssetCheck = true;
       } else {
-        nodeReq._nitroHandled = true;
+        req._nitroHandled = true;
       }
     }
     next();
-  });
+  };
+  server.middlewares.use(nitroDevMiddlewarePre);
 
   return () => {
     server.middlewares.use(nitroDevMiddleware);

--- a/test/vite/app-fixture/app/entry-server.ts
+++ b/test/vite/app-fixture/app/entry-server.ts
@@ -15,7 +15,8 @@ export default {
       return Response.json({ path: pathname });
     }
     if (/\.[a-z0-9]+$/i.test(pathname)) {
-      // Naive SSR shape: render an HTML page for any unmatched path, extensioned or not.
+      // Naive SSR shape for extensioned misses: render an HTML page instead of a 404.
+      // Extensionless paths keep the JSON payload below for the storage/config tests.
       return new Response(`<!doctype html><h1>${pathname}</h1>`, {
         headers: { "content-type": "text/html" },
       });

--- a/test/vite/app-fixture/app/entry-server.ts
+++ b/test/vite/app-fixture/app/entry-server.ts
@@ -7,6 +7,9 @@ export default {
     if (req.url.includes("?error")) {
       throw new HTTPError({ status: 418, headers: { "x-test": "123" } });
     }
+    if (new URL(req.url).pathname === "/dynamic-asset.png") {
+      return new Response("PNGDATA", { headers: { "content-type": "image/png" } });
+    }
     const storage = useStorage();
     const config = useRuntimeConfig();
     await storage.set("test:key", "value-from-ssr");

--- a/test/vite/app-fixture/app/entry-server.ts
+++ b/test/vite/app-fixture/app/entry-server.ts
@@ -7,8 +7,18 @@ export default {
     if (req.url.includes("?error")) {
       throw new HTTPError({ status: 418, headers: { "x-test": "123" } });
     }
-    if (new URL(req.url).pathname === "/dynamic-asset.png") {
+    const pathname = new URL(req.url).pathname;
+    if (pathname === "/dynamic-asset.png") {
       return new Response("PNGDATA", { headers: { "content-type": "image/png" } });
+    }
+    if (pathname.startsWith("/api-json/")) {
+      return Response.json({ path: pathname });
+    }
+    if (/\.[a-z0-9]+$/i.test(pathname)) {
+      // Naive SSR shape: render an HTML page for any unmatched path, extensioned or not.
+      return new Response(`<!doctype html><h1>${pathname}</h1>`, {
+        headers: { "content-type": "text/html" },
+      });
     }
     const storage = useStorage();
     const config = useRuntimeConfig();

--- a/test/vite/app.test.ts
+++ b/test/vite/app.test.ts
@@ -82,6 +82,23 @@ describe("vite:app", () => {
     expect(res.status).not.toBe(200);
   });
 
+  // #4252: an asset-tagged request the SSR catch-all deliberately serves (non-page content-type)
+  // must reach the renderer and pass through, even though the URL looks like an asset.
+  test("SSR catch-all can serve asset-tagged requests", async () => {
+    for (const headers of [
+      { "sec-fetch-dest": "image", accept: "image/*" },
+      { accept: "*/*" },
+    ] as Record<string, string>[]) {
+      const res = await fetch(`${serverURL}/dynamic-asset.png`, {
+        headers,
+        redirect: "manual",
+      });
+      expect(res.status, JSON.stringify(headers)).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/png");
+      expect(await res.text()).toBe("PNGDATA");
+    }
+  });
+
   // HTTPError thrown from the SSR entry must propagate to the nitro app so the h3
   // error handler preserves its status and headers (consistent with production).
   test("propagates HTTPError status and headers from the SSR entry", async () => {

--- a/test/vite/app.test.ts
+++ b/test/vite/app.test.ts
@@ -58,7 +58,7 @@ describe("vite:app", () => {
       headers: { "sec-fetch-dest": "style" },
       redirect: "manual",
     });
-    // The SSR renderer would answer 200 with JSON; Vite 404s a missing asset.
+    // The SSR renderer would answer 200 with an HTML page; Vite 404s a missing asset.
     expect(res.status).not.toBe(200);
   });
 
@@ -96,6 +96,24 @@ describe("vite:app", () => {
       expect(res.status, JSON.stringify(headers)).toBe(200);
       expect(res.headers.get("content-type")).toBe("image/png");
       expect(await res.text()).toBe("PNGDATA");
+    }
+  });
+
+  // TanStack/router#7403 / #4274: JSON API routes served by the opaque SSR catch-all
+  // (`<img src="/api/.../thumbnail">`) must pass through even when tagged as asset loads —
+  // `application/json` is a deliberate serve, not a swallow.
+  test("SSR catch-all can serve JSON API routes under asset sec-fetch-dest", async () => {
+    for (const path of [
+      "/api-json/thumbnail",
+      "/api-json/foo.png",
+      "/api-json/files?filename=something.png",
+    ]) {
+      const res = await fetch(`${serverURL}${path}`, {
+        headers: { "sec-fetch-dest": "image", accept: "image/*" },
+        redirect: "manual",
+      });
+      expect(res.status, path).toBe(200);
+      expect(res.headers.get("content-type"), path).toContain("application/json");
     }
   });
 

--- a/test/vite/server-entry-fixture/server.ts
+++ b/test/vite/server-entry-fixture/server.ts
@@ -1,0 +1,17 @@
+import { H3 } from "h3";
+
+const app = new H3();
+
+app.get("/", (event) => {
+  event.res.headers.set("content-type", "text/html");
+  return `<img src="/image.png" />`;
+});
+
+app.get("/image.png", (event) => {
+  event.res.headers.set("content-type", "image/png");
+  return "PNGDATA";
+});
+
+app.get("/generated.js", () => "console.log('generated')");
+
+export default app;

--- a/test/vite/server-entry-fixture/server.ts
+++ b/test/vite/server-entry-fixture/server.ts
@@ -14,4 +14,8 @@ app.get("/image.png", (event) => {
 
 app.get("/generated.js", () => "console.log('generated')");
 
+app.get("/generated.js.map", () => Response.json({ version: 3, mappings: "" }));
+
+app.post("/upload.png", () => Response.json({ uploaded: true }));
+
 export default app;

--- a/test/vite/server-entry-fixture/vite.config.ts
+++ b/test/vite/server-entry-fixture/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
+
+export default defineConfig({
+  plugins: [nitro()],
+});

--- a/test/vite/server-entry.test.ts
+++ b/test/vite/server-entry.test.ts
@@ -1,0 +1,87 @@
+import { fileURLToPath } from "node:url";
+import type { ViteDevServer } from "vite";
+import { beforeAll, afterAll, describe, expect, test } from "vitest";
+
+const { createServer } = (await import(
+  process.env.NITRO_VITE_PKG || "vite"
+)) as typeof import("vite");
+
+describe("vite:server entry", { sequential: true }, () => {
+  let server: ViteDevServer;
+  let serverURL: string;
+
+  const rootDir = fileURLToPath(new URL("./server-entry-fixture", import.meta.url));
+  const originalCwd = process.cwd();
+
+  beforeAll(async () => {
+    process.chdir(rootDir);
+    server = await createServer({ root: rootDir });
+    await server.listen("0" as unknown as number);
+    const addr = server.httpServer?.address() as {
+      port: number;
+      address: string;
+      family: string;
+    };
+    serverURL = `http://${addr.family === "IPv6" ? `[${addr.address}]` : addr.address}:${addr.port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server?.close();
+    process.chdir(originalCwd);
+  });
+
+  test("custom server entry handles page navigations", async () => {
+    const res = await fetch(serverURL, {
+      headers: { "sec-fetch-dest": "document", accept: "text/html" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("/image.png");
+  });
+
+  // #4252: routes defined in a custom server entry are invisible to `nitro.routing.routes`,
+  // but asset-tagged requests must still reach them instead of dying in Vite as a 404.
+  test("custom server entry serves asset-extensioned routes (sec-fetch-dest: image)", async () => {
+    const res = await fetch(`${serverURL}/image.png`, {
+      headers: { "sec-fetch-dest": "image", accept: "image/*" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("PNGDATA");
+  });
+
+  // #4252/#4234: same, with `Sec-Fetch-*` absent (plain-HTTP non-loopback origins) so only the
+  // extension heuristic tags the request as an asset.
+  test("custom server entry serves asset-extensioned routes (sec-fetch-dest absent)", async () => {
+    const res = await fetch(`${serverURL}/image.png`, {
+      headers: { accept: "*/*" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("PNGDATA");
+  });
+
+  // A handler response without a content-type must pass through untouched.
+  test("custom server entry serves script routes without a content-type", async () => {
+    const res = await fetch(`${serverURL}/generated.js`, {
+      headers: { "sec-fetch-dest": "script" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("generated");
+  });
+
+  // #4234 contract: a genuinely missing asset must still not be answered with 200.
+  test("missing assets still 404", async () => {
+    for (const headers of [{ "sec-fetch-dest": "style" }, { accept: "*/*" }] as Record<
+      string,
+      string
+    >[]) {
+      const res = await fetch(`${serverURL}/missing-asset.css`, {
+        headers,
+        redirect: "manual",
+      });
+      expect(res.status, JSON.stringify(headers)).not.toBe(200);
+    }
+  });
+});

--- a/test/vite/server-entry.test.ts
+++ b/test/vite/server-entry.test.ts
@@ -71,6 +71,34 @@ describe("vite:server entry", { sequential: true }, () => {
     expect(await res.text()).toContain("generated");
   });
 
+  // Sourcemaps are legitimately `application/json`, so the page/data response inspection
+  // must not discard them even though `.map` is an asset extension.
+  test("custom server entry serves JSON sourcemaps", async () => {
+    for (const headers of [{ accept: "*/*" }, { "sec-fetch-dest": "empty" }] as Record<
+      string,
+      string
+    >[]) {
+      const res = await fetch(`${serverURL}/generated.js.map`, {
+        headers,
+        redirect: "manual",
+      });
+      expect(res.status, JSON.stringify(headers)).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+    }
+  });
+
+  // Non-GET/HEAD requests are never browser asset loads — a POST to an asset-extensioned
+  // URL must reach the handler and its JSON response must pass through uninspected.
+  test("custom server entry handles POST to asset-extensioned routes", async () => {
+    const res = await fetch(`${serverURL}/upload.png`, {
+      method: "POST",
+      headers: { "sec-fetch-dest": "empty", accept: "*/*" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ uploaded: true });
+  });
+
   // #4234 contract: a genuinely missing asset must still not be answered with 200.
   test("missing assets still 404", async () => {
     for (const headers of [{ "sec-fetch-dest": "style" }, { accept: "*/*" }] as Record<


### PR DESCRIPTION
### 🔗 Linked issue

resolves #4252, resolves TanStack/router#7403 (related: #4234, #4241, #4266, #4270, #4272, #4274)

### 📚 Description

Routes owned by an **opaque catch-all** — a custom `server.ts` server entry (an H3 app with its own routes) or the SSR renderer (framework routers like TanStack Start) — are invisible to `nitro.routing.routes`. The dev middleware classifier therefore treated asset-tagged requests to them (`sec-fetch-dest: image`, asset extensions, …) as Vite assets and marked them `_nitroHandled`, so the user's handler could never run: `<img src="/image.png">` served by a `server.ts` route, or a TanStack Start API route serving a thumbnail, died in a connect `finalhandler` 404.

The two cases (`/image.png` is a real opaque route vs. a genuinely missing asset a naive SSR `/**` would render as a 200 page) cannot be told apart *before* dispatching — but they can from the **response**:

- The pre-pass now splits non-explicit matches into **transparent** catch-alls (user route files, e.g. `routes/[...path].ts` — Nitro sees everything they can handle, so the existing `_nitroHandled` divert stays and they still never swallow Vite asset misses) and **opaque** ones (renderer / `serverEntry` `/**`, identified by their registered handler paths — or no match at all).
- Opaque/no-match asset requests are stamped `_nitroAssetCheck` instead: Vite keeps first shot, and on a Vite miss the post catch-all dispatches to nitro and inspects the response. A 2xx **`text/html`** response means the catch-all rendered a page for a missing asset (#4234) → discarded via `next()` (same `finalhandler` 404 as before). Anything else — real asset types, JSON (deliberate API responses, TanStack/router#7403; sourcemaps), `text/plain` (bridge default for bare string returns), no content-type, non-2xx framework 404 pages, redirects — passes through verbatim.
- Only `GET`/`HEAD` requests can be classified as asset loads at all (a `POST /upload.png` is never a browser asset load).

Zero config, host-side only: no runtime/bundle changes and no production behavior change. All #4234/#4241/#4266/#4270/#4272 regression contracts stay covered by the existing tests. Verified against a real `@tanstack/react-start` app: API routes under `sec-fetch-dest: image` (extensionless, `.png`-param, and `?filename=x.png` shapes from #7403 / #4274) now return their JSON 200s, while genuinely missing assets and unmatched routes still 404.

New regression tests (fail before, pass after, both builders):

- `test/vite/server-entry.test.ts` + fixture — custom `server.ts` H3 app: asset-extensioned routes reachable under `image`/absent/`script` fetch dests (including a no-content-type string return and a JSON sourcemap), `POST` to an asset-extensioned route, missing assets still 404, navigations work.
- `test/vite/app.test.ts` — the SSR catch-all can deliberately serve `/dynamic-asset.png` (`image/png`) and JSON API routes under `sec-fetch-dest: image` (#7403 shapes), while the missing-asset swallow contracts still hold against an HTML-rendering fixture.

Known limitation (documented): opaque semantics require registration via `renderer`/`serverEntry` — a `/**` catch-all added through `routes:`/`handlers:` config or a module is still classified transparent and pre-empted for asset-tagged requests.

Also includes `.agents/vite-dev.md` documenting the routing design, its issue lineage, and the invariants to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)