### PR TITLE
feat: import optional deps on demand from the user project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,22 @@ Review these changes carefully for backwards compatibility, bundle size, and cro
 - `consola` — Logging in build/dev code (use `nitro.logger` when available).
 - `unstorage` — Storage abstraction.
 
+### Optional Dependencies
+
+Packages that are only needed by some presets, builders, or opt-in features are imported on demand
+from the user project via `src/utils/dep.ts` (`ensureDep` / `importDep` / `isDepInstalled`), which
+resolves from `nitro.options.rootDir` and offers to install what is missing.
+
+- Don't add a `peerDependencies` entry. Add the package to `devDependencies` (for tests and types)
+  and import it with `importDep({ id, dir: nitro.options.rootDir, reason })`.
+- Keep the package listed in `optionalDeps` in `build.config.ts` so it stays external.
+- `import type` from such a package is fine; only value imports must go through `utils/dep.ts`.
+- Optional dependencies of the libraries Nitro *bundles* (e.g. `jiti` for `c12`) cannot resolve from
+  `dist/`. Those get a bundle-time alias to a shim in `src/shims/` (see `shimmedDeps` in
+  `build.config.ts`).
+- `vite` is the only remaining optional peer dependency: `src/build/vite/` extends its
+  `DevEnvironment` class and re-exports its types from Nitro's public `.d.ts`.
+
 ### Runtime Constraints
 
 Code in `src/runtime/` must be runtime-agnostic:
@@ -121,6 +137,7 @@ Each preset in `src/presets/` defines deployment target behavior:
 - **CLI commands** are in `src/cli/commands/` — Each file exports a command definition.
 - **Runtime size matters** — Check bundle impact with `pnpm build`.
 - **Use `pathe` not `node:path`** — Ensures cross-platform compatibility.
+- **Avoid peer dependencies** — Optional packages are imported on demand via `src/utils/dep.ts` (`vite` is the only exception).
 
 ## Error & Logging Guidelines
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -3,9 +3,24 @@ import { defineBuildConfig } from "obuild/config";
 import { resolveModulePath } from "exsolve";
 import { traceNodeModules } from "nf3";
 import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import type { CodeSplittingOptions } from "rolldown";
 
 const isStub = process.argv.includes("--stub");
+
+// Optional dependencies imported on demand from the user project (see `src/utils/dep.ts`)
+const optionalDeps = [
+  "@vercel/queue",
+  "dotenv",
+  "giget",
+  "jiti",
+  "rollup",
+  "xml2js",
+  "zephyr-agent",
+];
+
+// Optional dependencies of bundled libraries, replaced by an on demand import (see `src/shims/`)
+const shimmedDeps = ["dotenv", "giget", "jiti"];
 
 const pkg = await import("./package.json", { with: { type: "json" } }).then((r) => r.default || r);
 
