### PR TITLE
presets(vercel): add framework info to build output config

### DIFF
--- a/src/core/config/defaults.ts
+++ b/src/core/config/defaults.ts
@@ -1,3 +1,4 @@
+import { version as nitroVersion } from "nitropack/meta";
 import { runtimeDir } from "nitropack/runtime/meta";
 import type { NitroConfig } from "nitropack/types";
 import { resolve } from "pathe";
@@ -106,6 +107,6 @@ export const NitroDefaults: NitroConfig = {
   // Framework
   framework: {
     name: "nitro",
-    version: "",
+    version: nitroVersion,
   },
 };

--- a/src/presets/vercel/types.ts
+++ b/src/presets/vercel/types.ts
@@ -47,6 +47,9 @@ export interface VercelBuildConfigV3 {
   >;
   cache?: string[];
   bypassToken?: string;
+  framework?: {
+    version: string;
+  };
   crons?: {
     path: string;
     schedule: string;

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -156,6 +156,10 @@ function generateBuildConfig(nitro: Nitro, o11Routes?: ObservabilityRoute[]) {
 
   const config = defu(nitro.options.vercel?.config, <VercelBuildConfigV3>{
     version: 3,
+    framework: {
+      name: nitro.options.framework.name,
+      version: nitro.options.framework.version,
+    },
     overrides: {
       // Nitro static prerendered route overrides
       ...Object.fromEntries(

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -24,6 +24,10 @@ describe("nitro:preset:vercel", async () => {
           .then((r) => JSON.parse(r));
         expect(config).toMatchInlineSnapshot(`
           {
+            "framework": {
+              "name": "nitro",
+              "version": "2.x",
+            },
             "overrides": {
               "_scalar/index.html": {
                 "path": "_scalar",


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

backports https://github.com/nitrojs/nitro/pull/4032/changes

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this backports emitting vercel-specific framework metadata to v2

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
