### PR TITLE
fix(static): handle weighted accept-encoding values

### DIFF
--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -21,7 +21,7 @@ export default defineHandler((event) => {
   const encodings = [
     ...encodingHeader
       .split(",")
-      .map((e) => EncodingMap[e.trim() as keyof typeof EncodingMap])
+      .map((e) => EncodingMap[e.trim().split(";")[0].trim() as keyof typeof EncodingMap])
       .filter(Boolean)
       .sort(),
     "",

--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -21,7 +21,15 @@ export default defineHandler((event) => {
   const encodings = [
     ...encodingHeader
       .split(",")
-      .map((e) => EncodingMap[e.trim().split(";")[0].trim() as keyof typeof EncodingMap])
+      .map((entry) => {
+        const [name, ...parameters] = entry.split(";");
+        const quality = parameters
+          .map((parameter) => parameter.trim().split("="))
+          .find(([key]) => key.toLowerCase() === "q")?.[1];
+        return quality !== undefined && Number(quality) === 0
+          ? undefined
+          : EncodingMap[name.trim() as keyof typeof EncodingMap];
+      })
       .filter(Boolean)
       .sort(),
     "",

--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -28,7 +28,7 @@ export default defineHandler((event) => {
           .find(([key]) => key.toLowerCase() === "q")?.[1];
         return quality !== undefined && Number(quality) === 0
           ? undefined
-          : EncodingMap[name.trim() as keyof typeof EncodingMap];
+          : EncodingMap[name.trim().toLowerCase() as keyof typeof EncodingMap];
       })
       .filter(Boolean)
       .sort(),

--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -26,12 +26,18 @@ export default defineHandler((event) => {
         const quality = parameters
           .map((parameter) => parameter.trim().split("="))
           .find(([key]) => key.toLowerCase() === "q")?.[1];
-        return quality !== undefined && Number(quality) === 0
-          ? undefined
-          : EncodingMap[name.trim().toLowerCase() as keyof typeof EncodingMap];
+        const weight = quality === undefined ? 1 : Number.parseFloat(quality);
+        return {
+          ext: EncodingMap[name.trim().toLowerCase() as keyof typeof EncodingMap],
+          // An unparsable weight is an invalid parameter, not a rejection
+          weight: Number.isNaN(weight) ? 1 : weight,
+        };
       })
-      .filter(Boolean)
-      .sort(),
+      // `q=0` means "not acceptable" (RFC 9110 12.4.2)
+      .filter((entry) => entry.ext && entry.weight > 0)
+      // Highest client weight wins, then our own (alphabetical) preference
+      .sort((a, b) => b.weight - a.weight || (a.ext < b.ext ? -1 : a.ext > b.ext ? 1 : 0))
+      .map((entry) => entry.ext),
     "",
   ];
 

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -78,7 +78,7 @@ describe("runtime static middleware", () => {
     });
     isPublicAssetURL.mockReturnValue(true);
     readAsset.mockResolvedValue("body");
-    const event = createEvent("/foo.css", "gzip; q=1.0, br; q=0.9");
+    const event = createEvent("/foo.css", "GZIP; q=1.0, br; q=0.9");
 
     await handler(event);
 

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -85,4 +85,34 @@ describe("runtime static middleware", () => {
     expect(readAsset).toHaveBeenCalledWith("/foo.css.gz");
     expect(event.res.headers.get("Content-Encoding")).toBe("gzip");
   });
+
+  it("does not match compressed assets with zero quality", async () => {
+    getAsset.mockImplementation((id: string) => {
+      if (id === "/foo.css.gz") {
+        return {
+          etag: '"compressed"',
+          mtime: "2024-01-01T00:00:00.000Z",
+          size: 4,
+          type: "text/css",
+          encoding: "gzip",
+        };
+      }
+      if (id === "/foo.css") {
+        return {
+          etag: '"plain"',
+          mtime: "2024-01-01T00:00:00.000Z",
+          size: 4,
+          type: "text/css",
+        };
+      }
+      return undefined;
+    });
+    readAsset.mockResolvedValue("body");
+    const event = createEvent("/foo.css", "gzip; q=0.0");
+
+    await handler(event);
+
+    expect(readAsset).toHaveBeenCalledWith("/foo.css");
+    expect(event.res.headers.get("Content-Encoding")).toBeNull();
+  });
 });

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -62,4 +62,27 @@ describe("runtime static middleware", () => {
     expect(event.res.headers.get("Vary")).toContain("Origin");
     expect(event.res.headers.get("Vary")).toContain("Accept-Encoding");
   });
+
+  it("matches compressed assets when accept-encoding has quality values", async () => {
+    getAsset.mockImplementation((id: string) => {
+      if (id === "/foo.css.gz") {
+        return {
+          etag: '"test"',
+          mtime: Date.now(),
+          type: "text/css",
+          encoding: "gzip",
+          size: 1,
+        };
+      }
+      return undefined;
+    });
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockResolvedValue("body");
+    const event = createEvent("/foo.css", "gzip; q=1.0, br; q=0.9");
+
+    await handler(event);
+
+    expect(readAsset).toHaveBeenCalledWith("/foo.css.gz");
+    expect(event.res.headers.get("Content-Encoding")).toBe("gzip");
+  });
 });

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockEvent } from "h3";
 import handler from "../../src/runtime/internal/static.ts";
 
