### PR TITLE
fix(static): compressed public assets never actually served (only bundled)

### DIFF
--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -27,13 +27,13 @@ export default defineHandler((event) => {
     "",
   ];
 
-  for (const encoding of encodings) {
+  encodingLoop: for (const encoding of encodings) {
     for (const _id of [id + encoding, joinURL(id, "index.html" + encoding)]) {
       const _asset = getAsset(_id);
       if (_asset) {
         asset = _asset;
         id = _id;
-        break;
+        break encodingLoop;
       }
     }
   }


### PR DESCRIPTION
## Summary

- `compressPublicAssets` correctly generates `.gz`/`.br`/`.zst` sibling files at build time, and the manifest correctly records their `encoding`.
- But `runtime/internal/static.ts`'s encoding-negotiation loop has a bug: the `break` inside the inner `for` only exits that inner loop, not the outer `for (const encoding of encodings)` loop. Since `encodings` always ends with `""` (the uncompressed variant, which always exists), the outer loop keeps going after finding a compressed match and the uncompressed asset silently overwrites `asset` on the last iteration.
- Net effect: pre-compressed assets are built and shipped in the output, but the server **never serves them** — every request gets the full uncompressed asset regardless of `Accept-Encoding`, silently (no error, `Vary: Accept-Encoding` header still present, just always the wrong body).

## Repro

```ts
// nitro.config.ts
export default defineConfig({
  compressPublicAssets: { gzip: true, brotli: true },
});
```

Build, then:

```sh
curl -sD - -H "Accept-Encoding: gzip, br" http://localhost:3000/some-large-asset.css -o /dev/null
```

Response is always the full uncompressed `Content-Length`, with no `Content-Encoding` header.

## Fix

Label the outer loop and break out of both loops once a match is found, instead of only the inner one. One-line change, verified locally (built, confirmed `Content-Encoding: br` + correct compressed `Content-Length` after the fix, both missing before it).