### PR TITLE
fix(vite): support concurrent dev servers sharing a plugin instance

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -52,11 +52,20 @@ export function createFetchableDevEnvironment(
   config: ResolvedConfig,
   devServer: DevServer,
   entry: string,
-  opts?: { preventExternalize?: boolean }
+  opts?: FetchableDevEnvironmentOptions
 ): FetchableDevEnvironment {
   const transport = createViteHotChannel(devServer, name);
   const context: DevEnvironmentContext = { hot: true, transport };
   return new FetchableDevEnvironment(name, config, context, devServer, entry, opts);
+}
+
+export interface FetchableDevEnvironmentOptions {
+  preventExternalize?: boolean;
+  /**
+   * Called instead of `devServer.close()` when the environment is closed, so that a runner shared
+   * by several environments is only torn down once the last of them closes.
+   */
+  onClose?: () => void | Promise<void>;
 }
 
 export class FetchableDevEnvironment extends DevEnvironment {
@@ -64,6 +73,7 @@ export class FetchableDevEnvironment extends DevEnvironment {
 
   #entry: string;
   #preventExternalize: boolean;
+  #onClose?: () => void | Promise<void>;
 
   constructor(
     name: string,
@@ -71,12 +81,13 @@ export class FetchableDevEnvironment extends DevEnvironment {
     context: DevEnvironmentContext,
     devServer: DevServer,
     entry: string,
-    opts?: { preventExternalize?: boolean }
+    opts?: FetchableDevEnvironmentOptions
   ) {
     super(name, config, context);
     this.devServer = devServer;
     this.#entry = entry;
     this.#preventExternalize = opts?.preventExternalize ?? false;
+    this.#onClose = opts?.onClose;
   }
 
   override async fetchModule(
@@ -124,7 +135,7 @@ export class FetchableDevEnvironment extends DevEnvironment {
 
   override async close(): Promise<void> {
     await super.close();
-    await this.devServer.close?.();
+    await (this.#onClose ? this.#onClose() : this.devServer.close?.());
   }
 }
 

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentOptions, RollupCommonJSOptions, Plugin as VitePlugin } from "vite";
+import type {
+  EnvironmentOptions,
+  ResolvedConfig,
+  RollupCommonJSOptions,
+  Plugin as VitePlugin,
+} from "vite";
 import type { NitroPluginContext, ServiceConfig } from "./types.ts";
 
 import type { RunnerName } from "env-runner";
@@ -46,9 +51,16 @@ export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOpti
       createEnvironment: async (envName, envConfig) => {
         const entry = resolve(runtimeDir, "internal/vite/dev-entry.mjs");
         const { createFetchableDevEnvironment } = await import("./dev.ts");
-        const env = createFetchableDevEnvironment(envName, envConfig, getEnvRunner(ctx), entry, {
-          preventExternalize: isWorkerdRunner,
-        });
+        const env = createFetchableDevEnvironment(
+          envName,
+          envConfig,
+          await acquireEnvRunner(ctx, envConfig),
+          entry,
+          {
+            preventExternalize: isWorkerdRunner,
+            onClose: () => releaseEnvRunner(ctx, envConfig),
+          }
+        );
         ctx._transformRequest = (id) => env.transformRequest(id);
         (ctx._viteEnvs ??= new Map()).set(envName, entry);
         return env;
@@ -90,9 +102,16 @@ export function createServiceEnvironment(
         const entry = tryResolve(serviceConfig.entry);
         (ctx._viteEnvs ??= new Map()).set(envName, entry);
         const { createFetchableDevEnvironment } = await import("./dev.ts");
-        return createFetchableDevEnvironment(envName, envConfig, getEnvRunner(ctx), entry, {
-          preventExternalize: isWorkerdRunner,
-        });
+        return createFetchableDevEnvironment(
+          envName,
+          envConfig,
+          await acquireEnvRunner(ctx, envConfig),
+          entry,
+          {
+            preventExternalize: isWorkerdRunner,
+            onClose: () => releaseEnvRunner(ctx, envConfig),
+          }
+        );
       },
     },
   };
@@ -113,39 +132,81 @@ export async function initEnvRunner(ctx: NitroPluginContext) {
   if (ctx._envRunner) {
     return ctx._envRunner;
   }
-  if (!ctx._initPromise) {
-    ctx._initPromise = (async () => {
-      const manager = new RunnerManager();
-      let _retries = 0;
-      manager.onClose((_runner, cause) => {
-        if (_retries++ < 3) {
-          ctx.nitro!.logger.info("Restarting env runner...", cause ? `Cause: ${cause}` : "");
-          _loadRunner(ctx, manager);
-        } else {
-          ctx.nitro!.logger.error(
-            "Env runner failed after 3 retries.",
-            cause ? `Last cause: ${cause}` : ""
-          );
-        }
-      });
-      manager.onReady(() => {
-        _retries = 0;
-        if (ctx._viteEnvs) {
-          for (const [name, entry] of ctx._viteEnvs) {
-            manager.sendMessage({
-              type: "custom",
-              event: "nitro:vite-env",
-              data: { name, entry },
-            });
-          }
-        }
-      });
-      await _loadRunner(ctx, manager);
-      ctx._envRunner = manager;
-      return manager;
-    })();
-  }
+  ctx._initPromise ??= _createEnvRunner(ctx).then((manager) => {
+    ctx._envRunner = manager;
+    return manager;
+  });
   return await ctx._initPromise;
+}
+
+/**
+ * Get the runner backing a single Vite dev server, creating it on demand.
+ *
+ * A runner maps environment name to dev environment, so two dev servers cannot share one: the
+ * second to register its environments would take over module resolution for the first. Runners
+ * are therefore tracked per resolved config (one per dev server), and the runner warmed up during
+ * setup is adopted by whichever dev server is created first.
+ */
+export async function acquireEnvRunner(ctx: NitroPluginContext, config: ResolvedConfig) {
+  const runners = (ctx._serverEnvRunners ??= new WeakMap());
+  let entry = runners.get(config);
+  if (!entry) {
+    entry = {
+      refs: 0,
+      promise: ctx._primaryClaimed ? _createEnvRunner(ctx) : initEnvRunner(ctx),
+    };
+    ctx._primaryClaimed = true;
+    runners.set(config, entry);
+  }
+  entry.refs++;
+  return await entry.promise;
+}
+
+// Every environment of a dev server holds a reference to that server's runner, so the runner is
+// only closed once the last of them has been closed.
+export async function releaseEnvRunner(ctx: NitroPluginContext, config: ResolvedConfig) {
+  const entry = ctx._serverEnvRunners?.get(config);
+  if (!entry || --entry.refs > 0) {
+    return;
+  }
+  ctx._serverEnvRunners!.delete(config);
+  const manager = await entry.promise;
+  if (manager === ctx._envRunner) {
+    ctx._envRunner = undefined;
+    ctx._initPromise = undefined;
+    ctx._primaryClaimed = false;
+  }
+  await manager.close();
+}
+
+async function _createEnvRunner(ctx: NitroPluginContext): Promise<RunnerManager> {
+  const manager = new RunnerManager();
+  let _retries = 0;
+  manager.onClose((_runner, cause) => {
+    if (_retries++ < 3) {
+      ctx.nitro!.logger.info("Restarting env runner...", cause ? `Cause: ${cause}` : "");
+      _loadRunner(ctx, manager);
+    } else {
+      ctx.nitro!.logger.error(
+        "Env runner failed after 3 retries.",
+        cause ? `Last cause: ${cause}` : ""
+      );
+    }
+  });
+  manager.onReady(() => {
+    _retries = 0;
+    if (ctx._viteEnvs) {
+      for (const [name, entry] of ctx._viteEnvs) {
+        manager.sendMessage({
+          type: "custom",
+          event: "nitro:vite-env",
+          data: { name, entry },
+        });
+      }
+    }
+  });
+  await _loadRunner(ctx, manager);
+  return manager;
 }
 
 export function getEnvRunner(ctx: NitroPluginContext) {

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -151,11 +151,24 @@ export async function acquireEnvRunner(ctx: NitroPluginContext, config: Resolved
   const runners = (ctx._serverEnvRunners ??= new WeakMap());
   let entry = runners.get(config);
   if (!entry) {
-    entry = {
-      refs: 0,
-      promise: ctx._primaryClaimed ? _createEnvRunner(ctx) : initEnvRunner(ctx),
-    };
+    const wasClaimed = ctx._primaryClaimed;
     ctx._primaryClaimed = true;
+    // A failed startup must not poison the plugin instance: drop the cached entry (and the
+    // primary claim, if this call made it) so a later dev server can warm a fresh runner.
+    const created: { refs: number; promise: Promise<RunnerManager> } = {
+      refs: 0,
+      promise: (wasClaimed ? _createEnvRunner(ctx) : initEnvRunner(ctx)).catch((error) => {
+        if (runners.get(config) === created) {
+          runners.delete(config);
+        }
+        if (!wasClaimed) {
+          ctx._initPromise = undefined;
+          ctx._primaryClaimed = false;
+        }
+        throw error;
+      }),
+    };
+    entry = created;
     runners.set(config, entry);
   }
   entry.refs++;
@@ -185,7 +198,9 @@ async function _createEnvRunner(ctx: NitroPluginContext): Promise<RunnerManager>
   manager.onClose((_runner, cause) => {
     if (_retries++ < 3) {
       ctx.nitro!.logger.info("Restarting env runner...", cause ? `Cause: ${cause}` : "");
-      _loadRunner(ctx, manager);
+      _loadRunner(ctx, manager).catch((error) => {
+        ctx.nitro!.logger.error("Failed to restart env runner.", error);
+      });
     } else {
       ctx.nitro!.logger.error(
         "Env runner failed after 3 retries.",

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -70,11 +70,11 @@ function nitroInit(ctx: NitroPluginContext): VitePlugin {
 
     async config(config, configEnv) {
       ctx._isRolldown = !!(this.meta as Record<string, string>).rolldownVersion;
-      if (!ctx._initialized) {
+      if (!ctx._setupPromise) {
         debug("[init] Initializing nitro");
-        ctx._initialized = true;
-        await setupNitroContext(ctx, configEnv, config);
+        ctx._setupPromise = setupNitroContext(ctx, configEnv, config);
       }
+      await ctx._setupPromise;
     },
 
     configResolved(config) {

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -1,4 +1,4 @@
-import type { TransformResult, Plugin as VitePlugin } from "vite";
+import type { ResolvedConfig, TransformResult, Plugin as VitePlugin } from "vite";
 import type { getBundlerConfig } from "./bundler.ts";
 import type { Nitro, NitroConfig, NitroModule } from "nitro/types";
 import type { RunnerManager } from "env-runner";
@@ -59,9 +59,11 @@ export interface NitroPluginContext {
   services: Record<string, ServiceConfig>;
 
   _isRolldown?: boolean;
-  _initialized?: boolean;
+  _setupPromise?: Promise<void>;
   _envRunner?: RunnerManager;
   _initPromise?: Promise<RunnerManager>;
+  _serverEnvRunners?: WeakMap<ResolvedConfig, { refs: number; promise: Promise<RunnerManager> }>;
+  _primaryClaimed?: boolean;
   _viteEnvs?: Map<string, string>;
   _transformRequest?: (id: string) => Promise<TransformResult | null | undefined>;
   _publicDistDir?: string;

--- a/test/unit/vite-concurrent-servers.test.ts
+++ b/test/unit/vite-concurrent-servers.test.ts
@@ -1,0 +1,61 @@
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "pathe";
+import { describe, expect, it } from "vitest";
+import { createServer, type InlineConfig, type ViteDevServer } from "vite";
+
+import { nitro } from "../../src/build/vite/plugin.ts";
+import type { FetchableDevEnvironment } from "../../src/build/vite/dev.ts";
+
+const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), "../fixture");
+
+// A single `nitro()` plugin instance shared by several Vite dev servers created in the same
+// process (as vitest does when initialising projects with `Promise.allSettled`).
+function sharedConfig(plugins: ReturnType<typeof nitro>): InlineConfig {
+  return {
+    root: fixtureDir,
+    configFile: false,
+    logLevel: "silent",
+    plugins: [plugins],
+    server: { middlewareMode: true, hmr: false },
+  };
+}
+
+async function hello(server: ViteDevServer) {
+  const env = server.environments.nitro as FetchableDevEnvironment;
+  const res = await env.dispatchFetch(new Request("http://localhost/api/hello"));
+  return { status: res.status, body: await res.text() };
+}
+
+describe("vite dev servers sharing a plugin instance", () => {
+  it("should create concurrently without racing env runner init", async () => {
+    const plugins = nitro();
+    const servers = await Promise.all([
+      createServer(sharedConfig(plugins)),
+      createServer(sharedConfig(plugins)),
+    ]);
+    try {
+      for (const server of servers) {
+        expect(await hello(server)).toMatchObject({
+          status: 200,
+          body: expect.stringContaining("Hello"),
+        });
+      }
+    } finally {
+      await Promise.all(servers.map((server) => server.close()));
+    }
+  });
+
+  it("should keep the env runner alive until the last server closes", async () => {
+    const plugins = nitro();
+    const [first, second] = await Promise.all([
+      createServer(sharedConfig(plugins)),
+      createServer(sharedConfig(plugins)),
+    ]);
+    try {
+      await first.close();
+      expect(await hello(second)).toMatchObject({ status: 200 });
+    } finally {
+      await second.close();
+    }
+  });
+});

--- a/test/unit/vite-concurrent-servers.test.ts
+++ b/test/unit/vite-concurrent-servers.test.ts
@@ -20,6 +20,23 @@ function sharedConfig(plugins: ReturnType<typeof nitro>): InlineConfig {
   };
 }
 
+// `Promise.all` rejects before the callers' `finally`, so any server that did start must be
+// closed here or it keeps the runner worker (and the vitest process) alive.
+async function createServers(plugins: ReturnType<typeof nitro>, count: number) {
+  const servers: ViteDevServer[] = [];
+  try {
+    await Promise.all(
+      Array.from({ length: count }, async () => {
+        servers.push(await createServer(sharedConfig(plugins)));
+      })
+    );
+  } catch (error) {
+    await Promise.all(servers.map((server) => server.close()));
+    throw error;
+  }
+  return servers;
+}
+
 async function hello(server: ViteDevServer) {
   const env = server.environments.nitro as FetchableDevEnvironment;
   const res = await env.dispatchFetch(new Request("http://localhost/api/hello"));
@@ -29,10 +46,7 @@ async function hello(server: ViteDevServer) {
 describe("vite dev servers sharing a plugin instance", () => {
   it("should create concurrently without racing env runner init", async () => {
     const plugins = nitro();
-    const servers = await Promise.all([
-      createServer(sharedConfig(plugins)),
-      createServer(sharedConfig(plugins)),
-    ]);
+    const servers = await createServers(plugins, 2);
     try {
       for (const server of servers) {
         expect(await hello(server)).toMatchObject({
@@ -47,10 +61,7 @@ describe("vite dev servers sharing a plugin instance", () => {
 
   it("should keep the env runner alive until the last server closes", async () => {
     const plugins = nitro();
-    const [first, second] = await Promise.all([
-      createServer(sharedConfig(plugins)),
-      createServer(sharedConfig(plugins)),
-    ]);
+    const [first, second] = await createServers(plugins, 2);
     try {
       await first.close();
       expect(await hello(second)).toMatchObject({ status: 200 });


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've hit this a couple of times (first [when adopting nitro/vite](https://github.com/nuxt/nuxt/blob/6eeeb74f6c9fe4d1a341d656003da627bcbee7fd/vitest.config.ts#L124-L127) and now in https://github.com/nuxt/nuxt/pull/35891 where I'm making it the default option) when trying to run multiple vitest projects (which share a vite config, and therefore share a nitro plugin):

```
Error: Env runner not initialized. Call initEnvRunner() first.
    at getEnvRunner (nitro/dist/_build/vite.env.mjs:107:29)
    at Object.createEnvironment (nitro/dist/_build/vite.env.mjs:71:61)
    at async Promise.all (index 1)
    at _createServer (vite/dist/node/chunks/node.js:25804:2)
```

a minimal repro is two servers sharing one `nitro()` plugin instance:

```js
import { createServer } from "vite";
import { nitro } from "nitro/vite";

const plugins = nitro();
const cfg = () => ({ root, configFile: false, plugins: [plugins], server: { middlewareMode: true } });

await Promise.all([createServer(cfg()), createServer(cfg())]);
// second one throws
```

there are two separate issues:

1. the second server skips setup entirely (because `ctx._initialized` is set, so it tries to create an environment before the first server has finished

2. both servers share a runner, so closing one server throws `503 Runner is unavailable` for the other

simply awaiting `initEnvRunner` fixes the first one but not the second

let me know if you have any better ideas on how to fix it 🙏 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
