### PR TITLE
fix(rollup): escape dynamic route segments in chunk names

### DIFF
--- a/src/build/chunks.ts
+++ b/src/build/chunks.ts
@@ -78,7 +78,7 @@ export function getChunkName(chunk: { name: string; moduleIds: string[] }, nitro
       .flatMap((h) => h.data)
       .find((h) => h.handler === mainId);
     if (routeHandler?.route) {
-      return `_routes/${routeToFsPath(routeHandler.route)}.mjs`;
+      return `_routes/${routeToFsPath(routeHandler.route).replace(/\[/g, "%5B").replace(/\]/g, "%5D")}.mjs`;
     }
 
     const taskHandler = Object.entries(nitro.options.tasks).find(

--- a/src/build/chunks.ts
+++ b/src/build/chunks.ts
@@ -78,7 +78,12 @@ export function getChunkName(chunk: { name: string; moduleIds: string[] }, nitro
       .flatMap((h) => h.data)
       .find((h) => h.handler === mainId);
     if (routeHandler?.route) {
-      return `_routes/${routeToFsPath(routeHandler.route).replace(/\[/g, "%5B").replace(/\]/g, "%5D")}.mjs`;
+      let routePath = routeToFsPath(routeHandler.route);
+      if (nitro.options.builder === "rollup") {
+        // rollup treats [name] in chunkFileNames as an invalid placeholder
+        routePath = routePath.replace(/\[/g, "%5B").replace(/\]/g, "%5D");
+      }
+      return `_routes/${routePath}.mjs`;
     }
 
     const taskHandler = Object.entries(nitro.options.tasks).find(

--- a/test/unit/chunks.test.ts
+++ b/test/unit/chunks.test.ts
@@ -149,8 +149,12 @@ describe("getChunkName", () => {
     );
   });
 
-  it("returns _routes/<path>.mjs for dynamic route", () => {
+  it.each([
+    ["rolldown", "_routes/api/users/[id].mjs"],
+    ["rollup", "_routes/api/users/%5Bid%5D.mjs"],
+  ])("returns _routes/<path>.mjs for dynamic route (%s)", (builder, expected) => {
     const n = createNitro({
+      options: { builder },
       routing: {
         routes: {
           routes: [
@@ -161,13 +165,15 @@ describe("getChunkName", () => {
         },
       },
     } as any);
-    expect(getChunkName(createChunk("route", ["/src/routes/api/users/[id].ts"]), n)).toBe(
-      "_routes/api/users/%5Bid%5D.mjs"
-    );
+    expect(getChunkName(createChunk("route", ["/src/routes/api/users/[id].ts"]), n)).toBe(expected);
   });
 
-  it("returns _routes/<path>.mjs for nested dynamic route", () => {
+  it.each([
+    ["rolldown", "_routes/api/applications/[id]/context.mjs"],
+    ["rollup", "_routes/api/applications/%5Bid%5D/context.mjs"],
+  ])("returns _routes/<path>.mjs for nested dynamic route (%s)", (builder, expected) => {
     const n = createNitro({
+      options: { builder },
       routing: {
         routes: {
           routes: [
@@ -185,7 +191,7 @@ describe("getChunkName", () => {
     } as any);
     expect(
       getChunkName(createChunk("route", ["/src/routes/api/applications/[id]/context.ts"]), n)
-    ).toBe("_routes/api/applications/%5Bid%5D/context.mjs");
+    ).toBe(expected);
   });
 
   it("returns _routes/index.mjs for root route", () => {

--- a/test/unit/chunks.test.ts
+++ b/test/unit/chunks.test.ts
@@ -162,8 +162,30 @@ describe("getChunkName", () => {
       },
     } as any);
     expect(getChunkName(createChunk("route", ["/src/routes/api/users/[id].ts"]), n)).toBe(
-      "_routes/api/users/[id].mjs"
+      "_routes/api/users/%5Bid%5D.mjs"
     );
+  });
+
+  it("returns _routes/<path>.mjs for nested dynamic route", () => {
+    const n = createNitro({
+      routing: {
+        routes: {
+          routes: [
+            {
+              data: [
+                {
+                  route: "/api/applications/:id/context",
+                  handler: "/src/routes/api/applications/[id]/context.ts",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    } as any);
+    expect(
+      getChunkName(createChunk("route", ["/src/routes/api/applications/[id]/context.ts"]), n)
+    ).toBe("_routes/api/applications/%5Bid%5D/context.mjs");
   });
 
   it("returns _routes/index.mjs for root route", () => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getChunkName` returns `_routes/<path>.mjs` for route handlers, and `routeToFsPath` converts dynamic segments like `:id` to `[id]`. Rollup rejects `[id]` as an invalid `chunkFileNames` placeholder, so building with the Rollup builder fails on nested dynamic routes like `server/api/applications/[id]/context.get.ts`.

It looks like Rolldown (the default builder) tolerates the brackets, which is why this slipped through.

This PR encodes brackets (`[` and `]`) as `%5B`/`%5D` in the chunk name so it's a valid `chunkFileNames` pattern.
This also avoids any collision with literal route segments named `_id_` (the concern that closed the similar PR I found #4393).
Also updated the unit test and added a nested dynamic route case.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
