### PR TITLE
fix(prerender): write files atomically to avoid torn output

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,5 @@
 import type { Nitro } from "nitro/types";
-import { stat, mkdir, writeFile as fspWriteFile } from "node:fs/promises";
+import { stat, mkdir, rename, rm, writeFile as fspWriteFile } from "node:fs/promises";
 import { dirname } from "pathe";
 import consola from "consola";
 import { colors } from "consola/utils";
@@ -47,9 +47,21 @@ function _compilePathTemplate(contents: string) {
     });
 }
 
+let _tmpFileCounter = 0;
+
 export async function writeFile(file: string, contents: Buffer | string, log = false) {
   await mkdir(dirname(file), { recursive: true });
-  await fspWriteFile(file, contents, typeof contents === "string" ? "utf8" : undefined);
+  // Write to a sibling temp file and rename it into place. `rename` is atomic within a
+  // filesystem, so two writers racing for the same path produce last-one-wins instead
+  // of a file torn between both payloads.
+  const tmpFile = `${file}.${process.pid}-${_tmpFileCounter++}.tmp`;
+  try {
+    await fspWriteFile(tmpFile, contents, typeof contents === "string" ? "utf8" : undefined);
+    await rename(tmpFile, file);
+  } catch (error) {
+    await rm(tmpFile, { force: true });
+    throw error;
+  }
   if (log) {
     consola.info("Generated", prettyPath(file));
   }

--- a/test/unit/fs.test.ts
+++ b/test/unit/fs.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readFile, readdir, rm, writeFile as fspWriteFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { join } from "pathe";
+import { writeFile } from "../../src/utils/fs.ts";
+
+describe("writeFile", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "nitro-fs-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes contents and creates missing parent directories", async () => {
+    const file = join(dir, "nested/deeply/index.html");
+
+    await writeFile(file, "<h1>hello</h1>");
+
+    expect(await readFile(file, "utf8")).toBe("<h1>hello</h1>");
+  });
+
+  it("leaves no temporary files behind", async () => {
+    await writeFile(join(dir, "index.html"), "<h1>hello</h1>");
+
+    expect(await readdir(dir)).toEqual(["index.html"]);
+  });
+
+  it("overwrites an existing file", async () => {
+    const file = join(dir, "index.html");
+    await fspWriteFile(file, "old");
+
+    await writeFile(file, "new");
+
+    expect(await readFile(file, "utf8")).toBe("new");
+  });
+
+  it("never leaves a file torn between two concurrent writers", async () => {
+    // Two prerender routes can resolve to a single output file, and with
+    // `prerender.concurrency > 1` their writes overlap. A non-atomic write then
+    // leaves the longer payload's tail after the shorter payload's body.
+    const file = join(dir, "other/index.html");
+    const long = Buffer.from("L".repeat(300));
+    const short = Buffer.from("S".repeat(256));
+
+    for (let i = 0; i < 100; i++) {
+      await Promise.all([writeFile(file, long), writeFile(file, short)]);
+
+      const written = await readFile(file);
+      const isWhole = written.equals(long) || written.equals(short);
+      expect(isWhole, `torn after ${written.length} bytes on run ${i}`).toBe(true);
+    }
+  });
+});

--- a/test/unit/fs.test.ts
+++ b/test/unit/fs.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, writeFile as fspWriteFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile as fspWriteFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { join } from "pathe";
@@ -36,6 +36,15 @@ describe("writeFile", () => {
     await writeFile(file, "new");
 
     expect(await readFile(file, "utf8")).toBe("new");
+  });
+
+  it("removes the temporary file when the write cannot be completed", async () => {
+    const file = join(dir, "index.html");
+    await mkdir(join(file, "nested"), { recursive: true });
+
+    await expect(writeFile(file, "<h1>hello</h1>")).rejects.toThrow();
+
+    expect(await readdir(dir)).toEqual(["index.html"]);
   });
 
   it("never leaves a file torn between two concurrent writers", async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Partially resolves #4487 — this covers the "not written atomically" half. The dedup half is left out deliberately, see below.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Two prerender routes can resolve to the same output file (for example `/other` and `/other/index.html` via `autoSubfolderIndex`). With `prerender.concurrency > 1` their writes overlap, and because `writeFile` truncates and writes in place, the result can be a file torn between both payloads rather than either one of them.

The interleaving is: writer A truncates, writer B truncates, B writes 256 bytes, A writes 300 bytes — leaving a 300 byte file whose first 256 bytes came from B and whose last 44 came from A. That is exactly the shape reported in #4487, where it corrupted roughly 1 in 10 production static builds of a Nuxt SPA and shipped silently.

This writes to a sibling temp file and renames it into place. `rename` is atomic within a filesystem, and the temp file is created in the same directory as the destination, so overlapping writers now produce last-one-wins instead of a torn file. The temp file is removed if the write fails.

Reproducing the current behaviour locally, 200 pairs of concurrent writes of a 300 byte and a 256 byte payload to one path:

```
torn: 172/200
sizes seen: 300b x198, 256b x2
```

With this change, 0/200.

I left the dedup half of #4487 out on purpose. Which of two colliding routes should win is a design call, and deduping needs the resolved `fileName`, which is only known after the route has already been rendered — so it seemed better to leave that to you rather than guess. The atomic write stands on its own: it removes the corruption for any path that reaches this state, which is what the reporter suggested doing independently.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

`test/unit/fs.test.ts` covers the regression along with the basic write behaviour. The concurrency test fails on `main` immediately (run 0) and passes with the change. Locally after `pnpm build`: `tsc --noEmit` clean, `test/unit` 178 passed / 2 skipped, `oxlint` and `oxfmt --check` clean.
