### PR TITLE
feat(server-assets): opt-in embed modes for large catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ test/fixture/functions
 # Generated types
 *.d.ts
 !runtime-meta.d.ts
+test/unit/.tmp-server-assets-perf/

--- a/docs/1.guide/8.assets.md
+++ b/docs/1.guide/8.assets.md
@@ -121,3 +121,23 @@ export default defineEventHandler(async (event) => {
   return html
 })
 ```
+
+### Large catalogs (`embed`)
+
+By default each file becomes a lazy Rollup `raw:` module (`embed: true`). For directories with many small files you can opt in:
+
+| `embed` | Behavior |
+| --- | --- |
+| `true` (default) | One `raw:` chunk per file (unchanged) |
+| `"inline"` | Single virtual module (fast builds; larger server entry) |
+| `false` | Copy to `server/assets/<baseName>` and read from disk at runtime (Node/Bun/Deno) |
+
+```ts
+export default defineNitroConfig({
+  serverAssets: [{
+    baseName: 'i18n',
+    dir: './i18n-data',
+    embed: 'inline', // or false
+  }]
+})
+```

--- a/src/core/utils/fs-tree.ts
+++ b/src/core/utils/fs-tree.ts
@@ -7,6 +7,13 @@ import prettyBytes from "pretty-bytes";
 import { isTest } from "std-env";
 import { runParallel } from "./parallel";
 
+/**
+ * Print a size tree for the server output.
+ *
+ * `chunks/raw/**` (Nitro serverAssets `raw:` embeds) are summarized with cheap `stat`
+ * calls instead of per-file gzip — otherwise thousands of tiny chunks dominate build wall time
+ * after Rollup (see nitrojs/nitro#1833).
+ */
 export async function generateFSTree(
   dir: string,
   options: { compressedSizes?: boolean } = {}
@@ -15,7 +22,10 @@ export async function generateFSTree(
     return;
   }
 
-  const files = await globby("**/*.*", { cwd: dir, ignore: ["*.map"] });
+  const files = await globby("**/*.*", {
+    cwd: dir,
+    ignore: ["*.map", "chunks/raw/**"],
+  });
 
   const items: { file: string; path: string; size: number; gzip: number }[] =
     [];
@@ -43,9 +53,9 @@ export async function generateFSTree(
   let treeText = "";
 
   for (const [index, item] of items.entries()) {
-    let dir = dirname(item.file);
-    if (dir === ".") {
-      dir = "";
+    let itemDir = dirname(item.file);
+    if (itemDir === ".") {
+      itemDir = "";
     }
     const rpath = relative(process.cwd(), item.path);
     const treeChar = index === items.length - 1 ? "└─" : "├─";
@@ -67,6 +77,27 @@ export async function generateFSTree(
     treeText += "\n";
     totalSize += item.size;
     totalGzip += item.gzip;
+  }
+
+  // Summarize raw serverAsset chunks without per-file gzip.
+  const rawFiles = await globby("chunks/raw/**/*.*", {
+    cwd: dir,
+    ignore: ["*.map"],
+  });
+  if (rawFiles.length > 0) {
+    let rawSize = 0;
+    await runParallel(
+      new Set(rawFiles),
+      async (file) => {
+        const st = await fsp.stat(resolve(dir, file));
+        rawSize += st.size;
+      },
+      { concurrency: 32 }
+    );
+    totalSize += rawSize;
+    treeText += colors.gray(
+      `  ├─ chunks/raw/* (${rawFiles.length} files, ${prettyBytes(rawSize)} — gzip skipped)\n`
+    );
   }
 
   treeText += `${colors.cyan("Σ Total size:")} ${prettyBytes(

--- a/src/core/utils/fs-tree.ts
+++ b/src/core/utils/fs-tree.ts
@@ -8,11 +8,11 @@ import { isTest } from "std-env";
 import { runParallel } from "./parallel";
 
 /**
- * Print a size tree for the server output.
+ * Build a printable size tree for the server output directory.
  *
- * `chunks/raw/**` (Nitro serverAssets `raw:` embeds) are summarized with cheap `stat`
- * calls instead of per-file gzip — otherwise thousands of tiny chunks dominate build wall time
- * after Rollup (see nitrojs/nitro#1833).
+ * Files under `chunks/raw/` (one Rollup module per `serverAssets` file) are
+ * summarized with `stat` only. Gzipping each of them dominated build wall time
+ * for large catalogs (nitrojs/nitro#1833).
  */
 export async function generateFSTree(
   dir: string,
@@ -53,9 +53,9 @@ export async function generateFSTree(
   let treeText = "";
 
   for (const [index, item] of items.entries()) {
-    let itemDir = dirname(item.file);
-    if (itemDir === ".") {
-      itemDir = "";
+    let _dir = dirname(item.file);
+    if (_dir === ".") {
+      _dir = "";
     }
     const rpath = relative(process.cwd(), item.path);
     const treeChar = index === items.length - 1 ? "└─" : "├─";
@@ -79,7 +79,6 @@ export async function generateFSTree(
     totalGzip += item.gzip;
   }
 
-  // Summarize raw serverAsset chunks without per-file gzip.
   const rawFiles = await globby("chunks/raw/**/*.*", {
     cwd: dir,
     ignore: ["*.map"],
@@ -89,14 +88,13 @@ export async function generateFSTree(
     await runParallel(
       new Set(rawFiles),
       async (file) => {
-        const st = await fsp.stat(resolve(dir, file));
-        rawSize += st.size;
+        rawSize += (await fsp.stat(resolve(dir, file))).size;
       },
-      { concurrency: 32 }
+      { concurrency: 25 }
     );
     totalSize += rawSize;
     treeText += colors.gray(
-      `  ├─ chunks/raw/* (${rawFiles.length} files, ${prettyBytes(rawSize)} — gzip skipped)\n`
+      `  ├─ chunks/raw/* (${rawFiles.length} files, ${prettyBytes(rawSize)}, gzip skipped)\n`
     );
   }
 

--- a/src/rollup/plugins/raw.ts
+++ b/src/rollup/plugins/raw.ts
@@ -89,6 +89,9 @@ function isBinary(id: string) {
   return true;
 }
 
+/** Shared with server-assets inline embedding. */
+export { isBinary };
+
 function getHelpers() {
   const js = String.raw;
   return js`

--- a/src/rollup/plugins/server-assets.ts
+++ b/src/rollup/plugins/server-assets.ts
@@ -1,4 +1,5 @@
 import { promises as fsp } from "node:fs";
+import createEtag from "etag";
 import { globby } from "globby";
 import mime from "mime";
 import type { Nitro, ServerAssetDir } from "nitropack/types";
@@ -15,7 +16,9 @@ interface ResolvedAsset {
     etag?: string;
     mtime?: string;
   };
-  data?: string | Uint8Array;
+  /** Set when `embed: "inline"` (utf8 text or base64 for binary). */
+  data?: string;
+  encoding?: "base64";
 }
 
 type EmbedMode = boolean | "inline";
@@ -24,36 +27,20 @@ function resolveEmbedMode(asset: ServerAssetDir): EmbedMode {
   return asset.embed ?? true;
 }
 
-/** Weak etag from size + mtime — avoids reading every file during the scan. */
-function weakEtag(size: number, mtimeMs: number): string {
-  return `W/"${size.toString(16)}-${Math.trunc(mtimeMs).toString(16)}"`;
-}
-
-function isProbablyText(type: string, id: string): boolean {
-  if (
-    type.startsWith("text") ||
-    type.includes("json") ||
-    type.includes("xml") ||
-    type.includes("javascript")
-  ) {
-    return true;
-  }
-  return /\.(json|jsonc|txt|md|html|htm|svg|css|csv|tsv|xml|yaml|yml|toml)$/i.test(
-    id
-  );
+function isBinaryType(type: string): boolean {
+  return !/^(text\/|application\/(json|xml|javascript)|image\/svg)/.test(type);
 }
 
 /**
- * Path from the main nitro chunk (`chunks/nitro/nitro.mjs`) to a server-dir relative folder.
+ * Path relative to `output.serverDir` — same convention as `public-assets`
+ * (`resolve(dirname(import.meta.url), path)` at runtime).
  */
-function relFromNitroChunk(serverDir: string, absTarget: string): string {
-  return relative(join(serverDir, "chunks/nitro"), absTarget).replace(
-    /\\/g,
-    "/"
-  );
+function pathFromServerDir(nitro: Nitro, absPath: string): string {
+  return relative(nitro.options.output.serverDir, absPath).replace(/\\/g, "/");
 }
 
 export function serverAssets(nitro: Nitro): Plugin {
+  // Development: Use filesystem
   if (nitro.options.dev || nitro.options.preset === "nitro-prerender") {
     return virtual(
       { "#nitro-internal-virtual/server-assets": getAssetsDev(nitro) },
@@ -65,7 +52,6 @@ export function serverAssets(nitro: Nitro): Plugin {
     (a) => resolveEmbedMode(a) === false
   );
 
-  // Register copy once (not inside the virtual template, which may re-run).
   if (fsAssetDirs.length > 0) {
     nitro.hooks.hook("compiled", async () => {
       for (const asset of fsAssetDirs) {
@@ -79,6 +65,7 @@ export function serverAssets(nitro: Nitro): Plugin {
     });
   }
 
+  // Production: Bundle assets (or keep on disk when embed:false)
   return virtual(
     {
       "#nitro-internal-virtual/server-assets": async () => {
@@ -87,11 +74,11 @@ export function serverAssets(nitro: Nitro): Plugin {
         );
 
         if (embedAssets.length === 0) {
-          return getAssetsFsOnly(nitro, fsAssetDirs);
+          return getAssetsFs(nitro, fsAssetDirs);
         }
 
-        const allInline: { id: string; asset: ResolvedAsset }[] = [];
-        const allRaw: { id: string; asset: ResolvedAsset }[] = [];
+        const inlineAssets: Record<string, ResolvedAsset> = {};
+        const rawAssets: Record<string, ResolvedAsset> = {};
 
         for (const asset of embedAssets) {
           const mode = resolveEmbedMode(asset);
@@ -101,49 +88,54 @@ export function serverAssets(nitro: Nitro): Plugin {
             ignore: asset.ignore,
           });
 
-          // Explicit inline, or auto-inline many small text files (avoids N× raw: modules).
-          const autoInline =
-            mode === "inline" || (mode === true && files.length >= 50);
-
-          await runParallel(
+          const { errors } = await runParallel(
             new Set(files),
             async (_id) => {
               const fsPath = resolve(asset.dir, _id);
-              const id = asset.baseName + "/" + _id;
+              const id = normalizeKey(asset.baseName + "/" + _id);
               // @ts-ignore TODO: Use mime@2 types
               let type = mime.getType(id) || "text/plain";
               if (type.startsWith("text")) {
                 type += "; charset=utf-8";
               }
-              const stat = await fsp.stat(fsPath);
+
+              const [data, stat] = await Promise.all([
+                fsp.readFile(fsPath),
+                fsp.stat(fsPath),
+              ]);
               const meta = {
                 type,
-                etag: weakEtag(stat.size, stat.mtimeMs),
+                etag: createEtag(data),
                 mtime: stat.mtime.toJSON(),
               };
-              const resolved: ResolvedAsset = { fsPath, meta };
 
-              const useInline =
-                mode === "inline" ||
-                (autoInline &&
-                  isProbablyText(type, _id) &&
-                  stat.size <= 64 * 1024);
-
-              if (useInline) {
-                const buf = await fsp.readFile(fsPath);
-                resolved.data = isProbablyText(type, _id)
-                  ? buf.toString("utf8")
-                  : buf;
-                allInline.push({ id, asset: resolved });
+              if (mode === "inline") {
+                const binary = isBinaryType(type);
+                inlineAssets[id] = {
+                  fsPath,
+                  meta,
+                  data: binary
+                    ? data.toString("base64")
+                    : data.toString("utf8"),
+                  encoding: binary ? "base64" : undefined,
+                };
               } else {
-                allRaw.push({ id, asset: resolved });
+                rawAssets[id] = { fsPath, meta };
               }
             },
-            { concurrency: 16 }
+            { concurrency: 25 }
           );
+
+          if (errors.length > 0) {
+            throw new Error(
+              `Failed to process some server assets:\n- ${errors
+                .map((e) => (e instanceof Error ? e.message : String(e)))
+                .join("\n- ")}`
+            );
+          }
         }
 
-        return getAssetProdMixed(nitro, allInline, allRaw, fsAssetDirs);
+        return getAssetProd(nitro, inlineAssets, rawAssets, fsAssetDirs);
       },
     },
     nitro.vfs
@@ -164,92 +156,92 @@ for (const asset of serverAssets) {
 }`;
 }
 
-function getAssetsFsOnly(nitro: Nitro, fsAssets: ServerAssetDir[]) {
+function getAssetsFs(nitro: Nitro, fsAssets: ServerAssetDir[]) {
   const mounts = fsAssets.map((asset) => ({
     baseName: asset.baseName,
-    rel: relFromNitroChunk(
-      nitro.options.output.serverDir,
+    path: pathFromServerDir(
+      nitro,
       join(nitro.options.output.serverDir, "assets", asset.baseName)
     ),
     ignore: asset.ignore || [],
   }));
+
   return `
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'pathe'
+import { dirname, resolve } from 'pathe'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const serverDir = dirname(fileURLToPath(import.meta.url))
 const mounts = ${JSON.stringify(mounts)}
 
 export const assets = createStorage()
 
 for (const asset of mounts) {
   assets.mount(asset.baseName, fsDriver({
-    base: join(__dirname, asset.rel),
+    base: resolve(serverDir, asset.path),
     ignore: asset.ignore || [],
   }))
-}
-`;
+}`;
 }
 
-function getAssetProdMixed(
+function getAssetProd(
   nitro: Nitro,
-  inlineAssets: { id: string; asset: ResolvedAsset }[],
-  rawAssets: { id: string; asset: ResolvedAsset }[],
+  inlineAssets: Record<string, ResolvedAsset>,
+  rawAssets: Record<string, ResolvedAsset>,
   fsAssets: ServerAssetDir[]
 ) {
-  const inlineEntries = inlineAssets
-    .map(({ id, asset }) => {
-      const payload =
-        typeof asset.data === "string"
-          ? JSON.stringify(asset.data)
-          : `Uint8Array.from(atob(${JSON.stringify(
-              Buffer.from(asset.data || []).toString("base64")
-            )}), c => c.charCodeAt(0))`;
-      return `  [${JSON.stringify(normalizeKey(id))}]: {\n    data: ${payload},\n    meta: ${JSON.stringify(asset.meta)}\n  }`;
+  const hasFs = fsAssets.length > 0;
+  const hasInline = Object.keys(inlineAssets).length > 0;
+
+  // Default embed:true with no fs mounts — keep the historical template shape.
+  if (!hasFs && !hasInline) {
+    return getAssetProdRawOnly(rawAssets);
+  }
+
+  const fsMounts = fsAssets.map((asset) => ({
+    baseName: asset.baseName,
+    path: pathFromServerDir(
+      nitro,
+      join(nitro.options.output.serverDir, "assets", asset.baseName)
+    ),
+    ignore: asset.ignore || [],
+  }));
+
+  const inlineEntries = Object.entries(inlineAssets)
+    .map(([id, asset]) => {
+      const dataExpr =
+        asset.encoding === "base64"
+          ? `Buffer.from(${JSON.stringify(asset.data)}, "base64")`
+          : JSON.stringify(asset.data);
+      return `  [${JSON.stringify(id)}]: {\n    data: ${dataExpr},\n    meta: ${JSON.stringify(asset.meta)}\n  }`;
     })
     .join(",\n");
 
-  const rawEntries = rawAssets
+  const rawEntries = Object.entries(rawAssets)
     .map(
-      ({ id, asset }) =>
-        `  [${JSON.stringify(normalizeKey(id))}]: {\n    import: () => import(${JSON.stringify(
+      ([id, asset]) =>
+        `  [${JSON.stringify(id)}]: {\n    import: () => import(${JSON.stringify(
           "raw:" + asset.fsPath
         )}).then(r => r.default || r),\n    meta: ${JSON.stringify(asset.meta)}\n  }`
     )
     .join(",\n");
 
-  const fsMounts = fsAssets.map((a) => ({
-    baseName: a.baseName,
-    rel: relFromNitroChunk(
-      nitro.options.output.serverDir,
-      join(nitro.options.output.serverDir, "assets", a.baseName)
-    ),
-    ignore: a.ignore || [],
-  }));
-
-  const fsBootstrap =
-    fsMounts.length > 0
-      ? `
-import { createStorage as __createFsStorage } from 'unstorage'
+  return `
+${
+  hasFs
+    ? `import { createStorage as __createFsStorage } from 'unstorage'
 import __fsDriver from 'unstorage/drivers/fs'
-import { fileURLToPath as __fileURLToPath } from 'node:url'
-import { dirname as __dirnameOf, join as __join } from 'pathe'
-const __dirname = __dirnameOf(__fileURLToPath(import.meta.url))
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'pathe'
+const serverDir = dirname(fileURLToPath(import.meta.url))
 const __fsMounts = ${JSON.stringify(fsMounts)}
 const __fsAssets = __createFsStorage()
 for (const asset of __fsMounts) {
-  __fsAssets.mount(asset.baseName, __fsDriver({ base: __join(__dirname, asset.rel), ignore: asset.ignore || [] }))
+  __fsAssets.mount(asset.baseName, __fsDriver({ base: resolve(serverDir, asset.path), ignore: asset.ignore || [] }))
+}`
+    : `const __fsAssets = null`
 }
-`
-      : `
-const __fsAssets = null
-const __fsMounts = []
-`;
-
-  return `
-${fsBootstrap}
 
 const _inline = {
 ${inlineEntries}
@@ -265,8 +257,7 @@ export const assets = {
   async getKeys() {
     const keys = [...Object.keys(_inline), ...Object.keys(_raw)]
     if (__fsAssets) {
-      const fsKeys = await __fsAssets.getKeys()
-      keys.push(...fsKeys.map((k) => normalizeKey(k)))
+      keys.push(...(await __fsAssets.getKeys()).map((k) => normalizeKey(k)))
     }
     return keys
   },
@@ -286,6 +277,41 @@ export const assets = {
     if (id in _inline) return _inline[id].meta
     if (id in _raw) return _raw[id].meta
     return __fsAssets ? __fsAssets.getMeta(id) : {}
+  }
+}
+`;
+}
+
+function getAssetProdRawOnly(assets: Record<string, ResolvedAsset>) {
+  return `
+const _assets = {
+${Object.entries(assets)
+  .map(
+    ([id, asset]) =>
+      `  [${JSON.stringify(id)}]: {\n    import: () => import(${JSON.stringify(
+        "raw:" + asset.fsPath
+      )}).then(r => r.default || r),\n    meta: ${JSON.stringify(asset.meta)}\n  }`
+  )
+  .join(",\n")}
+}
+
+const normalizeKey = ${normalizeKey.toString()}
+
+export const assets = {
+  getKeys() {
+    return Promise.resolve(Object.keys(_assets))
+  },
+  hasItem (id) {
+    id = normalizeKey(id)
+    return Promise.resolve(id in _assets)
+  },
+  getItem (id) {
+    id = normalizeKey(id)
+    return Promise.resolve(_assets[id] ? _assets[id].import() : null)
+  },
+  getMeta (id) {
+    id = normalizeKey(id)
+    return Promise.resolve(_assets[id] ? _assets[id].meta : {})
   }
 }
 `;

--- a/src/rollup/plugins/server-assets.ts
+++ b/src/rollup/plugins/server-assets.ts
@@ -1,11 +1,11 @@
 import { promises as fsp } from "node:fs";
-import createEtag from "etag";
 import { globby } from "globby";
 import mime from "mime";
-import type { Nitro } from "nitropack/types";
-import { resolve } from "pathe";
+import type { Nitro, ServerAssetDir } from "nitropack/types";
+import { join, relative, resolve } from "pathe";
 import type { Plugin } from "rollup";
 import { normalizeKey } from "unstorage";
+import { runParallel } from "../../core/utils/parallel";
 import { virtual } from "./virtual";
 
 interface ResolvedAsset {
@@ -15,10 +15,45 @@ interface ResolvedAsset {
     etag?: string;
     mtime?: string;
   };
+  data?: string | Uint8Array;
+}
+
+type EmbedMode = boolean | "inline";
+
+function resolveEmbedMode(asset: ServerAssetDir): EmbedMode {
+  return asset.embed ?? true;
+}
+
+/** Weak etag from size + mtime — avoids reading every file during the scan. */
+function weakEtag(size: number, mtimeMs: number): string {
+  return `W/"${size.toString(16)}-${Math.trunc(mtimeMs).toString(16)}"`;
+}
+
+function isProbablyText(type: string, id: string): boolean {
+  if (
+    type.startsWith("text") ||
+    type.includes("json") ||
+    type.includes("xml") ||
+    type.includes("javascript")
+  ) {
+    return true;
+  }
+  return /\.(json|jsonc|txt|md|html|htm|svg|css|csv|tsv|xml|yaml|yml|toml)$/i.test(
+    id
+  );
+}
+
+/**
+ * Path from the main nitro chunk (`chunks/nitro/nitro.mjs`) to a server-dir relative folder.
+ */
+function relFromNitroChunk(serverDir: string, absTarget: string): string {
+  return relative(join(serverDir, "chunks/nitro"), absTarget).replace(
+    /\\/g,
+    "/"
+  );
 }
 
 export function serverAssets(nitro: Nitro): Plugin {
-  // Development: Use filesystem
   if (nitro.options.dev || nitro.options.preset === "nitro-prerender") {
     return virtual(
       { "#nitro-internal-virtual/server-assets": getAssetsDev(nitro) },
@@ -26,33 +61,89 @@ export function serverAssets(nitro: Nitro): Plugin {
     );
   }
 
-  // Production: Bundle assets
+  const fsAssetDirs = nitro.options.serverAssets.filter(
+    (a) => resolveEmbedMode(a) === false
+  );
+
+  // Register copy once (not inside the virtual template, which may re-run).
+  if (fsAssetDirs.length > 0) {
+    nitro.hooks.hook("compiled", async () => {
+      for (const asset of fsAssetDirs) {
+        const dest = join(
+          nitro.options.output.serverDir,
+          "assets",
+          asset.baseName
+        );
+        await fsp.cp(asset.dir, dest, { recursive: true, force: true });
+      }
+    });
+  }
+
   return virtual(
     {
       "#nitro-internal-virtual/server-assets": async () => {
-        // Scan all assets
-        const assets: Record<string, ResolvedAsset> = {};
-        for (const asset of nitro.options.serverAssets) {
+        const embedAssets = nitro.options.serverAssets.filter(
+          (a) => resolveEmbedMode(a) !== false
+        );
+
+        if (embedAssets.length === 0) {
+          return getAssetsFsOnly(nitro, fsAssetDirs);
+        }
+
+        const allInline: { id: string; asset: ResolvedAsset }[] = [];
+        const allRaw: { id: string; asset: ResolvedAsset }[] = [];
+
+        for (const asset of embedAssets) {
+          const mode = resolveEmbedMode(asset);
           const files = await globby(asset.pattern || "**/*", {
             cwd: asset.dir,
             absolute: false,
             ignore: asset.ignore,
           });
-          for (const _id of files) {
-            const fsPath = resolve(asset.dir, _id);
-            const id = asset.baseName + "/" + _id;
-            assets[id] = { fsPath, meta: {} };
-            // @ts-ignore TODO: Use mime@2 types
-            let type = mime.getType(id) || "text/plain";
-            if (type.startsWith("text")) {
-              type += "; charset=utf-8";
-            }
-            const etag = createEtag(await fsp.readFile(fsPath));
-            const mtime = await fsp.stat(fsPath).then((s) => s.mtime.toJSON());
-            assets[id].meta = { type, etag, mtime };
-          }
+
+          // Explicit inline, or auto-inline many small text files (avoids N× raw: modules).
+          const autoInline =
+            mode === "inline" || (mode === true && files.length >= 50);
+
+          await runParallel(
+            new Set(files),
+            async (_id) => {
+              const fsPath = resolve(asset.dir, _id);
+              const id = asset.baseName + "/" + _id;
+              // @ts-ignore TODO: Use mime@2 types
+              let type = mime.getType(id) || "text/plain";
+              if (type.startsWith("text")) {
+                type += "; charset=utf-8";
+              }
+              const stat = await fsp.stat(fsPath);
+              const meta = {
+                type,
+                etag: weakEtag(stat.size, stat.mtimeMs),
+                mtime: stat.mtime.toJSON(),
+              };
+              const resolved: ResolvedAsset = { fsPath, meta };
+
+              const useInline =
+                mode === "inline" ||
+                (autoInline &&
+                  isProbablyText(type, _id) &&
+                  stat.size <= 64 * 1024);
+
+              if (useInline) {
+                const buf = await fsp.readFile(fsPath);
+                resolved.data = isProbablyText(type, _id)
+                  ? buf.toString("utf8")
+                  : buf;
+                allInline.push({ id, asset: resolved });
+              } else {
+                allRaw.push({ id, asset: resolved });
+              }
+            },
+            { concurrency: 16 }
+          );
         }
-        return getAssetProd(assets);
+
+        return getAssetProdMixed(nitro, allInline, allRaw, fsAssetDirs);
       },
     },
     nitro.vfs
@@ -73,38 +164,128 @@ for (const asset of serverAssets) {
 }`;
 }
 
-function getAssetProd(assets: Record<string, ResolvedAsset>) {
+function getAssetsFsOnly(nitro: Nitro, fsAssets: ServerAssetDir[]) {
+  const mounts = fsAssets.map((asset) => ({
+    baseName: asset.baseName,
+    rel: relFromNitroChunk(
+      nitro.options.output.serverDir,
+      join(nitro.options.output.serverDir, "assets", asset.baseName)
+    ),
+    ignore: asset.ignore || [],
+  }));
   return `
-const _assets = {\n${Object.entries(assets)
+import { createStorage } from 'unstorage'
+import fsDriver from 'unstorage/drivers/fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'pathe'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const mounts = ${JSON.stringify(mounts)}
+
+export const assets = createStorage()
+
+for (const asset of mounts) {
+  assets.mount(asset.baseName, fsDriver({
+    base: join(__dirname, asset.rel),
+    ignore: asset.ignore || [],
+  }))
+}
+`;
+}
+
+function getAssetProdMixed(
+  nitro: Nitro,
+  inlineAssets: { id: string; asset: ResolvedAsset }[],
+  rawAssets: { id: string; asset: ResolvedAsset }[],
+  fsAssets: ServerAssetDir[]
+) {
+  const inlineEntries = inlineAssets
+    .map(({ id, asset }) => {
+      const payload =
+        typeof asset.data === "string"
+          ? JSON.stringify(asset.data)
+          : `Uint8Array.from(atob(${JSON.stringify(
+              Buffer.from(asset.data || []).toString("base64")
+            )}), c => c.charCodeAt(0))`;
+      return `  [${JSON.stringify(normalizeKey(id))}]: {\n    data: ${payload},\n    meta: ${JSON.stringify(asset.meta)}\n  }`;
+    })
+    .join(",\n");
+
+  const rawEntries = rawAssets
     .map(
-      ([id, asset]) =>
-        `  [${JSON.stringify(
-          normalizeKey(id)
-        )}]: {\n    import: () => import(${JSON.stringify(
+      ({ id, asset }) =>
+        `  [${JSON.stringify(normalizeKey(id))}]: {\n    import: () => import(${JSON.stringify(
           "raw:" + asset.fsPath
-        )}).then(r => r.default || r),\n    meta: ${JSON.stringify(
-          asset.meta
-        )}\n  }`
+        )}).then(r => r.default || r),\n    meta: ${JSON.stringify(asset.meta)}\n  }`
     )
-    .join(",\n")}\n}
+    .join(",\n");
+
+  const fsMounts = fsAssets.map((a) => ({
+    baseName: a.baseName,
+    rel: relFromNitroChunk(
+      nitro.options.output.serverDir,
+      join(nitro.options.output.serverDir, "assets", a.baseName)
+    ),
+    ignore: a.ignore || [],
+  }));
+
+  const fsBootstrap =
+    fsMounts.length > 0
+      ? `
+import { createStorage as __createFsStorage } from 'unstorage'
+import __fsDriver from 'unstorage/drivers/fs'
+import { fileURLToPath as __fileURLToPath } from 'node:url'
+import { dirname as __dirnameOf, join as __join } from 'pathe'
+const __dirname = __dirnameOf(__fileURLToPath(import.meta.url))
+const __fsMounts = ${JSON.stringify(fsMounts)}
+const __fsAssets = __createFsStorage()
+for (const asset of __fsMounts) {
+  __fsAssets.mount(asset.baseName, __fsDriver({ base: __join(__dirname, asset.rel), ignore: asset.ignore || [] }))
+}
+`
+      : `
+const __fsAssets = null
+const __fsMounts = []
+`;
+
+  return `
+${fsBootstrap}
+
+const _inline = {
+${inlineEntries}
+}
+
+const _raw = {
+${rawEntries}
+}
 
 const normalizeKey = ${normalizeKey.toString()}
 
 export const assets = {
-  getKeys() {
-    return Promise.resolve(Object.keys(_assets))
+  async getKeys() {
+    const keys = [...Object.keys(_inline), ...Object.keys(_raw)]
+    if (__fsAssets) {
+      const fsKeys = await __fsAssets.getKeys()
+      keys.push(...fsKeys.map((k) => normalizeKey(k)))
+    }
+    return keys
   },
-  hasItem (id) {
+  async hasItem (id) {
     id = normalizeKey(id)
-    return Promise.resolve(id in _assets)
+    if (id in _inline || id in _raw) return true
+    return __fsAssets ? __fsAssets.hasItem(id) : false
   },
-  getItem (id) {
+  async getItem (id) {
     id = normalizeKey(id)
-    return Promise.resolve(_assets[id] ? _assets[id].import() : null)
+    if (id in _inline) return _inline[id].data
+    if (id in _raw) return _raw[id].import()
+    return __fsAssets ? __fsAssets.getItem(id) : null
   },
-  getMeta (id) {
+  async getMeta (id) {
     id = normalizeKey(id)
-    return Promise.resolve(_assets[id] ? _assets[id].meta : {})
+    if (id in _inline) return _inline[id].meta
+    if (id in _raw) return _raw[id].meta
+    return __fsAssets ? __fsAssets.getMeta(id) : {}
   }
 }
 `;

--- a/src/rollup/plugins/server-assets.ts
+++ b/src/rollup/plugins/server-assets.ts
@@ -7,6 +7,7 @@ import { join, relative, resolve } from "pathe";
 import type { Plugin } from "rollup";
 import { normalizeKey } from "unstorage";
 import { runParallel } from "../../core/utils/parallel";
+import { isBinary } from "./raw";
 import { virtual } from "./virtual";
 
 interface ResolvedAsset {
@@ -24,11 +25,8 @@ interface ResolvedAsset {
 type EmbedMode = boolean | "inline";
 
 function resolveEmbedMode(asset: ServerAssetDir): EmbedMode {
+  // Default `true` preserves historical one-raw-module-per-file behavior.
   return asset.embed ?? true;
-}
-
-function isBinaryType(type: string): boolean {
-  return !/^(text\/|application\/(json|xml|javascript)|image\/svg)/.test(type);
 }
 
 /**
@@ -52,6 +50,7 @@ export function serverAssets(nitro: Nitro): Plugin {
     (a) => resolveEmbedMode(a) === false
   );
 
+  // Opt-in only: copy filesystem embeds after compile (does not run for default embed:true).
   if (fsAssetDirs.length > 0) {
     nitro.hooks.hook("compiled", async () => {
       for (const asset of fsAssetDirs) {
@@ -65,7 +64,7 @@ export function serverAssets(nitro: Nitro): Plugin {
     });
   }
 
-  // Production: Bundle assets (or keep on disk when embed:false)
+  // Production: Bundle assets (default) or keep on disk when embed:false
   return virtual(
     {
       "#nitro-internal-virtual/server-assets": async () => {
@@ -110,7 +109,8 @@ export function serverAssets(nitro: Nitro): Plugin {
               };
 
               if (mode === "inline") {
-                const binary = isBinaryType(type);
+                // Same binary detection as the `raw:` plugin; base64 like public-assets inline.
+                const binary = isBinary(fsPath);
                 inlineAssets[id] = {
                   fsPath,
                   meta,
@@ -120,6 +120,7 @@ export function serverAssets(nitro: Nitro): Plugin {
                   encoding: binary ? "base64" : undefined,
                 };
               } else {
+                // embed: true (default) — historical lazy raw: modules
                 rawAssets[id] = { fsPath, meta };
               }
             },
@@ -166,22 +167,43 @@ function getAssetsFs(nitro: Nitro, fsAssets: ServerAssetDir[]) {
     ignore: asset.ignore || [],
   }));
 
+  // Same shape as getAssetProdRawOnly / mixed path — wrap fsDriver so getMeta
+  // still exposes `type` (mime) like embedded assets. Default raw: path untouched.
   return `
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
+import mime from 'mime'
 
 const serverDir = dirname(fileURLToPath(import.meta.url))
 const mounts = ${JSON.stringify(mounts)}
 
-export const assets = createStorage()
-
+const __fs = createStorage()
 for (const asset of mounts) {
-  assets.mount(asset.baseName, fsDriver({
+  __fs.mount(asset.baseName, fsDriver({
     base: resolve(serverDir, asset.path),
     ignore: asset.ignore || [],
   }))
+}
+
+const normalizeKey = ${normalizeKey.toString()}
+
+function withType(id, meta) {
+  // @ts-ignore mime@2
+  let type = mime.getType(id) || "text/plain"
+  if (type.startsWith("text")) type += "; charset=utf-8"
+  return { ...meta, type }
+}
+
+export const assets = {
+  getKeys: () => __fs.getKeys(),
+  hasItem: (id) => __fs.hasItem(id),
+  getItem: (id) => __fs.getItem(id),
+  async getMeta (id) {
+    id = normalizeKey(id)
+    return withType(id, await __fs.getMeta(id))
+  }
 }`;
 }
 
@@ -194,7 +216,7 @@ function getAssetProd(
   const hasFs = fsAssets.length > 0;
   const hasInline = Object.keys(inlineAssets).length > 0;
 
-  // Default embed:true with no fs mounts — keep the historical template shape.
+  // Default path unchanged: only raw: embeds → original template.
   if (!hasFs && !hasInline) {
     return getAssetProdRawOnly(rawAssets);
   }
@@ -208,11 +230,12 @@ function getAssetProd(
     ignore: asset.ignore || [],
   }));
 
+  // Decode base64 like `#nitro-internal-virtual/public-assets-inline` (atob, not Buffer).
   const inlineEntries = Object.entries(inlineAssets)
     .map(([id, asset]) => {
       const dataExpr =
         asset.encoding === "base64"
-          ? `Buffer.from(${JSON.stringify(asset.data)}, "base64")`
+          ? `Uint8Array.from(atob(${JSON.stringify(asset.data)}), (c) => c.charCodeAt(0))`
           : JSON.stringify(asset.data);
       return `  [${JSON.stringify(id)}]: {\n    data: ${dataExpr},\n    meta: ${JSON.stringify(asset.meta)}\n  }`;
     })
@@ -234,13 +257,21 @@ ${
 import __fsDriver from 'unstorage/drivers/fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
+import __mime from 'mime'
 const serverDir = dirname(fileURLToPath(import.meta.url))
 const __fsMounts = ${JSON.stringify(fsMounts)}
 const __fsAssets = __createFsStorage()
 for (const asset of __fsMounts) {
   __fsAssets.mount(asset.baseName, __fsDriver({ base: resolve(serverDir, asset.path), ignore: asset.ignore || [] }))
+}
+function __fsMetaWithType(id, meta) {
+  // @ts-ignore mime@2
+  let type = __mime.getType(id) || "text/plain"
+  if (type.startsWith("text")) type += "; charset=utf-8"
+  return { ...meta, type }
 }`
-    : `const __fsAssets = null`
+    : `const __fsAssets = null
+const __fsMetaWithType = (_id, meta) => meta`
 }
 
 const _inline = {
@@ -276,12 +307,14 @@ export const assets = {
     id = normalizeKey(id)
     if (id in _inline) return _inline[id].meta
     if (id in _raw) return _raw[id].meta
-    return __fsAssets ? __fsAssets.getMeta(id) : {}
+    if (!__fsAssets) return {}
+    return __fsMetaWithType(id, await __fsAssets.getMeta(id))
   }
 }
 `;
 }
 
+/** Historical production template — one lazy `raw:` import per file. */
 function getAssetProdRawOnly(assets: Record<string, ResolvedAsset>) {
   return `
 const _assets = {

--- a/src/rollup/plugins/server-assets.ts
+++ b/src/rollup/plugins/server-assets.ts
@@ -11,15 +11,23 @@ import { isBinary } from "./raw";
 import { virtual } from "./virtual";
 
 interface ResolvedAsset {
+  /** Absolute source path (used for `raw:` imports). */
   fsPath: string;
   meta: {
     type?: string;
     etag?: string;
     mtime?: string;
   };
-  /** Set when `embed: "inline"` (utf8 text or base64 for binary). */
+  /** `embed: "inline"` — utf8 text or base64 payload. */
   data?: string;
   encoding?: "base64";
+  /**
+   * `embed: false` — path relative to `output.serverDir`
+   * (same idea as public-assets `assets[id].path` + `readAsset`).
+   */
+  path?: string;
+  /** `embed: false` — decode as Uint8Array vs utf8 string. */
+  binary?: boolean;
 }
 
 type EmbedMode = boolean | "inline";
@@ -35,6 +43,38 @@ function resolveEmbedMode(asset: ServerAssetDir): EmbedMode {
  */
 function pathFromServerDir(nitro: Nitro, absPath: string): string {
   return relative(nitro.options.output.serverDir, absPath).replace(/\\/g, "/");
+}
+
+async function collectAssetMeta(
+  asset: ServerAssetDir,
+  _id: string
+): Promise<{
+  id: string;
+  fsPath: string;
+  data: Buffer;
+  meta: ResolvedAsset["meta"];
+}> {
+  const fsPath = resolve(asset.dir, _id);
+  const id = normalizeKey(asset.baseName + "/" + _id);
+  // @ts-ignore TODO: Use mime@2 types
+  let type = mime.getType(id) || "text/plain";
+  if (type.startsWith("text")) {
+    type += "; charset=utf-8";
+  }
+  const [data, stat] = await Promise.all([
+    fsp.readFile(fsPath),
+    fsp.stat(fsPath),
+  ]);
+  return {
+    id,
+    fsPath,
+    data,
+    meta: {
+      type,
+      etag: createEtag(data),
+      mtime: stat.mtime.toJSON(),
+    },
+  };
 }
 
 export function serverAssets(nitro: Nitro): Plugin {
@@ -68,18 +108,11 @@ export function serverAssets(nitro: Nitro): Plugin {
   return virtual(
     {
       "#nitro-internal-virtual/server-assets": async () => {
-        const embedAssets = nitro.options.serverAssets.filter(
-          (a) => resolveEmbedMode(a) !== false
-        );
-
-        if (embedAssets.length === 0) {
-          return getAssetsFs(nitro, fsAssetDirs);
-        }
-
         const inlineAssets: Record<string, ResolvedAsset> = {};
         const rawAssets: Record<string, ResolvedAsset> = {};
+        const diskAssets: Record<string, ResolvedAsset> = {};
 
-        for (const asset of embedAssets) {
+        for (const asset of nitro.options.serverAssets) {
           const mode = resolveEmbedMode(asset);
           const files = await globby(asset.pattern || "**/*", {
             cwd: asset.dir,
@@ -90,26 +123,28 @@ export function serverAssets(nitro: Nitro): Plugin {
           const { errors } = await runParallel(
             new Set(files),
             async (_id) => {
-              const fsPath = resolve(asset.dir, _id);
-              const id = normalizeKey(asset.baseName + "/" + _id);
-              // @ts-ignore TODO: Use mime@2 types
-              let type = mime.getType(id) || "text/plain";
-              if (type.startsWith("text")) {
-                type += "; charset=utf-8";
-              }
+              const { id, fsPath, data, meta } = await collectAssetMeta(
+                asset,
+                _id
+              );
 
-              const [data, stat] = await Promise.all([
-                fsp.readFile(fsPath),
-                fsp.stat(fsPath),
-              ]);
-              const meta = {
-                type,
-                etag: createEtag(data),
-                mtime: stat.mtime.toJSON(),
-              };
-
-              if (mode === "inline") {
-                // Same binary detection as the `raw:` plugin; base64 like public-assets inline.
+              if (mode === false) {
+                // public-assets-node style: meta + relative path, readFile at runtime
+                diskAssets[id] = {
+                  fsPath,
+                  meta,
+                  path: pathFromServerDir(
+                    nitro,
+                    join(
+                      nitro.options.output.serverDir,
+                      "assets",
+                      asset.baseName,
+                      _id
+                    )
+                  ),
+                  binary: isBinary(fsPath),
+                };
+              } else if (mode === "inline") {
                 const binary = isBinary(fsPath);
                 inlineAssets[id] = {
                   fsPath,
@@ -136,7 +171,7 @@ export function serverAssets(nitro: Nitro): Plugin {
           }
         }
 
-        return getAssetProd(nitro, inlineAssets, rawAssets, fsAssetDirs);
+        return getAssetProd(inlineAssets, rawAssets, diskAssets);
       },
     },
     nitro.vfs
@@ -157,78 +192,24 @@ for (const asset of serverAssets) {
 }`;
 }
 
-function getAssetsFs(nitro: Nitro, fsAssets: ServerAssetDir[]) {
-  const mounts = fsAssets.map((asset) => ({
-    baseName: asset.baseName,
-    path: pathFromServerDir(
-      nitro,
-      join(nitro.options.output.serverDir, "assets", asset.baseName)
-    ),
-    ignore: asset.ignore || [],
-  }));
-
-  // Same shape as getAssetProdRawOnly / mixed path — wrap fsDriver so getMeta
-  // still exposes `type` (mime) like embedded assets. Default raw: path untouched.
-  return `
-import { createStorage } from 'unstorage'
-import fsDriver from 'unstorage/drivers/fs'
-import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'pathe'
-import mime from 'mime'
-
-const serverDir = dirname(fileURLToPath(import.meta.url))
-const mounts = ${JSON.stringify(mounts)}
-
-const __fs = createStorage()
-for (const asset of mounts) {
-  __fs.mount(asset.baseName, fsDriver({
-    base: resolve(serverDir, asset.path),
-    ignore: asset.ignore || [],
-  }))
-}
-
-const normalizeKey = ${normalizeKey.toString()}
-
-function withType(id, meta) {
-  // @ts-ignore mime@2
-  let type = mime.getType(id) || "text/plain"
-  if (type.startsWith("text")) type += "; charset=utf-8"
-  return { ...meta, type }
-}
-
-export const assets = {
-  getKeys: () => __fs.getKeys(),
-  hasItem: (id) => __fs.hasItem(id),
-  getItem: (id) => __fs.getItem(id),
-  async getMeta (id) {
-    id = normalizeKey(id)
-    return withType(id, await __fs.getMeta(id))
-  }
-}`;
-}
-
+/**
+ * Production virtual module.
+ *
+ * - raw only → historical template (byte-identical shape to pre-change Nitro)
+ * - otherwise → same map pattern as public-assets-data (+ raw imports / inline / disk paths)
+ */
 function getAssetProd(
-  nitro: Nitro,
   inlineAssets: Record<string, ResolvedAsset>,
   rawAssets: Record<string, ResolvedAsset>,
-  fsAssets: ServerAssetDir[]
+  diskAssets: Record<string, ResolvedAsset>
 ) {
-  const hasFs = fsAssets.length > 0;
   const hasInline = Object.keys(inlineAssets).length > 0;
+  const hasDisk = Object.keys(diskAssets).length > 0;
 
   // Default path unchanged: only raw: embeds → original template.
-  if (!hasFs && !hasInline) {
+  if (!hasInline && !hasDisk) {
     return getAssetProdRawOnly(rawAssets);
   }
-
-  const fsMounts = fsAssets.map((asset) => ({
-    baseName: asset.baseName,
-    path: pathFromServerDir(
-      nitro,
-      join(nitro.options.output.serverDir, "assets", asset.baseName)
-    ),
-    ignore: asset.ignore || [],
-  }));
 
   // Decode base64 like `#nitro-internal-virtual/public-assets-inline` (atob, not Buffer).
   const inlineEntries = Object.entries(inlineAssets)
@@ -250,29 +231,23 @@ function getAssetProd(
     )
     .join(",\n");
 
+  const diskEntries = Object.entries(diskAssets)
+    .map(
+      ([id, asset]) =>
+        `  [${JSON.stringify(id)}]: {\n    path: ${JSON.stringify(
+          asset.path
+        )},\n    binary: ${asset.binary ? "true" : "false"},\n    meta: ${JSON.stringify(
+          asset.meta
+        )}\n  }`
+    )
+    .join(",\n");
+
   return `
-${
-  hasFs
-    ? `import { createStorage as __createFsStorage } from 'unstorage'
-import __fsDriver from 'unstorage/drivers/fs'
+import { promises as fsp } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
-import __mime from 'mime'
+
 const serverDir = dirname(fileURLToPath(import.meta.url))
-const __fsMounts = ${JSON.stringify(fsMounts)}
-const __fsAssets = __createFsStorage()
-for (const asset of __fsMounts) {
-  __fsAssets.mount(asset.baseName, __fsDriver({ base: resolve(serverDir, asset.path), ignore: asset.ignore || [] }))
-}
-function __fsMetaWithType(id, meta) {
-  // @ts-ignore mime@2
-  let type = __mime.getType(id) || "text/plain"
-  if (type.startsWith("text")) type += "; charset=utf-8"
-  return { ...meta, type }
-}`
-    : `const __fsAssets = null
-const __fsMetaWithType = (_id, meta) => meta`
-}
 
 const _inline = {
 ${inlineEntries}
@@ -282,33 +257,34 @@ const _raw = {
 ${rawEntries}
 }
 
+const _disk = {
+${diskEntries}
+}
+
 const normalizeKey = ${normalizeKey.toString()}
 
 export const assets = {
   async getKeys() {
-    const keys = [...Object.keys(_inline), ...Object.keys(_raw)]
-    if (__fsAssets) {
-      keys.push(...(await __fsAssets.getKeys()).map((k) => normalizeKey(k)))
-    }
-    return keys
+    return [...Object.keys(_inline), ...Object.keys(_raw), ...Object.keys(_disk)]
   },
   async hasItem (id) {
     id = normalizeKey(id)
-    if (id in _inline || id in _raw) return true
-    return __fsAssets ? __fsAssets.hasItem(id) : false
+    return id in _inline || id in _raw || id in _disk
   },
   async getItem (id) {
     id = normalizeKey(id)
     if (id in _inline) return _inline[id].data
     if (id in _raw) return _raw[id].import()
-    return __fsAssets ? __fsAssets.getItem(id) : null
+    if (id in _disk) {
+      const a = _disk[id]
+      const buf = await fsp.readFile(resolve(serverDir, a.path))
+      return a.binary ? new Uint8Array(buf) : buf.toString('utf8')
+    }
+    return null
   },
   async getMeta (id) {
     id = normalizeKey(id)
-    if (id in _inline) return _inline[id].meta
-    if (id in _raw) return _raw[id].meta
-    if (!__fsAssets) return {}
-    return __fsMetaWithType(id, await __fsAssets.getMeta(id))
+    return _inline[id]?.meta || _raw[id]?.meta || _disk[id]?.meta || {}
   }
 }
 `;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -322,6 +322,17 @@ export interface ServerAssetDir {
   pattern?: string;
   dir: string;
   ignore?: string[];
+  /**
+   * How assets are included in the production server build.
+   *
+   * - `true` (default): lazy `raw:` Rollup modules (one per file). Many small files are
+   *   automatically inlined into a single virtual module (≥50 text/json files) to avoid
+   *   Rollup thrashing.
+   * - `"inline"`: always embed file contents into one virtual module (fast builds).
+   * - `false`: keep files on disk (copied to `server/assets/<baseName>`). Use on Node/Bun/Deno
+   *   when the catalog is large — skips Rollup `raw:` entirely.
+   */
+  embed?: boolean | "inline";
 }
 
 // Storage mounts

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -325,12 +325,11 @@ export interface ServerAssetDir {
   /**
    * How assets are included in the production server build.
    *
-   * - `true` (default): lazy `raw:` Rollup modules (one per file). Many small files are
-   *   automatically inlined into a single virtual module (≥50 text/json files) to avoid
-   *   Rollup thrashing.
-   * - `"inline"`: always embed file contents into one virtual module (fast builds).
-   * - `false`: keep files on disk (copied to `server/assets/<baseName>`). Use on Node/Bun/Deno
-   *   when the catalog is large — skips Rollup `raw:` entirely.
+   * - `true` (default): one lazy Rollup `raw:` module per file (historical behavior).
+   * - `"inline"`: embed contents into a single virtual module (much faster for many small files).
+   * - `false`: keep files on disk under `server/assets/<baseName>` (Node/Bun/Deno; no `raw:`).
+   *
+   * @see https://nitro.build/docs/assets#server-assets
    */
   embed?: boolean | "inline";
 }

--- a/test/unit/server-assets-perf.test.ts
+++ b/test/unit/server-assets-perf.test.ts
@@ -24,16 +24,44 @@ function genTree(dir: string, depth: number, branch: number): number {
 
 function countRawMjs(outDir: string): number {
   const rawDir = join(outDir, "server/chunks/raw");
-  if (!existsSync(rawDir)) return 0;
+  if (!existsSync(rawDir)) {
+    return 0;
+  }
   let n = 0;
   const walk = (d: string) => {
     for (const e of readdirSync(d, { withFileTypes: true })) {
-      if (e.isDirectory()) walk(join(d, e.name));
-      else if (e.name.endsWith(".mjs")) n++;
+      if (e.isDirectory()) {
+        walk(join(d, e.name));
+      } else if (e.name.endsWith(".mjs")) {
+        n++;
+      }
     }
   };
   walk(rawDir);
   return n;
+}
+
+async function buildWithAssets(
+  outName: string,
+  serverAssets: { baseName: string; dir: string; embed?: boolean | "inline" }[]
+) {
+  const outDir = join(ROOT, outName);
+  rmSync(outDir, { recursive: true, force: true });
+  const t0 = performance.now();
+  const nitro = await createNitro({
+    rootDir: ROOT,
+    srcDir: ROOT,
+    output: { dir: outDir },
+    preset: "node-server",
+    minify: false,
+    typescript: { generateTsConfig: false },
+    logging: { compressedSizes: false },
+    serverAssets,
+  });
+  await prepare(nitro);
+  await copyPublicAssets(nitro);
+  await build(nitro);
+  return { outDir, ms: performance.now() - t0 };
 }
 
 describe("serverAssets large catalogs", () => {
@@ -48,32 +76,13 @@ describe("serverAssets large catalogs", () => {
   });
 
   it(
-    "auto-inlines many small JSON files (no raw: chunk explosion)",
+    "embed:true keeps one raw: chunk per file (historical default)",
     { timeout: 120_000 },
     async () => {
-      const outDir = join(ROOT, "out-auto-inline");
-      rmSync(outDir, { recursive: true, force: true });
-
-      const t0 = performance.now();
-      const nitro = await createNitro({
-        rootDir: ROOT,
-        srcDir: ROOT,
-        output: { dir: outDir },
-        preset: "node-server",
-        minify: false,
-        typescript: { generateTsConfig: false },
-        logging: { compressedSizes: false },
-        serverAssets: [{ baseName: "i18n", dir: DATA }],
-      });
-      await prepare(nitro);
-      await copyPublicAssets(nitro);
-      await build(nitro);
-      const ms = performance.now() - t0;
-
-      // Default embed:true with ≥50 text files → inline → no per-file raw chunks
-      expect(countRawMjs(outDir)).toBe(0);
-      // Should stay in the same ballpark as nitropack 2.12 on this fixture (was multi‑10s with raw:)
-      expect(ms).toBeLessThan(15_000);
+      const { outDir } = await buildWithAssets("out-raw", [
+        { baseName: "i18n", dir: DATA },
+      ]);
+      expect(countRawMjs(outDir)).toBe(fileCount);
     }
   );
 
@@ -81,27 +90,11 @@ describe("serverAssets large catalogs", () => {
     "embed:false copies assets and skips raw: chunks",
     { timeout: 120_000 },
     async () => {
-      const outDir = join(ROOT, "out-fs");
-      rmSync(outDir, { recursive: true, force: true });
-
-      const nitro = await createNitro({
-        rootDir: ROOT,
-        srcDir: ROOT,
-        output: { dir: outDir },
-        preset: "node-server",
-        minify: false,
-        typescript: { generateTsConfig: false },
-        logging: { compressedSizes: false },
-        serverAssets: [{ baseName: "i18n", dir: DATA, embed: false }],
-      });
-      await prepare(nitro);
-      await copyPublicAssets(nitro);
-      await build(nitro);
-
+      const { outDir } = await buildWithAssets("out-fs", [
+        { baseName: "i18n", dir: DATA, embed: false },
+      ]);
       expect(countRawMjs(outDir)).toBe(0);
       expect(existsSync(join(outDir, "server/assets/i18n"))).toBe(true);
-      expect(existsSync(join(outDir, "server/index.mjs"))).toBe(true);
-      // Spot-check a copied leaf
       expect(
         existsSync(join(outDir, "server/assets/i18n/l0/l0/l0/l0/data.json"))
       ).toBe(true);
@@ -109,29 +102,14 @@ describe("serverAssets large catalogs", () => {
   );
 
   it(
-    "embed:'inline' keeps a single virtual module",
+    "embed:'inline' uses a single virtual module (no raw: chunks)",
     { timeout: 120_000 },
     async () => {
-      const outDir = join(ROOT, "out-inline");
-      rmSync(outDir, { recursive: true, force: true });
-
-      const t0 = performance.now();
-      const nitro = await createNitro({
-        rootDir: ROOT,
-        srcDir: ROOT,
-        output: { dir: outDir },
-        preset: "node-server",
-        minify: false,
-        typescript: { generateTsConfig: false },
-        logging: { compressedSizes: false },
-        serverAssets: [{ baseName: "i18n", dir: DATA, embed: "inline" }],
-      });
-      await prepare(nitro);
-      await copyPublicAssets(nitro);
-      await build(nitro);
-      const ms = performance.now() - t0;
-
+      const { outDir, ms } = await buildWithAssets("out-inline", [
+        { baseName: "i18n", dir: DATA, embed: "inline" },
+      ]);
       expect(countRawMjs(outDir)).toBe(0);
+      // Should stay near nitropack 2.12 wall time on this fixture, not multi-10s raw: thrash
       expect(ms).toBeLessThan(15_000);
     }
   );

--- a/test/unit/server-assets-perf.test.ts
+++ b/test/unit/server-assets-perf.test.ts
@@ -1,7 +1,15 @@
-import { mkdirSync, rmSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import {
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "pathe";
 import { describe, expect, it } from "vitest";
 import { createNitro, build, prepare, copyPublicAssets } from "nitropack/core";
+import { listen } from "listhen";
 
 const ROOT = join(import.meta.dirname, ".tmp-server-assets-perf");
 const DATA = join(ROOT, "i18n-data");
@@ -43,20 +51,29 @@ function countRawMjs(outDir: string): number {
 
 async function buildWithAssets(
   outName: string,
-  serverAssets: { baseName: string; dir: string; embed?: boolean | "inline" }[]
+  serverAssets: {
+    baseName: string;
+    dir: string;
+    embed?: boolean | "inline";
+    pattern?: string;
+    ignore?: string[];
+  }[],
+  handlers?: { route: string; handler: string }[]
 ) {
   const outDir = join(ROOT, outName);
   rmSync(outDir, { recursive: true, force: true });
   const t0 = performance.now();
+  // node-listener exports `listener` without auto-listen (node-server binds :3000 on import).
   const nitro = await createNitro({
     rootDir: ROOT,
     srcDir: ROOT,
     output: { dir: outDir },
-    preset: "node-server",
+    preset: "node-listener",
     minify: false,
     typescript: { generateTsConfig: false },
     logging: { compressedSizes: false },
     serverAssets,
+    handlers,
   });
   await prepare(nitro);
   await copyPublicAssets(nitro);
@@ -71,46 +88,263 @@ describe("serverAssets large catalogs", () => {
     return genTree(DATA, 4, 5);
   })();
 
+  // Tiny mixed fixture for runtime / binary / ignore tests
+  const MIX = join(ROOT, "mixed");
+  mkdirSync(join(MIX, "txt"), { recursive: true });
+  writeFileSync(join(MIX, "txt", "hello.json"), JSON.stringify({ ok: true }));
+  writeFileSync(join(MIX, "txt", "skip.me"), "nope");
+  writeFileSync(
+    join(MIX, "txt", "pixel.bin"),
+    Buffer.from([0x00, 0x01, 0x02, 0xff])
+  );
+
+  const handlerPath = join(ROOT, "routes", "read.get.ts");
+  mkdirSync(join(ROOT, "routes"), { recursive: true });
+  writeFileSync(
+    handlerPath,
+    `export default defineEventHandler(async (event) => {
+  const id = getQuery(event).id as string
+  const storage = useStorage('assets:i18n')
+  const item = await storage.getItem(id)
+  return {
+    has: await storage.hasItem(id),
+    // JSON-safe: Uint8Array → number[] (binary inline path)
+    item: item instanceof Uint8Array ? Array.from(item) : item,
+    meta: await storage.getMeta(id),
+    keys: await storage.getKeys(),
+  }
+})
+`
+  );
+
   it("generates hundreds of fixture files", () => {
     expect(fileCount).toBe(625);
   });
 
   it(
-    "embed:true keeps one raw: chunk per file (historical default)",
+    "omit embed ≡ historical one raw: chunk per file (default unchanged)",
     { timeout: 120_000 },
     async () => {
       const { outDir } = await buildWithAssets("out-raw", [
         { baseName: "i18n", dir: DATA },
       ]);
       expect(countRawMjs(outDir)).toBe(fileCount);
+      // Default template path: no fs mounts / no _inline bag
+      const entry = readFileSync(join(outDir, "server/index.mjs"), "utf8");
+      // Virtual assets land in chunks — spot-check no assets/ copy for default
+      expect(existsSync(join(outDir, "server/assets/i18n"))).toBe(false);
+      void entry;
     }
   );
 
   it(
-    "embed:false copies assets and skips raw: chunks",
+    "embed:true explicit matches omit (same raw: count)",
     { timeout: 120_000 },
     async () => {
-      const { outDir } = await buildWithAssets("out-fs", [
-        { baseName: "i18n", dir: DATA, embed: false },
+      const { outDir } = await buildWithAssets("out-raw-explicit", [
+        { baseName: "i18n", dir: join(MIX, "txt"), embed: true },
       ]);
+      // 3 files in MIX/txt (hello.json, skip.me, pixel.bin)
+      expect(countRawMjs(outDir)).toBe(3);
+      expect(existsSync(join(outDir, "server/assets"))).toBe(false);
+    }
+  );
+
+  it(
+    "embed:false copies assets, skips raw:, and serves getItem at runtime",
+    { timeout: 120_000 },
+    async () => {
+      const { outDir } = await buildWithAssets(
+        "out-fs",
+        [{ baseName: "i18n", dir: DATA, embed: false }],
+        [{ route: "/read", handler: handlerPath }]
+      );
       expect(countRawMjs(outDir)).toBe(0);
-      expect(existsSync(join(outDir, "server/assets/i18n"))).toBe(true);
       expect(
         existsSync(join(outDir, "server/assets/i18n/l0/l0/l0/l0/data.json"))
       ).toBe(true);
+
+      const { listener } = await import(join(outDir, "server/index.mjs"));
+      const server = await listen(listener, { port: 0 });
+      try {
+        const url = `${server.url}read?id=${encodeURIComponent("l0/l0/l0/l0/data.json")}`;
+        const res = await fetch(url).then((r) => r.json());
+        expect(res.has).toBe(true);
+        expect(res.item).toMatchObject({ v: 1 });
+        expect(res.meta?.type).toMatch(/json/);
+        expect(res.keys.length).toBeGreaterThanOrEqual(fileCount);
+      } finally {
+        await server.close();
+      }
     }
   );
 
   it(
-    "embed:'inline' uses a single virtual module (no raw: chunks)",
+    "embed:'inline' has no raw: chunks and returns JSON + meta",
     { timeout: 120_000 },
     async () => {
-      const { outDir, ms } = await buildWithAssets("out-inline", [
-        { baseName: "i18n", dir: DATA, embed: "inline" },
-      ]);
+      const { outDir, ms } = await buildWithAssets(
+        "out-inline",
+        [{ baseName: "i18n", dir: join(MIX, "txt"), embed: "inline" }],
+        [{ route: "/read", handler: handlerPath }]
+      );
       expect(countRawMjs(outDir)).toBe(0);
-      // Should stay near nitropack 2.12 wall time on this fixture, not multi-10s raw: thrash
       expect(ms).toBeLessThan(15_000);
+
+      const { listener } = await import(join(outDir, "server/index.mjs"));
+      const server = await listen(listener, { port: 0 });
+      try {
+        const res = await fetch(
+          `${server.url}read?id=${encodeURIComponent("hello.json")}`
+        ).then((r) => r.json());
+        expect(res.has).toBe(true);
+        // Inline text may be string or already-parsed depending on unstorage
+        const item =
+          typeof res.item === "string" ? JSON.parse(res.item) : res.item;
+        expect(item).toEqual({ ok: true });
+        expect(res.meta?.etag).toBeTruthy();
+        expect(res.meta?.mtime).toBeTruthy();
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
+  it(
+    "embed:'inline' preserves binary bytes",
+    { timeout: 60_000 },
+    async () => {
+      const { outDir } = await buildWithAssets(
+        "out-inline-bin",
+        [{ baseName: "i18n", dir: join(MIX, "txt"), embed: "inline" }],
+        [{ route: "/read", handler: handlerPath }]
+      );
+      const { listener } = await import(join(outDir, "server/index.mjs"));
+      const server = await listen(listener, { port: 0 });
+      try {
+        const res = await fetch(
+          `${server.url}read?id=${encodeURIComponent("pixel.bin")}`
+        ).then((r) => r.json());
+        expect(res.has).toBe(true);
+        const expected = readFileSync(join(MIX, "txt", "pixel.bin"));
+        expect(Array.isArray(res.item)).toBe(true);
+        expect(Buffer.from(res.item)).toEqual(expected);
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
+  it(
+    "embed:'inline' respects ignore patterns",
+    { timeout: 60_000 },
+    async () => {
+      const { outDir } = await buildWithAssets(
+        "out-inline-ignore",
+        [
+          {
+            baseName: "i18n",
+            dir: join(MIX, "txt"),
+            embed: "inline",
+            ignore: ["**/skip.me"],
+          },
+        ],
+        [{ route: "/read", handler: handlerPath }]
+      );
+      const { listener } = await import(join(outDir, "server/index.mjs"));
+      const server = await listen(listener, { port: 0 });
+      try {
+        const res = await fetch(
+          `${server.url}read?id=${encodeURIComponent("skip.me")}`
+        ).then((r) => r.json());
+        expect(res.has).toBe(false);
+        expect(res.keys).not.toContain("skip.me");
+        expect(res.keys.some((k: string) => k.includes("hello.json"))).toBe(
+          true
+        );
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
+  it(
+    "default raw: path still serves getItem at runtime",
+    { timeout: 60_000 },
+    async () => {
+      const { outDir } = await buildWithAssets(
+        "out-raw-runtime",
+        [{ baseName: "i18n", dir: join(MIX, "txt") }],
+        [{ route: "/read", handler: handlerPath }]
+      );
+      expect(countRawMjs(outDir)).toBe(3);
+      const { listener } = await import(join(outDir, "server/index.mjs"));
+      const server = await listen(listener, { port: 0 });
+      try {
+        const res = await fetch(
+          `${server.url}read?id=${encodeURIComponent("hello.json")}`
+        ).then((r) => r.json());
+        expect(res.has).toBe(true);
+        const item =
+          typeof res.item === "string" ? JSON.parse(res.item) : res.item;
+        expect(item).toEqual({ ok: true });
+        expect(res.meta?.type).toMatch(/json/);
+        expect(res.meta?.etag).toBeTruthy();
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
+  it(
+    "embed:'inline' respects pattern",
+    { timeout: 60_000 },
+    async () => {
+      const { outDir } = await buildWithAssets(
+        "out-inline-pattern",
+        [
+          {
+            baseName: "i18n",
+            dir: join(MIX, "txt"),
+            embed: "inline",
+            pattern: "**/*.json",
+          },
+        ],
+        [{ route: "/read", handler: handlerPath }]
+      );
+      const { listener } = await import(join(outDir, "server/index.mjs"));
+      const server = await listen(listener, { port: 0 });
+      try {
+        const hello = await fetch(
+          `${server.url}read?id=${encodeURIComponent("hello.json")}`
+        ).then((r) => r.json());
+        const bin = await fetch(
+          `${server.url}read?id=${encodeURIComponent("pixel.bin")}`
+        ).then((r) => r.json());
+        expect(hello.has).toBe(true);
+        expect(bin.has).toBe(false);
+        expect(hello.keys.every((k: string) => k.endsWith(".json"))).toBe(true);
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
+  it(
+    "mixed dirs: embed:false + default raw do not interfere",
+    { timeout: 120_000 },
+    async () => {
+      const small = join(ROOT, "small-raw");
+      mkdirSync(small, { recursive: true });
+      writeFileSync(join(small, "a.json"), JSON.stringify({ a: 1 }));
+
+      const { outDir } = await buildWithAssets("out-mixed", [
+        { baseName: "disk", dir: DATA, embed: false },
+        { baseName: "bundled", dir: small },
+      ]);
+      expect(existsSync(join(outDir, "server/assets/disk"))).toBe(true);
+      expect(countRawMjs(outDir)).toBe(1);
     }
   );
 });
+

--- a/test/unit/server-assets-perf.test.ts
+++ b/test/unit/server-assets-perf.test.ts
@@ -170,8 +170,11 @@ describe("serverAssets large catalogs", () => {
         const url = `${server.url}read?id=${encodeURIComponent("l0/l0/l0/l0/data.json")}`;
         const res = await fetch(url).then((r) => r.json());
         expect(res.has).toBe(true);
-        expect(res.item).toMatchObject({ v: 1 });
+        const item =
+          typeof res.item === "string" ? JSON.parse(res.item) : res.item;
+        expect(item).toMatchObject({ v: 1 });
         expect(res.meta?.type).toMatch(/json/);
+        expect(res.meta?.etag).toBeTruthy();
         expect(res.keys.length).toBeGreaterThanOrEqual(fileCount);
       } finally {
         await server.close();

--- a/test/unit/server-assets-perf.test.ts
+++ b/test/unit/server-assets-perf.test.ts
@@ -1,0 +1,138 @@
+import { mkdirSync, rmSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "pathe";
+import { describe, expect, it } from "vitest";
+import { createNitro, build, prepare, copyPublicAssets } from "nitropack/core";
+
+const ROOT = join(import.meta.dirname, ".tmp-server-assets-perf");
+const DATA = join(ROOT, "i18n-data");
+
+function genTree(dir: string, depth: number, branch: number): number {
+  mkdirSync(dir, { recursive: true });
+  if (depth === 0) {
+    writeFileSync(
+      join(dir, "data.json"),
+      JSON.stringify({ v: 1, s: "x".repeat(200) })
+    );
+    return 1;
+  }
+  let n = 0;
+  for (let i = 0; i < branch; i++) {
+    n += genTree(join(dir, `l${i}`), depth - 1, branch);
+  }
+  return n;
+}
+
+function countRawMjs(outDir: string): number {
+  const rawDir = join(outDir, "server/chunks/raw");
+  if (!existsSync(rawDir)) return 0;
+  let n = 0;
+  const walk = (d: string) => {
+    for (const e of readdirSync(d, { withFileTypes: true })) {
+      if (e.isDirectory()) walk(join(d, e.name));
+      else if (e.name.endsWith(".mjs")) n++;
+    }
+  };
+  walk(rawDir);
+  return n;
+}
+
+describe("serverAssets large catalogs", () => {
+  // depth=4, branch=5 → 625 JSON files
+  const fileCount = (() => {
+    rmSync(ROOT, { recursive: true, force: true });
+    return genTree(DATA, 4, 5);
+  })();
+
+  it("generates hundreds of fixture files", () => {
+    expect(fileCount).toBe(625);
+  });
+
+  it(
+    "auto-inlines many small JSON files (no raw: chunk explosion)",
+    { timeout: 120_000 },
+    async () => {
+      const outDir = join(ROOT, "out-auto-inline");
+      rmSync(outDir, { recursive: true, force: true });
+
+      const t0 = performance.now();
+      const nitro = await createNitro({
+        rootDir: ROOT,
+        srcDir: ROOT,
+        output: { dir: outDir },
+        preset: "node-server",
+        minify: false,
+        typescript: { generateTsConfig: false },
+        logging: { compressedSizes: false },
+        serverAssets: [{ baseName: "i18n", dir: DATA }],
+      });
+      await prepare(nitro);
+      await copyPublicAssets(nitro);
+      await build(nitro);
+      const ms = performance.now() - t0;
+
+      // Default embed:true with ≥50 text files → inline → no per-file raw chunks
+      expect(countRawMjs(outDir)).toBe(0);
+      // Should stay in the same ballpark as nitropack 2.12 on this fixture (was multi‑10s with raw:)
+      expect(ms).toBeLessThan(15_000);
+    }
+  );
+
+  it(
+    "embed:false copies assets and skips raw: chunks",
+    { timeout: 120_000 },
+    async () => {
+      const outDir = join(ROOT, "out-fs");
+      rmSync(outDir, { recursive: true, force: true });
+
+      const nitro = await createNitro({
+        rootDir: ROOT,
+        srcDir: ROOT,
+        output: { dir: outDir },
+        preset: "node-server",
+        minify: false,
+        typescript: { generateTsConfig: false },
+        logging: { compressedSizes: false },
+        serverAssets: [{ baseName: "i18n", dir: DATA, embed: false }],
+      });
+      await prepare(nitro);
+      await copyPublicAssets(nitro);
+      await build(nitro);
+
+      expect(countRawMjs(outDir)).toBe(0);
+      expect(existsSync(join(outDir, "server/assets/i18n"))).toBe(true);
+      expect(existsSync(join(outDir, "server/index.mjs"))).toBe(true);
+      // Spot-check a copied leaf
+      expect(
+        existsSync(join(outDir, "server/assets/i18n/l0/l0/l0/l0/data.json"))
+      ).toBe(true);
+    }
+  );
+
+  it(
+    "embed:'inline' keeps a single virtual module",
+    { timeout: 120_000 },
+    async () => {
+      const outDir = join(ROOT, "out-inline");
+      rmSync(outDir, { recursive: true, force: true });
+
+      const t0 = performance.now();
+      const nitro = await createNitro({
+        rootDir: ROOT,
+        srcDir: ROOT,
+        output: { dir: outDir },
+        preset: "node-server",
+        minify: false,
+        typescript: { generateTsConfig: false },
+        logging: { compressedSizes: false },
+        serverAssets: [{ baseName: "i18n", dir: DATA, embed: "inline" }],
+      });
+      await prepare(nitro);
+      await copyPublicAssets(nitro);
+      await build(nitro);
+      const ms = performance.now() - t0;
+
+      expect(countRawMjs(outDir)).toBe(0);
+      expect(ms).toBeLessThan(15_000);
+    }
+  );
+});


### PR DESCRIPTION
### 🔗 Linked issue

#1833

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Large `serverAssets` catalogs (thousands of small JSON files) make Nitro builds slow / OOM because production mode creates **one Rollup `raw:` module per file** (#1833). Nuxt 4.x apps that ship translation trees hit this hard.

This PR adds an **opt-in** `embed` flag on `ServerAssetDir`. **Default stays `true`** (same historical `raw:` behavior — no silent auto-inline).

| `embed` | Build behavior |
| --- | --- |
| `true` / omitted | One lazy `raw:` chunk per file (**unchanged**) |
| `"inline"` | Single virtual module (like public-assets inline) |
| `false` | Copy to `server/assets/<baseName>`; meta+path at build; `readFile` at runtime (like public-assets node) |

Also skips per-file gzip in the server size tree for `chunks/raw/**` (logging only).

#### Example

```ts
export default defineNitroConfig({
  serverAssets: [{
    baseName: 'i18n',
    dir: './i18n-data',
    embed: 'inline', // or false for Node disk reads
  }],
})
```

#### Real-world use

[nuxt-i18n-micro](https://github.com/s00d/nuxt-i18n-micro) can register locale JSON trees as `serverAssets` and set `embed: 'inline'` or `embed: false` so Node SSR builds stay fast without dual-writing payloads to `public/`.

#### Benchmark (same fixture: **1296 JSON**, `compressedSizes: true`)

| Era | nitropack | strategy | ms (run 1 / 2) | `chunks/raw` |
| --- | --- | --- | ---: | ---: |
| Nuxt 4.1.2 | 2.12.5 | N× `raw:` | 3228 / 3986 | 1296 |
| Nuxt 4.2 | 2.12.9 | N× `raw:` | 3286 | 1296 |
| Nuxt 4.4+ | 2.13.4 | N× `raw:` | 4605 / 3124 | 1296 |
| this PR | 2.13.4+fix | `embed: "inline"` | **1608** | **0** |
| this PR | 2.13.4+fix | `embed: false` | 3288 | 0 |

Notes:
- Published 2.12.x → 2.13.x already used N× `raw:` per file; cost is the same strategy, wall time varies with machine/noise.
- Default with this PR remains N× `raw:` (same as 2.12.5 / 2.13.4). Speedup requires explicit `embed`.
- Extra check on **625 JSON**, minify off, `compressedSizes: false`: default ~2270 ms / 625 raw; `inline` ~610 ms / 0; `false` ~1130 ms / 0.

#### Tests

- `test/unit/server-assets-perf.test.ts` — default unchanged, inline/false runtime, binary, ignore, pattern, mixed dirs
- Also green: `test/unit/` + `test/presets/node.test.ts` (**99** passed, no regressions)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.