@@ -50,10 +65,19 @@ export default defineBuildConfig({
 
       config.resolve ??= {};
       config.resolve.alias ??= {};
-      Object.assign(config.resolve.alias, {
-        "node-fetch-native/proxy": "node-fetch-native/native",
-        "node-fetch-native": "node-fetch-native/native",
-      });
+      Object.assign(
+        config.resolve.alias,
+        {
+          "node-fetch-native/proxy": "node-fetch-native/native",
+          "node-fetch-native": "node-fetch-native/native",
+        },
+        Object.fromEntries(
+          shimmedDeps.map((dep) => [
+            dep,
+            fileURLToPath(new URL(`src/shims/${dep}.ts`, import.meta.url)),
+          ])
+        )
+      );
 
       config.external ??= [];
       (config.external as string[]).push(
@@ -61,6 +85,7 @@ export default defineBuildConfig({
         ...Object.keys(pkg.exports || {}).map((key) => key.replace(/^./, "nitro")),
         ...Object.keys(pkg.dependencies),
         ...Object.keys(pkg.peerDependencies),
+        ...optionalDeps.filter((dep) => !shimmedDeps.includes(dep)),
         ...tracePkgs,
         "typescript",
         "firebase-functions",
@@ -162,6 +187,7 @@ export default defineBuildConfig({
               const deps = new Set([
                 ...Object.keys(pkg.dependencies),
                 ...Object.keys(pkg.peerDependencies),
+                ...optionalDeps,
               ]);
               for (const dep of deps) {
                 delete packages[dep];

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "defu": "^6.1.7",
     "destr": "^2.0.5",
     "dot-prop": "^10.2.0",
+    "dotenv": "^17.4.2",
     "etag": "^1.8.1",
     "execa": "^10.0.1",
     "exsolve": "^1.1.1",
@@ -131,6 +132,7 @@
     "giget": "^3.3.1",
     "gzip-size": "^7.0.0",
     "httpxy": "^0.5.5",
+    "jiti": "^2.7.0",
     "klona": "^2.0.6",
     "knitwork": "^1.3.0",
     "mdzilla": "^0.2.1",
@@ -170,38 +172,10 @@
     "zephyr-agent": "^1.2.2"
   },
   "peerDependencies": {
-    "@vercel/queue": "^0.4.0",
-    "dotenv": "*",
-    "giget": "*",
-    "jiti": "^2.7.0",
-    "rollup": "^4.62.2",
-    "vite": "^7 || ^8",
-    "xml2js": "^0.6.2",
-    "zephyr-agent": "^1.1.2"
+    "vite": "^7 || ^8"
   },
   "peerDependenciesMeta": {
-    "@vercel/queue": {
-      "optional": true
-    },
-    "dotenv": {
-      "optional": true
-    },
-    "rollup": {
-      "optional": true
-    },
     "vite": {
-      "optional": true
-    },
-    "xml2js": {
-      "optional": true
-    },
-    "giget": {
-      "optional": true
-    },
-    "jiti": {
-      "optional": true
-    },
-    "zephyr-agent": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       db0:
         specifier: ^0.3.4
         version: 0.3.4
-      dotenv:
-        specifier: '*'
-        version: 17.4.2
       env-runner:
         specifier: ^0.2.0
         version: 0.2.0
@@ -38,9 +35,6 @@ importers:
       hookable:
         specifier: ^6.1.1
         version: 6.1.1
-      jiti:
-        specifier: ^2.7.0
-        version: 2.7.0
       nf3:
         specifier: ^0.3.23
         version: 0.3.23
@@ -180,6 +174,9 @@ importers:
       dot-prop:
         specifier: ^10.2.0
         version: 10.2.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       etag:
         specifier: ^1.8.1
         version: 1.8.1
@@ -204,6 +201,9 @@ importers:
       httpxy:
         specifier: ^0.5.5
         version: 0.5.5
+      jiti:
+        specifier: ^2.7.0
+        version: 2.7.0
       klona:
         specifier: ^2.0.6
         version: 2.0.6

--- a/src/build/rollup/_import.ts
+++ b/src/build/rollup/_import.ts
@@ -1,0 +1,17 @@
+import type { Nitro } from "nitro/types";
+import { importDep } from "../../utils/dep.ts";
+
+/**
+ * Import `rollup` from the user project.
+ *
+ * Nitro does not depend on `rollup` itself: the `rollup` builder is opt-in and
+ * the version installed next to the app is the version that runs.
+ */
+export function importRollup(nitro: Nitro): Promise<typeof import("rollup")> {
+  return importDep<typeof import("rollup")>({
+    id: "rollup",
+    dir: nitro.options.rootDir,
+    reason: "the `rollup` builder",
+    version: "^4",
+  });
+}

--- a/src/build/rollup/dev.ts
+++ b/src/build/rollup/dev.ts
@@ -8,9 +8,10 @@ import { scanHandlers } from "../../scan.ts";
 import { formatRollupError } from "./error.ts";
 import { writeTypes } from "../types.ts";
 import { formatCompatibilityDate } from "compatx";
+import { importRollup } from "./_import.ts";
 
 export async function watchDev(nitro: Nitro, rollupConfig: RollupConfig) {
-  const rollup = await import("rollup");
+  const rollup = await importRollup(nitro);
 
   let rollupWatcher: RollupWatcher;
 

--- a/src/build/rollup/prod.ts
+++ b/src/build/rollup/prod.ts
@@ -6,9 +6,10 @@ import { writeTypes } from "../types.ts";
 import { writeBuildInfo } from "../info.ts";
 import { formatRollupError } from "./error.ts";
 import type { RollupOutput } from "rollup";
+import { importRollup } from "./_import.ts";
 
 export async function buildProduction(nitro: Nitro, rollupConfig: RollupConfig) {
-  const rollup = await import("rollup");
+  const rollup = await importRollup(nitro);
 
   const buildStartTime = Date.now();
 

--- a/src/presets/iis/utils.ts
+++ b/src/presets/iis/utils.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { defu } from "defu";
 import { writeFile } from "../_utils/fs.ts";
+import { importDep } from "../../utils/dep.ts";
 import type { Nitro } from "nitro/types";
 import { resolve } from "pathe";
 
@@ -93,14 +94,15 @@ async function iisnodeXmlTemplate(nitro: Nitro) {
 `;
   if (existsSync(path)) {
     const fileString = await readFile(path, "utf8");
-    const originalWebConfig: Record<string, unknown> = await parseXmlDoc(originalString);
-    const fileWebConfig: Record<string, unknown> = await parseXmlDoc(fileString);
+    const rootDir = nitro.options.rootDir;
+    const originalWebConfig: Record<string, unknown> = await parseXmlDoc(originalString, rootDir);
+    const fileWebConfig: Record<string, unknown> = await parseXmlDoc(fileString, rootDir);
 
     if (nitro.options.iis?.mergeConfig && !nitro.options.iis.overrideConfig) {
-      return buildNewXmlDoc(defu(fileWebConfig, originalWebConfig));
+      return buildNewXmlDoc(defu(fileWebConfig, originalWebConfig), rootDir);
     }
     if (nitro.options.iis?.overrideConfig) {
-      return buildNewXmlDoc({ ...fileWebConfig });
+      return buildNewXmlDoc({ ...fileWebConfig }, rootDir);
     }
   }
   return originalString;
@@ -125,26 +127,35 @@ async function iisXmlTemplate(nitro: Nitro) {
 `;
   if (existsSync(path)) {
     const fileString = await readFile(path, "utf8");
-    const originalWebConfig: Record<string, unknown> = await parseXmlDoc(originalString);
-    const fileWebConfig: Record<string, unknown> = await parseXmlDoc(fileString);
+    const rootDir = nitro.options.rootDir;
+    const originalWebConfig: Record<string, unknown> = await parseXmlDoc(originalString, rootDir);
+    const fileWebConfig: Record<string, unknown> = await parseXmlDoc(fileString, rootDir);
 
     if (nitro.options.iis?.mergeConfig && !nitro.options.iis.overrideConfig) {
-      return buildNewXmlDoc(defu(fileWebConfig, originalWebConfig));
+      return buildNewXmlDoc(defu(fileWebConfig, originalWebConfig), rootDir);
     }
     if (nitro.options.iis?.overrideConfig) {
-      return buildNewXmlDoc({ ...fileWebConfig });
+      return buildNewXmlDoc({ ...fileWebConfig }, rootDir);
     }
   }
   return originalString;
 }
 
 //  XML Helpers
-async function parseXmlDoc(xml: string): Promise<Record<string, unknown>> {
-  const { Parser } = await import("xml2js");
+function importXml2js(rootDir: string) {
+  return importDep<typeof import("xml2js")>({
+    id: "xml2js",
+    dir: rootDir,
+    reason: "merging a custom `web.config` for the IIS preset",
+    version: "^0.6.2",
+  });
+}
 
+async function parseXmlDoc(xml: string, rootDir: string): Promise<Record<string, unknown>> {
   if (xml === undefined || !xml) {
     return {};
   }
+  const { Parser } = await importXml2js(rootDir);
   const parser = new Parser({ explicitArray: false });
   let parsedRecord: Record<string, unknown> = {};
   parser.parseString(xml, (_, r) => {
@@ -153,8 +164,8 @@ async function parseXmlDoc(xml: string): Promise<Record<string, unknown>> {
   return parsedRecord;
 }
 
-async function buildNewXmlDoc(xmlObj: Record<string, unknown>): Promise<string> {
-  const { Builder } = await import("xml2js");
+async function buildNewXmlDoc(xmlObj: Record<string, unknown>, rootDir: string): Promise<string> {
+  const { Builder } = await importXml2js(rootDir);
   const builder = new Builder();
   return builder.buildObject({ ...xmlObj });
 }

--- a/src/shims/README.md
+++ b/src/shims/README.md
@@ -1,0 +1,6 @@
+Bundle-time replacements for the optional dependencies of the libraries Nitro bundles (see the
+`resolve.alias` entries in `build.config.ts`).
+
+Nitro does not declare those packages as (peer) dependencies, so a bare `import("<id>")` inside a
+bundled library cannot be resolved from Nitro's own `dist/`. Each shim resolves the real package
+from the user project instead, installing it on demand.

--- a/src/shims/dotenv.ts
+++ b/src/shims/dotenv.ts
@@ -1,0 +1,9 @@
+import { importDep } from "../utils/dep.ts";
+
+const dotenv = await importDep<typeof import("dotenv")>({
+  id: "dotenv",
+  dir: process.cwd(),
+  reason: "parsing `.env` files (`node:util.parseEnv` is not available in this runtime)",
+});
+
+export const parse = dotenv.parse;

--- a/src/shims/giget.ts
+++ b/src/shims/giget.ts
@@ -1,0 +1,9 @@
+import { importDep } from "../utils/dep.ts";
+
+const giget = await importDep<typeof import("giget")>({
+  id: "giget",
+  dir: process.cwd(),
+  reason: "extending the config from a remote template",
+});
+
+export const downloadTemplate = giget.downloadTemplate;

--- a/src/shims/jiti.ts
+++ b/src/shims/jiti.ts
@@ -1,0 +1,10 @@
+import { importDep } from "../utils/dep.ts";
+
+const jiti = await importDep<typeof import("jiti")>({
+  id: "jiti",
+  dir: process.cwd(),
+  reason: "loading config files this runtime cannot import natively",
+  version: "^2.7.0",
+});
+
+export const createJiti = jiti.createJiti;


### PR DESCRIPTION
Removes all optional peer dependencies except `vite`, resolving each from the user project on demand via `src/utils/dep.ts` (`importDep` / `ensureDep`, which resolves from `nitro.options.rootDir` and offers to install what is missing).

### Direct imports → `importDep`

| dep | before | now |
|---|---|---|
| `rollup` | `await import("rollup")` ×2 | new `src/build/rollup/_import.ts` helper |
| `xml2js` | `await import("xml2js")` | resolved from `rootDir` in the IIS `web.config` merge |
| `@vercel/queue` | optional peer | already went through `importDep` — the peer entry was redundant |
| `zephyr-agent` | optional peer | already went through `importDep` |

### `dotenv` / `giget` / `jiti`

These are optional peers of **`c12`**, which Nitro bundles — so a bare `import("jiti")` inside `dist/` cannot reach the user's `node_modules` under pnpm's isolated layout. They now get a bundle-time `resolve.alias` to a shim under `src/shims/` that goes through `importDep` too:

```js
// dist/_libs/c12+rc9.mjs
const { createJiti } = await import("./jiti.ts.mjs").catch(...)
```

`dotenv` is only reachable on runtimes without `node:util.parseEnv` (below Nitro's supported Node range), and `giget` only for remote `extends:` — both keep working, they just install on demand now.

### `vite` stays an optional peer

`src/build/vite/dev.ts` extends vite's `DevEnvironment` class and `src/types/build.ts` / `src/build/vite/*` re-export vite types from Nitro's public `.d.ts`, so dropping the peer entry would break type resolution for consumers. Left as-is to keep the risk down.

### Other

- `build.config.ts`: externals no longer derive the full list from `pkg.peerDependencies` (which would have silently started bundling `rollup`); explicit `optionalDeps` list instead, minus the shimmed ones. Same for the `tracedPackages` hook.
- `dotenv` + `jiti` moved to `devDependencies` (they were peer-only) so this repo's own tests and typecheck still resolve them.
- `AGENTS.md`: documents the convention.

### Testing

`pnpm lint`, `pnpm typecheck`, `pnpm build` clean. `pnpm test:rolldown` 913 passed. `pnpm test:rollup` has 3 failures in `test/unit/import-attributes.test.ts` — pre-existing on `main` (verified by stashing), caused by `resolveBuilder` prompting for an install against a temp `rootDir` instead of using `utils/dep.ts`, which has an `isTest` guard. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)