### PR TITLE
fix(dev): proxy subpaths for `devProxy` rules

### DIFF
--- a/src/dev/app.ts
+++ b/src/dev/app.ts
@@ -3,7 +3,7 @@ import type { H3Event, HTTPHandler } from "h3";
 import { createProxyServer, type ProxyServerOptions } from "httpxy";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { H3, toEventHandler, serveStatic, fromNodeHandler, HTTPError } from "h3";
-import { joinURL } from "ufo";
+import { joinURL, withoutTrailingSlash } from "ufo";
 import mime from "mime";
 import { join, resolve, extname } from "pathe";
 import { stat } from "node:fs/promises";
@@ -96,7 +96,17 @@ export class NitroDevApp {
         opts = { target: opts };
       }
       const proxy = createHTTPProxy(opts);
-      app.all(route, proxy.handleEvent);
+      const prefix = withoutTrailingSlash(route.replace(/\/?\*+$/, ""));
+      const base = prefix === "/" ? "" : prefix;
+      app.all(joinURL(prefix, "**"), async (event) => {
+        const originalPathname = event.url.pathname;
+        event.url.pathname = originalPathname.slice(base.length) || "/";
+        try {
+          return await proxy.handleEvent(event);
+        } finally {
+          event.url.pathname = originalPathname;
+        }
+      });
     }
 
     // Main handler

--- a/test/unit/dev-proxy.test.ts
+++ b/test/unit/dev-proxy.test.ts
@@ -1,0 +1,90 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { serve, type ServerHandler } from "srvx";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Nitro } from "nitro/types";
+import { NitroDevApp } from "../../src/dev/app.ts";
+
+describe("dev proxy", () => {
+  let target: Server;
+  let devServer: ReturnType<typeof serve>;
+  let devURL: string;
+
+  beforeAll(async () => {
+    target = createServer((req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ url: req.url }));
+    });
+    await new Promise<void>((resolve) => target.listen(0, "127.0.0.1", () => resolve()));
+    const targetPort = (target.address() as AddressInfo).port;
+
+    const nitro = {
+      options: {
+        baseURL: "/",
+        devHandlers: [],
+        publicAssets: [],
+        devProxy: {
+          "/proxy": { target: `http://127.0.0.1:${targetPort}` },
+          "/wildcard/**": { target: `http://127.0.0.1:${targetPort}` },
+          "/slash/": { target: `http://127.0.0.1:${targetPort}` },
+        },
+      },
+      logger: console,
+      vfs: {},
+    } as unknown as Nitro;
+
+    const devApp = new NitroDevApp(nitro, () => "app");
+    devServer = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: devApp.fetch as ServerHandler,
+    });
+    await devServer.ready();
+    devURL = devServer.url!;
+  });
+
+  afterAll(async () => {
+    await devServer?.close(true);
+    await new Promise<void>((resolve) => target.close(() => resolve()));
+  });
+
+  const req = async (path: string) => {
+    const res = await fetch(new URL(path, devURL));
+    return { status: res.status, body: await res.text() };
+  };
+
+  it("should proxy the exact route", async () => {
+    expect(await req("/proxy")).toMatchObject({ status: 200, body: '{"url":"/"}' });
+  });
+
+  it("should proxy the trailing slash form", async () => {
+    expect(await req("/proxy/")).toMatchObject({ status: 200, body: '{"url":"/"}' });
+  });
+
+  it("should proxy nested subpaths with a query string", async () => {
+    expect(await req("/proxy/foo/bar?x=1")).toMatchObject({
+      status: 200,
+      body: '{"url":"/foo/bar?x=1"}',
+    });
+  });
+
+  it("should not proxy sibling routes with the same prefix", async () => {
+    expect(await req("/proxyable")).toMatchObject({ status: 200, body: "app" });
+  });
+
+  it("should treat a wildcard rule the same as a bare prefix", async () => {
+    expect(await req("/wildcard")).toMatchObject({ status: 200, body: '{"url":"/"}' });
+    expect(await req("/wildcard/foo?x=1")).toMatchObject({
+      status: 200,
+      body: '{"url":"/foo?x=1"}',
+    });
+  });
+
+  it("should treat a trailing slash rule the same as a bare prefix", async () => {
+    expect(await req("/slash")).toMatchObject({ status: 200, body: '{"url":"/"}' });
+    expect(await req("/slash/foo?x=1")).toMatchObject({
+      status: 200,
+      body: '{"url":"/foo?x=1"}',
+    });
+  });
+});


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

noticed this when trying to reproduce a bug on nuxt/cli:

on v2 a single `devProxy` rule proxies the whole prefix, but on v3 only the exact route (and its trailing-slash form) is proxied; every subpath falls through to the app.

```ts
 export default defineConfig({
   serverDir: './server',
   devProxy: {
     '/proxy': { target: 'http://localhost:8080' },
   },
 })
```

hitting `/proxy` works with v2 (target sees '/') and v3 (target sees '/proxy') but in v3 hitting `/proxy/foo/bar?x=1` doesn't work - it 404s...

this is an attempt to resolve but you may have a different approach - or maybe you want to move into routerules (?)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
