### PR TITLE
fix(presets): keep `srvx/body-limit` out of the bare `srvx` alias in standard

### DIFF
--- a/src/presets/standard/preset.ts
+++ b/src/presets/standard/preset.ts
@@ -17,6 +17,7 @@ const standard = defineNitroPreset(
       "srvx/node": "srvx/node",
       "srvx/generic": "srvx/generic",
       "srvx/tracing": "srvx/tracing",
+      "srvx/body-limit": "srvx/body-limit",
     },
   },
   {


### PR DESCRIPTION
### 🔗 Linked issue

Not a separate issue. This is what #4521 is failing on.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

The `standard` preset aliases bare `srvx` to `srvx/generic`. That alias prefix-matches, so any subpath resolves against the generic adapter's file instead of the package. The `srvx/node`, `srvx/generic` and `srvx/tracing` entries sitting next to it are there to work around exactly that.

srvx 0.12 adds a `./body-limit` export and h3 imports it, so on any branch that bumps srvx the build dies:

```
[UNLOADABLE_DEPENDENCY] Could not load .../srvx@0.12.5/node_modules/srvx/dist/adapters/generic.mjs/body-limit
  from:  import { limitRequestBody } from "srvx/body-limit";
```

Adding the entry fixes it. On #4521's dependency set that takes the suite from 116 failures to 100; the remaining 100 are unrelated to this (mostly basic-auth assertions that need updating for h3 now sending `charset="UTF-8"`, plus the bundle size budgets).

On main this changes nothing, since srvx 0.11 has no `body-limit` export and nothing imports it. Full suite on main with the patch is unchanged at 903 passing, with the one pre-existing `bump-version` date failure.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
