### PR TITLE
fix(dev): do not leak a rejection when a proxied upgrade fails

### DIFF
--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -290,15 +290,35 @@ class DevServer {
     return app;
   }
 
+  /**
+   * Proxy a websocket upgrade to the current worker.
+   *
+   * Never rejects. Both callers -- `server.on("upgrade")` below and the
+   * `upgrade` method exposed by `createDevServer` -- hand this to a callback
+   * that drops the returned promise, so a rejection here surfaces as an
+   * unhandled rejection instead of an error anyone can act on. There is also
+   * nothing left to reply with once a handshake is in flight, so a failed
+   * upgrade just closes the socket.
+   */
   async handleUpgrade(req: IncomingMessage, socket: Socket, head: any) {
-    const worker = await this.getWorker();
-    if (!worker) {
-      throw createError({
-        statusCode: 503,
-        message: "No worker available.",
-      });
+    try {
+      const worker = await this.getWorker();
+      if (!worker) {
+        throw createError({
+          statusCode: 503,
+          message: "No worker available.",
+        });
+      }
+      await worker.handleUpgrade(req, socket, head);
+    } catch (error) {
+      // A websocket dying together with its connection is ordinary traffic: the
+      // peer went away, or the worker it was proxied to has been replaced by a
+      // reload. Only report what is not that.
+      if (!isDisconnect(error)) {
+        consola.warn("[nitro] [dev] Failed to proxy websocket upgrade.", error);
+      }
+      socket.destroy();
     }
-    return worker.handleUpgrade(req, socket, head);
   }
 
   #generateError() {
@@ -345,4 +365,18 @@ class DevServer {
       }
     );
   }
+}
+
+/**
+ * Whether an error is only the other end of a connection going away, rather
+ * than a fault worth reporting.
+ */
+function isDisconnect(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return (
+    code === "ECONNRESET" ||
+    code === "ECONNABORTED" ||
+    code === "EPIPE" ||
+    code === "ERR_STREAM_PREMATURE_CLOSE"
+  );
 }

--- a/src/core/dev-server/worker.ts
+++ b/src/core/dev-server/worker.ts
@@ -22,7 +22,11 @@ export interface DevWorker {
   readonly closed: boolean;
   close(): Promise<void>;
   handleEvent: (event: H3Event) => Promise<void>;
-  handleUpgrade: (req: IncomingMessage, socket: Socket, head: any) => void;
+  handleUpgrade: (
+    req: IncomingMessage,
+    socket: Socket,
+    head: any
+  ) => Promise<void> | void;
 }
 
 export class NodeDevWorker implements DevWorker {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4493

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`DevServer.handleUpgrade` is `async`, and both of its callers drop the promise it returns:

```ts
upgrade: (req, socket, head) => devServer.handleUpgrade(req, socket, head),
// ...
listener.server.on("upgrade", (req, sock, head) =>
  this.handleUpgrade(req, sock, head)
);
```

It rejects when no worker is available, and — far more often — from `NodeDevWorker.handleUpgrade`, which returns `proxy.ws(...)` without awaiting or catching it. Replacing the dev worker kills every websocket proxied to it, so that promise rejects with `ECONNRESET` and nothing catches it.

For Nitro alone that is a stray unhandled rejection. Under Nuxt it ends the session: the CLI treats any unhandled rejection as fatal and restarts the dev server, and with a client that keeps reconnecting it loops until the dev server is unusable. It has surfaced there repeatedly — nuxt/cli#247, nuxt/cli#968, nuxt/cli#994 — where it reads as a Windows/HMR flake, but the leak is here and platform-independent.

I traced it rather than inferred it: I wrapped both candidate call sites in a real project and logged which one rejected. Over 30 seconds — `NodeDevWorker.handleUpgrade` **8**, the CLI request handler **0**. Adding a `.catch()` at that call site removed the rejections, and the restarts with them.

**The change.** `handleUpgrade` now never rejects. There is nothing left to reply to the client with once a handshake is in flight, so a failed upgrade closes the socket, and only errors that are not a peer disconnect are reported. Fixing it here rather than in the `listen` listener is deliberate: Nuxt calls the exported `upgrade` method directly, so a guard on the listener alone would miss the case that motivated this.

`DevWorker["handleUpgrade"]` is widened to `Promise<void> | void`, which is what `NodeDevWorker` already returned, so awaiting it is type-correct.

`main` has the same shape in `src/dev/server.ts` — `upgrade()` is `async` and `server.on("upgrade", ...)` drops the promise. Happy to follow up there if you would like it handled the same way.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
