### PR TITLE
fix(rollup): keep import attributes in the build output

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -137,6 +137,8 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       },
       inlineDynamicImports: nitro.options.inlineDynamicImports,
       format: "esm",
+      // `assert` was removed in Node.js v22; Rollup 5 defaults to `with` (rollup/rollup#6248).
+      importAttributesKey: "with",
       exports: "auto",
       intro: "",
       outro: "",
@@ -294,6 +296,11 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       target: "es2019",
       sourceMap: nitro.options.sourceMap,
       ...nitro.options.esbuild?.options,
+      supported: {
+        // esbuild drops import attributes for every `esXXXX` target.
+        "import-attributes": true,
+        ...nitro.options.esbuild?.options?.supported,
+      },
     })
   );
 

--- a/test/unit/import-attributes.test.ts
+++ b/test/unit/import-attributes.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Plugin } from "rollup";
+import type { NitroConfig } from "nitropack/types";
+import { createNitro } from "../../src/core/nitro";
+import { getRollupConfig } from "../../src/rollup/config";
+
+const SOURCE = `export const load = () => import("pkg/data.json", { with: { type: "json" } });\n`;
+
+const rollupConfig = async (config?: NitroConfig) => {
+  const rootDir = mkdtempSync(join(tmpdir(), "nitro-import-attributes-"));
+  const nitro = await createNitro({
+    rootDir,
+    compatibilityDate: "latest",
+    ...config,
+  });
+  return getRollupConfig(nitro);
+};
+
+// Rollup 4 defaults to `assert`, which Node.js removed in v22.
+describe("import attributes", () => {
+  it("emits external imports with the `with` key", async () => {
+    const { output } = await rollupConfig();
+    expect(
+      (output as { importAttributesKey?: string }).importAttributesKey
+    ).toBe("with");
+  });
+
+  it("keeps an explicit key from user config", async () => {
+    const { output } = await rollupConfig({
+      rollupConfig: { output: { importAttributesKey: "assert" } },
+    });
+    expect(
+      (output as { importAttributesKey?: string }).importAttributesKey
+    ).toBe("assert");
+  });
+
+  it("survives the esbuild transform of a .ts source", async () => {
+    const { plugins } = await rollupConfig();
+    const esbuildPlugin = (plugins as Plugin[]).find(
+      (plugin) => plugin?.name === "esbuild"
+    );
+    const transform = esbuildPlugin?.transform as unknown as (
+      this: { warn: () => void },
+      code: string,
+      id: string
+    ) => Promise<{ code: string } | undefined>;
+    const transformed = await transform.call(
+      { warn: () => {} },
+      SOURCE,
+      "/src/entry.ts"
+    );
+    expect(transformed?.code).toContain(`with: { type: "json" }`);
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

#4518

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Two defaults in `getRollupConfig`, both still overridable by user config:

- `output.importAttributesKey: "with"`. Rollup 4 re-prints the import attributes of external
  modules with its default key, `assert`, which Node.js removed in 22.0.0 (nodejs/node#52104).
  Rollup flips this itself in v5 (rollup/rollup#6248, merged to `rollup-5`) and documents the option
  as the workaround until then. It goes in the `defu` defaults, so `rollupConfig.output` still wins.
  Nothing on the supported matrix loses: the runtimes that take `assert` but reject `with` are all
  below `engines.node`.
- `supported: { "import-attributes": true }` on the esbuild plugin. esbuild silently drops import
  attributes for every `esXXXX` target (checked up to `es2025`) and the target here is `es2019`, so
  attributes written in `.ts`/`.js` never reach Rollup at all. Merged with the user's own
  `esbuild.options.supported` rather than spread past it, so setting an unrelated feature flag
  doesn't quietly drop this one.

Without these, a module that marks a JSON import external produces code no supported runtime can
load, while the build stays green: pages render and only the affected route answers 500.
`@nuxt/icon`'s `serverBundle.externalizeIconsJson` is the case I hit — it generates a correct
`with { type: "json" }` import and has no way to know it will be rewritten.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. — neither the `es2019` target nor
      `importAttributesKey` is documented today; this changes no documented behaviour.

### Verification

`test/unit/import-attributes.test.ts` covers three things, each checked by breaking the
corresponding line one at a time: the emitted attribute key, an explicit `rollupConfig.output`
setting surviving the merge, and a `.ts` source keeping its attributes through the esbuild
transform. `pnpm vitest run test/unit`, `tsc --noEmit`, eslint and `prettier -c` are green.

A `test/fixture/` regression route wouldn't be portable — the case needs an *external* JSON import,
which the worker and edge presets can't load at all — so the regression is pinned at the config
level instead. Happy to move it if you'd rather have it elsewhere.

End-to-end, including the runtime 500 before and 200 after:
https://github.com/agantelin/nitro-import-attributes-repro (cases 2 and 3)
