### PR TITLE
fix(nitro): vercel function rules - preserve relative symlinks

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -642,6 +642,7 @@ async function createFunctionDirWithCustomConfig(
   await fsp.cp(serverDir, funcDir, {
     recursive: true,
     mode: constants.COPYFILE_FICLONE,
+    verbatimSymlinks: true,
     filter: (src) => basename(src) !== ".vc-config.json",
   });
   const mergedConfig = defu(overrides, baseFunctionConfig);

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -593,6 +593,17 @@ describe("nitro:preset:vercel:web", async () => {
         expect(indexStat.isFile()).toBe(true);
       });
 
+      it("should preserve dependency symlink targets inside functionRules directories", async () => {
+        const dependencyPath = "node_modules/@fixture/nitro-lib";
+        const serverTarget = await fsp.readlink(
+          resolve(ctx.outDir, "functions/__server.func", dependencyPath)
+        );
+        const functionTarget = await fsp.readlink(
+          resolve(ctx.outDir, "functions/api/hello.func", dependencyPath)
+        );
+        expect(functionTarget).toBe(serverTarget);
+      });
+
       it("should keep base __server.func without functionRules overrides", async () => {
         const config = await fsp
           .readFile(resolve(ctx.outDir, "functions/__server.func/.vc-config.json"), "utf8")


### PR DESCRIPTION
## Summary

- preserve relative symlink targets when Vercel `functionRules` copies the traced server function
- add a regression using Nitro’s existing multi-version nf3 fixture

## Context

nf3 emits relative links from package locations into `node_modules/.nf3`. Node’s `fs.cp` resolves those links by default, so copying `__server.func` into a route-specific function rewrites them to absolute paths in the temporary build directory. Once that directory is removed, the deployed function contains dangling dependency links.

Using `verbatimSymlinks: true` keeps the traced dependency graph self-contained in each copied function directory.

Related downstream report and workaround: https://github.com/vercel/eve/pull/1279

## Testing

- regression confirmed failing before the fix and passing afterward
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm vitest run test/presets/vercel.test.ts` — 139 passed, 2 skipped, 2 todo
- full suite attempted with `TZ=UTC pnpm test`; the Rollup run reached 1,025 passing tests and stopped on an unrelated Vite HMR assertion receiving two identical `full-reload` events instead of one