+const MTIME = "2024-01-01T00:00:00.000Z";
+
 const { getAsset, isPublicAssetURL, readAsset } = vi.hoisted(() => ({
   getAsset: vi.fn(),
   isPublicAssetURL: vi.fn(),
@@ -100,7 +102,7 @@ describe("runtime static middleware", () => {
       if (id === "/foo.css.gz") {
         return {
           etag: '"test"',
-          mtime: Date.now(),
+          mtime: MTIME,
           type: "text/css",
           encoding: "gzip",
           size: 1,
@@ -118,22 +120,23 @@ describe("runtime static middleware", () => {
     expect(event.res.headers.get("Vary")).toContain("Accept-Encoding");
   });
 
-  it("matches compressed assets when accept-encoding has quality values", async () => {
-    getAsset.mockImplementation((id: string) => {
-      if (id === "/foo.css.gz") {
-        return {
-          etag: '"test"',
-          mtime: Date.now(),
-          type: "text/css",
-          encoding: "gzip",
-          size: 1,
-        };
-      }
-      return undefined;
-    });
+  // Both `gzip` and `q` are case-insensitive, and both have to be recognised
+  // for `.gz` to outrank the alphabetically-earlier `.br`.
+  it("matches compressed assets when the encoding name and q key differ in case", async () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/foo.css.gz" || id === "/foo.css.br"
+        ? {
+            etag: '"test"',
+            mtime: MTIME,
+            type: "text/css",
+            encoding: id.endsWith(".gz") ? "gzip" : "br",
+            size: 1,
+          }
+        : undefined
+    );
     isPublicAssetURL.mockReturnValue(true);
     readAsset.mockResolvedValue("body");
-    const event = createEvent("/foo.css", "GZIP; q=1.0, br; q=0.9");
+    const event = createEvent("/foo.css", "GZIP; q=1.0, br; Q=0.9");
 
     await handler(event);
 
@@ -146,7 +149,7 @@ describe("runtime static middleware", () => {
       id === "/foo.css.gz" || id === "/foo.css.br"
         ? {
             etag: '"test"',
-            mtime: Date.now(),
+            mtime: MTIME,
             type: "text/css",
             encoding: id.endsWith(".gz") ? "gzip" : "br",
             size: 1,
@@ -168,7 +171,7 @@ describe("runtime static middleware", () => {
       id === "/foo.css.gz" || id === "/foo.css.br"
         ? {
             etag: '"test"',
-            mtime: Date.now(),
+            mtime: MTIME,
             type: "text/css",
             encoding: id.endsWith(".gz") ? "gzip" : "br",
             size: 1,
@@ -190,7 +193,7 @@ describe("runtime static middleware", () => {
       if (id === "/foo.css.gz") {
         return {
           etag: '"compressed"',
-          mtime: "2024-01-01T00:00:00.000Z",
+          mtime: MTIME,
           size: 4,
           type: "text/css",
           encoding: "gzip",
@@ -199,7 +202,7 @@ describe("runtime static middleware", () => {
       if (id === "/foo.css") {
         return {
           etag: '"plain"',
-          mtime: "2024-01-01T00:00:00.000Z",
+          mtime: MTIME,
           size: 4,
           type: "text/css",
         };

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -117,4 +117,27 @@ describe("runtime static middleware", () => {
     expect(event.res.headers.get("Vary")).toContain("Origin");
     expect(event.res.headers.get("Vary")).toContain("Accept-Encoding");
   });
+
+  it("matches compressed assets when accept-encoding has quality values", async () => {
+    getAsset.mockImplementation((id: string) => {
+      if (id === "/foo.css.gz") {
+        return {
+          etag: '"test"',
+          mtime: Date.now(),
+          type: "text/css",
+          encoding: "gzip",
+          size: 1,
+        };
+      }
+      return undefined;
+    });
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockResolvedValue("body");
+    const event = createEvent("/foo.css", "gzip; q=1.0, br; q=0.9");
+
+    await handler(event);
+
+    expect(readAsset).toHaveBeenCalledWith("/foo.css.gz");
+    expect(event.res.headers.get("Content-Encoding")).toBe("gzip");
+  });
 });

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -133,7 +133,7 @@ describe("runtime static middleware", () => {
     });
     isPublicAssetURL.mockReturnValue(true);
     readAsset.mockResolvedValue("body");
-    const event = createEvent("/foo.css", "gzip; q=1.0, br; q=0.9");
+    const event = createEvent("/foo.css", "GZIP; q=1.0, br; q=0.9");
 
     await handler(event);
 

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -140,4 +140,34 @@ describe("runtime static middleware", () => {
     expect(readAsset).toHaveBeenCalledWith("/foo.css.gz");
     expect(event.res.headers.get("Content-Encoding")).toBe("gzip");
   });
+
+  it("does not match compressed assets with zero quality", async () => {
+    getAsset.mockImplementation((id: string) => {
+      if (id === "/foo.css.gz") {
+        return {
+          etag: '"compressed"',
+          mtime: "2024-01-01T00:00:00.000Z",
+          size: 4,
+          type: "text/css",
+          encoding: "gzip",
+        };
+      }
+      if (id === "/foo.css") {
+        return {
+          etag: '"plain"',
+          mtime: "2024-01-01T00:00:00.000Z",
+          size: 4,
+          type: "text/css",
+        };
+      }
+      return undefined;
+    });
+    readAsset.mockResolvedValue("body");
+    const event = createEvent("/foo.css", "gzip; q=0.0");
+
+    await handler(event);
+
+    expect(readAsset).toHaveBeenCalledWith("/foo.css");
+    expect(event.res.headers.get("Content-Encoding")).toBeNull();
+  });
 });

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -141,6 +141,50 @@ describe("runtime static middleware", () => {
     expect(event.res.headers.get("Content-Encoding")).toBe("gzip");
   });
 
+  it("prefers the encoding with the highest quality value", async () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/foo.css.gz" || id === "/foo.css.br"
+        ? {
+            etag: '"test"',
+            mtime: Date.now(),
+            type: "text/css",
+            encoding: id.endsWith(".gz") ? "gzip" : "br",
+            size: 1,
+          }
+        : undefined
+    );
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockResolvedValue("body");
+    const event = createEvent("/foo.css", "br;q=0.5, gzip;q=1.0");
+
+    await handler(event);
+
+    expect(readAsset).toHaveBeenCalledWith("/foo.css.gz");
+    expect(event.res.headers.get("Content-Encoding")).toBe("gzip");
+  });
+
+  it("keeps the default preference when no quality values are sent", async () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/foo.css.gz" || id === "/foo.css.br"
+        ? {
+            etag: '"test"',
+            mtime: Date.now(),
+            type: "text/css",
+            encoding: id.endsWith(".gz") ? "gzip" : "br",
+            size: 1,
+          }
+        : undefined
+    );
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockResolvedValue("body");
+    const event = createEvent("/foo.css", "gzip, deflate, br, zstd");
+
+    await handler(event);
+
+    expect(readAsset).toHaveBeenCalledWith("/foo.css.br");
+    expect(event.res.headers.get("Content-Encoding")).toBe("br");
+  });
+
   it("does not match compressed assets with zero quality", async () => {
     getAsset.mockImplementation((id: string) => {
       if (id === "/foo.css.gz") {


### PR DESCRIPTION
### Linked issue

Resolves #4457

### Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Documentation
- [ ] New feature
- [ ] Chore
- [ ] Breaking change

### Description

Strip optional parameters from each `Accept-Encoding` token before looking it up in the compressed-asset encoding map. This lets standard weighted values such as `gzip; q=1.0` and `br; q=0.9` match their precompressed assets instead of silently falling back to the uncompressed file, matching the RFC 9110 grammar for `Accept-Encoding`.

A focused unit regression test verifies that a weighted header selects the gzip asset and sets `Content-Encoding: gzip`.

### Checklist

- [x] I have linked an issue.
- [x] Documentation not needed (internal parser bug fix, no public API change).
- [x] I have added tests to cover my changes.
- [x] I have run the tests and lint locally and they pass.

### Validation

- `pnpm vitest run test/unit/static-middleware.test.ts` (3 passed)
- `pnpm lint`
- `pnpm stub`
- `pnpm typecheck`
