### PR TITLE
fix(bun): call `close` hooks on server shutdown

### DIFF
--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -3,7 +3,7 @@ import type { ServerRequest } from "srvx";
 import { serve } from "srvx/bun";
 import wsAdapter from "crossws/adapters/bun";
 
-import { useNitroApp } from "nitro/app";
+import { useNitroApp, useNitroHooks } from "nitro/app";
 import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
@@ -40,6 +40,22 @@ const server = serve({
   },
   plugins: [...tracingSrvxPlugins],
 });
+
+// Run `close` hooks on server shutdown (srvx closes the server on `SIGINT`/`SIGTERM`)
+const closeServer = server.close.bind(server);
+let closeHooksCalled = false;
+server.close = async (closeActiveConnections?: boolean) => {
+  try {
+    await closeServer(closeActiveConnections);
+  } finally {
+    if (!closeHooksCalled) {
+      closeHooksCalled = true;
+      await useNitroHooks()
+        .callHook("close")
+        ?.catch((error) => console.error("[close]", error));
+    }
+  }
+};
 
 trapUnhandledErrors();
 

--- a/test/fixture/server/plugins/close.ts
+++ b/test/fixture/server/plugins/close.ts
@@ -1,0 +1,9 @@
+import { definePlugin } from "nitro";
+
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks.hook("close", () => {
+    if (globalThis.process?.env?.NITRO_TEST_CLOSE_HOOK) {
+      console.log("[fixture] close hook called");
+    }
+  });
+});

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -1,7 +1,8 @@
 import { execa, execaSync } from "execa";
+import { isWindows } from "std-env";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { resolve } from "pathe";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
 
 const hasBun = execaSync("bun", ["--version"], { stdio: "ignore", reject: false }).exitCode === 0;
@@ -27,4 +28,52 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       return res;
     };
   });
+  it.skipIf(isWindows)(
+    "calls the `close` hook on shutdown",
+    async () => {
+      const port = await getRandomPort();
+      const entryPath = resolve(ctx.outDir, "server/index.mjs");
+      // srvx graceful shutdown is disabled when the CI/TEST env vars are set,
+      // so drop them for this child to exercise the real SIGTERM path.
+      const env: Record<string, string | undefined> = {
+        ...process.env,
+        PORT: String(port),
+        NITRO_HOST: "127.0.0.1",
+        NITRO_TEST_CLOSE_HOOK: "true",
+      };
+      delete env.CI;
+      delete env.TEST;
+      const child = execa("bun", [entryPath], {
+        env,
+        extendEnv: false,
+        reject: false,
+      });
+
+      let output = "";
+      child.stdout!.on("data", (data) => (output += data));
+      child.stderr!.on("data", (data) => (output += data));
+
+      await waitForPort(port, { delay: 1000, retries: 20, host: "127.0.0.1" });
+
+      child.kill("SIGTERM");
+      await new Promise<void>((r) => {
+        const timeout = setTimeout(r, 10_000);
+        child.on("close", () => {
+          clearTimeout(timeout);
+          r();
+        });
+        child.stdout!.on("data", (data) => {
+          if (String(data).includes("[fixture] close hook called")) {
+            clearTimeout(timeout);
+            r();
+          }
+        });
+      });
+      child.kill("SIGKILL");
+
+      expect(output).toContain("[fixture] close hook called");
+      expect(output).not.toContain("unhandledRejection");
+    },
+    40_000
+  );
 });


### PR DESCRIPTION
Resolves #4479.

## The problem

The `bun` preset delegates shutdown to srvx (`gracefulShutdown`, default on), which closes the server on `SIGINT`/`SIGTERM` but has no callback into Nitro's runtime `close` hook. So a plugin that registers `nitroApp.hooks.hook("close", ...)` for resource cleanup is silently skipped when a production Bun server shuts down — the server prints "closed successfully" and the hook never runs.

This is the same root cause as #4502 (the `node_server` preset), fixed for node in #4522: Nitro v2 ran the hook after connections drained via `setupGracefulShutdown`; v3 hands shutdown to srvx, which closes the server without touching Nitro hooks.

## The change

Wrap `server.close()` so it runs the `close` hooks after the underlying close, using the exact pattern from #4522 (`useNitroHooks().callHook("close")`, guarded so it fires once, errors logged not thrown). srvx calls this `close()` on its signal handlers, so the hook now runs on `SIGINT`/`SIGTERM`.

## Scope

- This PR covers the **`bun`** preset (issue #4479); #4522 covers `node_server` / `node_cluster`.
- **`deno_server` has the identical gap** and is not covered here — happy to add it to this PR, or it can follow separately.
- `test/fixture/server/plugins/close.ts` is the same fixture #4522 adds; if these land in either order the identical file merges cleanly. If you'd prefer, I can rebase to depend on #4522 instead of including it.

## Tests

Added a `close`-hook test to `test/presets/bun.test.ts` (gated on `runIf(hasBun)`, skipped on Windows like the other preset shutdown tests): it builds the fixture, starts `.output/server/index.mjs` under Bun, sends `SIGTERM`, and asserts the fixture's `close`-hook marker is printed and no `unhandledRejection` occurs. It mirrors the node test in #4522.
