### PR TITLE
feat(types): opt-in flat NitroFetchRequest to bound $fetch type instantiation

### DIFF
--- a/src/types/fetch/fetch.ts
+++ b/src/types/fetch/fetch.ts
@@ -5,13 +5,23 @@ import type { MatchedRoutes } from "./_match.ts";
 // An interface to extend in a local project
 export interface InternalApi {}
 
+// Opt-in configuration interface to augment in a local project, e.g.
+//   declare module "nitropack" {
+//     interface NitroFetchConfig { flatRequest: true }
+//   }
+export interface NitroFetchConfig {}
+
 // TODO: upgrade to uppercase for h3 v2 types and web consistency
 type RouterMethod = Lowercase<HTTPMethod>;
 
-export type NitroFetchRequest =
+type TypedNitroFetchRequest =
   | Exclude<keyof InternalApi, `/_${string}` | `/api/_${string}`>
   | Exclude<FetchRequest, string>
   | (string & {});
+
+export type NitroFetchRequest = NitroFetchConfig extends { flatRequest: true }
+  ? string
+  : TypedNitroFetchRequest;
 
 export type MiddlewareOf<
   Route extends string,


### PR DESCRIPTION
### 🔗 Linked issue

Closes #4476

### ❓ Type of change

- [x] 🚀 Enhancement (opt-in, non-breaking)

### 📚 Description

Apps with a large generated `InternalApi` (hundreds of routes) hit **TS2589** (`Type instantiation is excessively deep`) and, under `tsgo`, a flood of **TS2321** on typed `$fetch` / `useFetch` / `useAsyncData` / `event.$fetch` calls. `NitroFetchRequest` is the union of all route keys used as the generic constraint (`R extends NitroFetchRequest`), so every call site re-scores the URL literal against the full union via `MatchedRoutes`/`AvailableRouterMethod`/`TypedInternalResponse`. `tsc` sits just under its 5M instantiation limit; `tsgo` (stricter, stable type ordering) tips over → the whole diagnostic class.

This is the same family the TypeScript team closes as intended / `NOT_PLANNED`, pointing to libraries to fix their types (microsoft/typescript-go#929, #4465, #787) — so the mitigation belongs here.

**This PR adds an opt-in, non-breaking escape hatch** — a `NitroFetchConfig` interface:

```ts
declare module "nitropack" {
  interface NitroFetchConfig { flatRequest: true }
}
```

When opted in, `NitroFetchRequest` resolves to `string`, which stops the per-call-site union scoring. **Default is unchanged** (the union) so existing users keep full request autocomplete + typing. When enabled, **response typing is preserved** (`MatchedRoutes<R>` still resolves the return type from the URL literal); only request-key autocomplete is traded away.

### ✅ Why this approach

- **Non-breaking**: gated behind an interface users must explicitly augment; default resolves to the current union.
- **Keeps response typing**: `TypedInternalResponse`/`MatchedRoutes` are untouched.
- **Minimal**: one type-only change in `src/types/fetch/fetch.ts`.

Alternatives rejected: making `MatchedRoutes` non-recursive or emptying `InternalApi` destroys response typing (trades TS2589 for a flood of TS2339/TS18046); changing only the `$Fetch` default `R` has no effect (the union must stay in the constraint for autocomplete, and that union is exactly what over-instantiates).

### 🧪 Measured

On a real Nuxt 4 app (~846 routes): removes the entire TS2589/TS2321 class on both `tsc` and `tsgo` with **zero new errors**, response types preserved.

> Note: the same change applies cleanly to the `v2` branch (nitropack 2.13.x) if a backport is wanted.