### PR TITLE
fix(prerender): warn and keep first output when two routes collide

### DIFF
--- a/src/prerender/prerender.ts
+++ b/src/prerender/prerender.ts
@@ -111,9 +111,10 @@ export async function prerender(nitro: Nitro) {
   const failedRoutes = new Set<PrerenderRoute>();
   const skippedRoutes = new Set();
   const displayedLengthWarns = new Set();
-  // Resolved output file -> the route that produced it. Two routes can resolve to
-  // one file (`/other` and `/other/index.html` both become `other/index.html`),
-  // which is only known once each of them has been rendered.
+  // Output path -> the route that produced it. Two routes can resolve to one file
+  // (`/other` and `/other/index.html` both become `other/index.html`), which is only
+  // known once each of them has been rendered. Keyed by the resolved path rather
+  // than `fileName`, so aliases pointing at one file still collide.
   const routeByOutputFile = new Map<string, string>();
 
   const publicAssetBases: string[] = nitro.options.publicAssets
@@ -299,7 +300,7 @@ export async function prerender(nitro: Nitro) {
 
     // Write to the disk
     const filePath = join(nitro.options.output.publicDir, _route.fileName);
-    const writtenBy = routeByOutputFile.get(_route.fileName);
+    const writtenBy = routeByOutputFile.get(filePath);
     if (writtenBy !== undefined) {
       // Writing again would replace the first route's output with this one, so the
       // build result would depend on which of the two rendered first
@@ -310,7 +311,7 @@ export async function prerender(nitro: Nitro) {
     } else if (canWriteToDisk(_route) && filePath.startsWith(nitro.options.output.publicDir)) {
       // Claim the file before awaiting, so a concurrent render of a route resolving
       // to the same file sees it as taken
-      routeByOutputFile.set(_route.fileName, route);
+      routeByOutputFile.set(filePath, route);
       await writeFile(filePath, dataBuff!);
       nitro._prerenderedRoutes!.push(_route);
     } else {

--- a/src/prerender/prerender.ts
+++ b/src/prerender/prerender.ts
@@ -111,6 +111,10 @@ export async function prerender(nitro: Nitro) {
   const failedRoutes = new Set<PrerenderRoute>();
   const skippedRoutes = new Set();
   const displayedLengthWarns = new Set();
+  // Resolved output file -> the route that produced it. Two routes can resolve to
+  // one file (`/other` and `/other/index.html` both become `other/index.html`),
+  // which is only known once each of them has been rendered.
+  const routeByOutputFile = new Map<string, string>();
 
   const publicAssetBases: string[] = nitro.options.publicAssets
     .filter(
@@ -295,7 +299,18 @@ export async function prerender(nitro: Nitro) {
 
     // Write to the disk
     const filePath = join(nitro.options.output.publicDir, _route.fileName);
-    if (canWriteToDisk(_route) && filePath.startsWith(nitro.options.output.publicDir)) {
+    const writtenBy = routeByOutputFile.get(_route.fileName);
+    if (writtenBy !== undefined) {
+      // Writing again would replace the first route's output with this one, so the
+      // build result would depend on which of the two rendered first
+      nitro.logger.warn(
+        `Routes \`${writtenBy}\` and \`${route}\` both prerender to \`${_route.fileName}\`. Keeping the output of \`${writtenBy}\`.`
+      );
+      _route.skip = true;
+    } else if (canWriteToDisk(_route) && filePath.startsWith(nitro.options.output.publicDir)) {
+      // Claim the file before awaiting, so a concurrent render of a route resolving
+      // to the same file sees it as taken
+      routeByOutputFile.set(_route.fileName, route);
       await writeFile(filePath, dataBuff!);
       nitro._prerenderedRoutes!.push(_route);
     } else {

--- a/test/prerender/collision.test.ts
+++ b/test/prerender/collision.test.ts
@@ -1,0 +1,54 @@
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { join } from "pathe";
+import { build, copyPublicAssets, createNitro, prepare, prerender } from "nitro/builder";
+import { afterAll, describe, expect, it } from "vitest";
+
+const fixtureDir = fileURLToPath(new URL("./fixture", import.meta.url));
+const tmpDir = fileURLToPath(new URL("./.tmp", import.meta.url));
+
+describe("prerender output collision", () => {
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("keeps the first route's output and warns instead of overwriting it", async () => {
+    const outDir = join(tmpDir, "output");
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+
+    const nitro = await createNitro({
+      rootDir: fixtureDir,
+      preset: "static",
+      output: { dir: outDir },
+      prerender: {
+        crawlLinks: false,
+        // both resolve to `other/index.html`
+        routes: ["/other", "/other/index.html"],
+      },
+    });
+
+    const warnings: string[] = [];
+    nitro.logger.warn = ((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    }) as typeof nitro.logger.warn;
+
+    await prepare(nitro);
+    await copyPublicAssets(nitro);
+    await prerender(nitro);
+    await build(nitro);
+    await nitro.close();
+
+    const collisionWarnings = warnings.filter((w) => w.includes("both prerender to"));
+    expect(collisionWarnings).toHaveLength(1);
+    expect(collisionWarnings[0]).toContain("other/index.html");
+
+    // only one of the two routes may claim the file
+    const written = nitro._prerenderedRoutes!.filter((r) => r.fileName === "/other/index.html");
+    expect(written).toHaveLength(1);
+
+    // and the file holds that route's render, whole
+    const contents = await readFile(join(outDir, "public/other/index.html"), "utf8");
+    expect(contents).toBe(`<!DOCTYPE html><html><body>rendered ${written[0].route}</body></html>`);
+  }, 120_000);
+});

--- a/test/prerender/collision.test.ts
+++ b/test/prerender/collision.test.ts
@@ -23,6 +23,8 @@ describe("prerender output collision", () => {
       output: { dir: outDir },
       prerender: {
         crawlLinks: false,
+        // one at a time, so the route that claims the file is the first one listed
+        concurrency: 1,
         // both resolve to `other/index.html`
         routes: ["/other", "/other/index.html"],
       },
@@ -33,22 +35,27 @@ describe("prerender output collision", () => {
       warnings.push(args.map(String).join(" "));
     }) as typeof nitro.logger.warn;
 
-    await prepare(nitro);
-    await copyPublicAssets(nitro);
-    await prerender(nitro);
-    await build(nitro);
-    await nitro.close();
+    try {
+      await prepare(nitro);
+      await copyPublicAssets(nitro);
+      await prerender(nitro);
+      await build(nitro);
+    } finally {
+      await nitro.close();
+    }
 
     const collisionWarnings = warnings.filter((w) => w.includes("both prerender to"));
     expect(collisionWarnings).toHaveLength(1);
-    expect(collisionWarnings[0]).toContain("other/index.html");
+    expect(collisionWarnings[0]).toContain("/other");
+    expect(collisionWarnings[0]).toContain("/other/index.html");
 
-    // only one of the two routes may claim the file
+    // only one of the two routes may claim the file, and it is the one rendered first
     const written = nitro._prerenderedRoutes!.filter((r) => r.fileName === "/other/index.html");
     expect(written).toHaveLength(1);
+    expect(written[0].route).toBe("/other");
 
     // and the file holds that route's render, whole
     const contents = await readFile(join(outDir, "public/other/index.html"), "utf8");
-    expect(contents).toBe(`<!DOCTYPE html><html><body>rendered ${written[0].route}</body></html>`);
+    expect(contents).toBe(`<!DOCTYPE html><html><body>rendered /other</body></html>`);
   }, 120_000);
 });

--- a/test/prerender/collision.test.ts
+++ b/test/prerender/collision.test.ts
@@ -25,8 +25,8 @@ describe("prerender output collision", () => {
         crawlLinks: false,
         // one at a time, so the route that claims the file is the first one listed
         concurrency: 1,
-        // both resolve to `other/index.html`
-        routes: ["/other", "/other/index.html"],
+        // the first two resolve to `other/index.html`, `/another` does not
+        routes: ["/other", "/other/index.html", "/another"],
       },
     });
 
@@ -53,6 +53,9 @@ describe("prerender output collision", () => {
     const written = nitro._prerenderedRoutes!.filter((r) => r.fileName === "/other/index.html");
     expect(written).toHaveLength(1);
     expect(written[0].route).toBe("/other");
+
+    // a route resolving to its own file is untouched
+    expect(nitro._prerenderedRoutes!.map((r) => r.fileName)).toContain("/another/index.html");
 
     // and the file holds that route's render, whole
     const contents = await readFile(join(outDir, "public/other/index.html"), "utf8");

--- a/test/prerender/fixture/server.ts
+++ b/test/prerender/fixture/server.ts
@@ -1,0 +1,8 @@
+export default {
+  fetch(req: Request) {
+    const { pathname } = new URL(req.url);
+    return new Response(`<!DOCTYPE html><html><body>rendered ${pathname}</body></html>`, {
+      headers: { "content-type": "text/html" },
+    });
+  },
+};


### PR DESCRIPTION
### 🔗 Linked issue

Resolves the dedup half of #4487. The other half, the non-atomic write, is #4488 — the two are independent and this branch is cut from `main`, not from that one.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Two prerender routes can resolve to a single output file — `/other` and `/other/index.html` both become `other/index.html` under `autoSubfolderIndex`. Nitro renders both and writes both to that one path, so the file that ships is whichever render happened to finish last, and nothing in the output says a route was discarded.

Nuxt produces exactly this pair without the user asking: it adds a prerender route `/index.html` alongside the page route `/` whenever `ssr: false`, and raises `prerender.concurrency` above 1.

The resolved `fileName` is only known after a route has been rendered, so this cannot be deduped when routes are queued. This tracks the file each route resolved to and, when a second route resolves to a file that is already taken, warns and skips the write instead of replacing the first route's output:

```
WARN  Routes `/other` and `/other/index.html` both prerender to `/other/index.html`. Keeping the output of `/other`.
```

The skipped route is marked `skip`, so it already renders as `(skipped)` in the prerender log through `formatPrerenderRoute`. The file is claimed synchronously before the write is awaited, so a concurrent render resolving to the same file sees it as taken.

Which of the two routes wins is still the one that finished first, and with `concurrency > 1` that is not deterministic. Making it deterministic would mean ordering the writes, which seemed like a bigger change than this warrants — the point here is that the build no longer silently discards a render, and the warning names both routes so the duplicate can be removed from the route list. Happy to go further if you would prefer the winner to be pinned to route order.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

`test/prerender/collision.test.ts` builds a small fixture with both routes and asserts the warning fires once, that only one route claims the file, and that the file holds that route's render. It fails on `main` (no warning, both routes recorded as written) and passes with this change.

Locally: `test/unit` 174 passed / 2 skipped, `tsc --noEmit` clean, `oxlint` and `oxfmt --check` clean.
