### PR TITLE
fix(dev): await worker shutdown before replacing it

### DIFF
--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -37,6 +37,7 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   #buildError?: unknown;
   #reloadPromise?: Promise<void>;
   #shuttingDown: boolean = false;
+  #closing: boolean = false;
 
   constructor(nitro: Nitro) {
     super(nitro, async (event) => {
@@ -152,6 +153,8 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   }
 
   async close() {
+    this.#closing = true;
+    await this.#reloadPromise?.catch(() => {});
     await this.#shutdownWorker();
     await Promise.all(
       [
@@ -171,6 +174,9 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   }
 
   reload() {
+    if (this.#closing) {
+      return;
+    }
     const nextReload = (this.#reloadPromise ?? Promise.resolve())
       .catch(() => {})
       .then(() => this.#reload());
@@ -232,7 +238,10 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
         this.#manager.onMessage(listener);
         try {
           this.#manager.sendMessage({ event: "shutdown" });
-        } catch {
+        } catch (error) {
+          this.nitro.logger.warn(
+            `Could not send shutdown message to the dev worker: ${error instanceof Error ? error.message : String(error)}`
+          );
           done();
         }
       });

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -18,6 +18,8 @@ import { isTest, isCI } from "std-env";
 import { NitroDevApp } from "./app.ts";
 import { writeDevBuildInfo } from "../build/info.ts";
 
+const SHUTDOWN_TIMEOUT = 5000;
+
 export function createDevServer(nitro: Nitro): NitroDevServer {
   return new NitroDevServer(nitro);
 }
@@ -34,6 +36,7 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   #building?: boolean = true; // Assume initial build will start soon
   #buildError?: unknown;
   #reloadPromise?: Promise<void>;
+  #shuttingDown: boolean = false;
 
   constructor(nitro: Nitro) {
     super(nitro, async (event) => {
@@ -76,6 +79,9 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
       });
     });
     this.#manager.onClose((_runner, cause) => {
+      if (this.#shuttingDown) {
+        return;
+      }
       this.#workerError = cause;
       if (this.#workerRetries++ < 3) {
         this.nitro.logger.info("Restarting dev worker...", cause ? `Cause: ${cause}` : "");
@@ -146,6 +152,7 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   }
 
   async close() {
+    await this.#shutdownWorker();
     await Promise.all(
       [
         Promise.all(this.#listeners.map((l) => l.close())).then(() => {
@@ -175,6 +182,7 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   }
 
   async #reload() {
+    await this.#shutdownWorker();
     const runnerName =
       this.nitro.options.devServer.runner || process.env.NITRO_DEV_RUNNER || "node-worker";
     const runner = await loadRunner(runnerName as RunnerName, {
@@ -199,6 +207,39 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
   // #endregion
 
   // #region Private Methods
+
+  async #shutdownWorker() {
+    if (!this.#manager.ready) {
+      return;
+    }
+    this.#shuttingDown = true;
+    try {
+      await new Promise<void>((resolve) => {
+        const done = () => {
+          clearTimeout(timer);
+          this.#manager.offMessage(listener);
+          resolve();
+        };
+        const timer = setTimeout(() => {
+          this.nitro.logger.warn("Dev worker did not shut down in time, force closing it...");
+          done();
+        }, SHUTDOWN_TIMEOUT);
+        const listener = (message: any) => {
+          if (message?.event === "exit") {
+            done();
+          }
+        };
+        this.#manager.onMessage(listener);
+        try {
+          this.#manager.sendMessage({ event: "shutdown" });
+        } catch {
+          done();
+        }
+      });
+    } finally {
+      this.#shuttingDown = false;
+    }
+  }
 
   async #waitForBuild() {
     const timeout = isTest || isCI ? 60_000 : 6000;


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/32928

related: #4088
partly resolve https://github.com/nitrojs/nitro/issues/2735

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

we currently don't await when shutting down a worker, meaning tasks or plugins shutdown can overlap with new startup (e.g. database connection). we've implemented waiting (+ timeout) in nuxt/cli for the nuxt dev server (https://github.com/nuxt/cli/pull/1424) but I thought we should probably do the same for nitro workers.

let me know if you don't think this is desired behaviour, or if you want to move it to `env-runner` instead 🙏 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
