### PR TITLE
fix(dev): resolve public assets dynamically in the worker

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -31,6 +31,7 @@ const tracePkgs = [
   "defu", // used by open-api runtime
   "destr", // used by node-server and deno-server
   "get-port-please", // used by dev server
+  "mime", // used by dev public assets runtime
   "rendu", // used by HTML renderer template
   "scule", // used by runtime config
   "source-map", // used by dev error runtime

--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -95,9 +95,6 @@ export default function publicAssets(nitro: Nitro) {
         );
 
         if (nitro.options.dev) {
-          // Assets are resolved dynamically in dev: the build-time snapshot in
-          // `public-assets-data` is always empty (nothing is copied to
-          // `output.publicDir` in dev) and would not follow file changes anyway.
           const publicAssetDirs = nitro.options.publicAssets.map((dir) => ({
             baseURL: withTrailingSlash(joinURL(nitro.options.baseURL, dir.baseURL || "/")),
             dir: dir.dir,
@@ -105,7 +102,7 @@ export default function publicAssets(nitro: Nitro) {
 
           return /* js */ `
 import { statSync, promises as fsp } from 'node:fs'
-import { resolve } from 'node:path'
+import { resolve, relative, isAbsolute, sep } from 'node:path'
 import mime from 'mime'
 
 const publicAssetDirs = ${JSON.stringify(publicAssetDirs)}
@@ -132,7 +129,8 @@ export function getAsset (id) {
   for (const { baseURL, dir } of publicAssetDirs) {
     if (!id.startsWith(baseURL)) { continue }
     const fullPath = resolve(dir, id.slice(baseURL.length))
-    if (fullPath !== dir && !fullPath.startsWith(dir + '/')) { continue }
+    const relativePath = relative(dir, fullPath)
+    if (relativePath.split(sep)[0] === '..' || isAbsolute(relativePath)) { continue }
     let stat
     try {
       stat = statSync(fullPath)

--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -94,6 +94,75 @@ export default function publicAssets(nitro: Nitro) {
             ])
         );
 
+        if (nitro.options.dev) {
+          // Assets are resolved dynamically in dev: the build-time snapshot in
+          // `public-assets-data` is always empty (nothing is copied to
+          // `output.publicDir` in dev) and would not follow file changes anyway.
+          const publicAssetDirs = nitro.options.publicAssets.map((dir) => ({
+            baseURL: withTrailingSlash(joinURL(nitro.options.baseURL, dir.baseURL || "/")),
+            dir: dir.dir,
+          }));
+
+          return /* js */ `
+import { statSync, promises as fsp } from 'node:fs'
+import { resolve } from 'node:path'
+import mime from 'mime'
+
+const publicAssetDirs = ${JSON.stringify(publicAssetDirs)}
+export const publicAssetBases = ${JSON.stringify(publicAssetBases)}
+
+export function isPublicAssetURL(id = '') {
+  if (getAsset(id)) {
+    return true
+  }
+  for (const base in publicAssetBases) {
+    if (id.startsWith(base)) { return true }
+  }
+  return false
+}
+
+export function getPublicAssetMeta(id = '') {
+  for (const base in publicAssetBases) {
+    if (id.startsWith(base)) { return publicAssetBases[base] }
+  }
+  return {}
+}
+
+export function getAsset (id) {
+  for (const { baseURL, dir } of publicAssetDirs) {
+    if (!id.startsWith(baseURL)) { continue }
+    const fullPath = resolve(dir, id.slice(baseURL.length))
+    if (fullPath !== dir && !fullPath.startsWith(dir + '/')) { continue }
+    let stat
+    try {
+      stat = statSync(fullPath)
+    } catch {
+      continue
+    }
+    if (!stat.isFile()) { continue }
+    let type = mime.getType(id.replace(/\\.(gz|br|zst)$/, '')) || 'text/plain'
+    if (type.startsWith('text')) { type += '; charset=utf-8' }
+    let encoding
+    if (id.endsWith('.gz')) { encoding = 'gzip' }
+    else if (id.endsWith('.br')) { encoding = 'br' }
+    else if (id.endsWith('.zst')) { encoding = 'zstd' }
+    return {
+      type,
+      encoding,
+      mtime: stat.mtime.toJSON(),
+      size: stat.size,
+      path: fullPath,
+    }
+  }
+}
+
+export function readAsset (id) {
+  const asset = getAsset(id)
+  return asset ? fsp.readFile(asset.path) : Promise.resolve(null)
+}
+`;
+        }
+
         // prettier-ignore
         type _serveStaticAsKey = Exclude<typeof nitro.options.serveStatic, boolean> | "true" | "false";
         // prettier-ignore

--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -153,7 +153,10 @@ export function getAsset (id) {
 
 export function readAsset (id) {
   const asset = getAsset(id)
-  return asset ? fsp.readFile(asset.path) : Promise.resolve(null)
+  if (!asset) { return Promise.resolve(null) }
+  return fsp.readFile(asset.path).catch((error) => {
+    if (error?.code !== 'ENOENT') { throw error }
+  })
 }
 `;
         }

--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -94,7 +94,9 @@ export default function publicAssets(nitro: Nitro) {
             ])
         );
 
-        if (nitro.options.dev) {
+        // The dev template resolves assets with `node:fs`, which the workerd-based
+        // `miniflare` runner cannot load.
+        if (nitro.options.dev && _devRunner(nitro) !== "miniflare") {
           const publicAssetDirs = nitro.options.publicAssets.map((dir) => ({
             baseURL: withTrailingSlash(joinURL(nitro.options.baseURL, dir.baseURL || "/")),
             dir: dir.dir,
@@ -138,15 +140,10 @@ export function getAsset (id) {
       continue
     }
     if (!stat.isFile()) { continue }
-    let type = mime.getType(id.replace(/\\.(gz|br|zst)$/, '')) || 'text/plain'
+    let type = mime.getType(id) || 'text/plain'
     if (type.startsWith('text')) { type += '; charset=utf-8' }
-    let encoding
-    if (id.endsWith('.gz')) { encoding = 'gzip' }
-    else if (id.endsWith('.br')) { encoding = 'br' }
-    else if (id.endsWith('.zst')) { encoding = 'zstd' }
     return {
       type,
-      encoding,
       mtime: stat.mtime.toJSON(),
       size: stat.size,
       path: fullPath,
@@ -245,4 +242,8 @@ export function readAsset (id) {
       },
     },
   ];
+}
+
+function _devRunner(nitro: Nitro): string {
+  return nitro.options.devServer.runner || process.env.NITRO_DEV_RUNNER || "node-worker";
 }

--- a/src/runtime/meta.ts
+++ b/src/runtime/meta.ts
@@ -20,6 +20,7 @@ export const runtimeDependencies: string[] = [
   "h3", // dep
   "rou3", // sub-dep of h3
   "hookable", // traced
+  "mime", // traced
   "ocache", // dep
   "rendu", // traced
   "scule", // traced

--- a/test/fixture/server/routes/fetch-public-asset.ts
+++ b/test/fixture/server/routes/fetch-public-asset.ts
@@ -1,0 +1,9 @@
+import { serverFetch } from "nitro";
+
+export default async () => {
+  const res = await serverFetch("/build/test.txt");
+  return {
+    status: res.status,
+    body: await res.text(),
+  };
+};

--- a/test/presets/nitro-dev.test.ts
+++ b/test/presets/nitro-dev.test.ts
@@ -2,6 +2,20 @@ import type { OpenAPI3 } from "../../src/types/openapi-ts.ts";
 import { describe, expect, it } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
 
+describe("nitro:preset:nitro-dev (serve static)", async () => {
+  const ctx = await setupTest("nitro-dev", {
+    config: { serveStatic: true },
+    outDirSuffix: "-serve-static",
+  });
+
+  it("serves public assets via internal fetch", async () => {
+    const res = await ctx.fetch("/fetch-public-asset");
+    const data = await res.json();
+    expect(data.status).toBe(200);
+    expect(data.body).toBe("Works!\n");
+  });
+});
+
 describe("nitro:preset:nitro-dev", async () => {
   const ctx = await setupTest("nitro-dev");
   testNitro(

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -323,6 +323,10 @@ describe("nitro:preset:vercel:web", async () => {
                 "src": "/file",
               },
               {
+                "dest": "/fetch-public-asset",
+                "src": "/fetch-public-asset",
+              },
+              {
                 "dest": "/fetch",
                 "src": "/fetch",
               },
@@ -590,6 +594,7 @@ describe("nitro:preset:vercel:web", async () => {
             "functions/errors/captured.func (symlink)",
             "functions/errors/stack.func (symlink)",
             "functions/errors/throw.func (symlink)",
+            "functions/fetch-public-asset.func (symlink)",
             "functions/fetch.func (symlink)",
             "functions/file.func (symlink)",
             "functions/icon.png.func (symlink)",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -129,7 +129,8 @@ export async function setupTest(
   if (ctx.isDev) {
     // Setup development server
     const devServer = createDevServer(ctx.nitro);
-    const server = await devServer.listen({});
+    // Use a random port so multiple dev contexts can coexist
+    const server = await devServer.listen({ port: 0 });
     ctx.server = {
       url: server.url!,
       close: () => server.close(),
@@ -485,6 +486,12 @@ export function testNitro(
       expect(status).toBe(200);
       expect(headers.etag).toBe('"7-vxGfAKTuGVGhpDZqQLqV60dnKPw"');
       expect(headers["content-type"]).toBe("text/plain; charset=utf-8");
+    });
+
+    it("serve static asset via internal fetch", async () => {
+      const { data } = await callHandler({ url: "/fetch-public-asset" });
+      expect(data.status).toBe(200);
+      expect(data.body).toBe("Works!\n");
     });
 
     it("stores content-type for prerendered routes", async () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -129,7 +129,6 @@ export async function setupTest(
   if (ctx.isDev) {
     // Setup development server
     const devServer = createDevServer(ctx.nitro);
-    // Use a random port so multiple dev contexts can coexist
     const server = await devServer.listen({ port: 0 });
     ctx.server = {
       url: server.url!,

--- a/test/unit/public-assets.test.ts
+++ b/test/unit/public-assets.test.ts
@@ -104,3 +104,53 @@ describe("virtual/public-assets node reader", () => {
     await expect(readAsset("/index.html")).rejects.toThrow("EACCES");
   });
 });
+
+// Return the `#nitro/virtual/public-assets` source for a dev build with the given runner.
+function devMainTemplate(runner?: string): string {
+  const nitro = {
+    options: {
+      dev: true,
+      serveStatic: true,
+      baseURL: "/",
+      publicAssets: [{ dir: PUBLIC_DIR, baseURL: "/" }],
+      devServer: runner ? { runner } : {},
+    },
+  } as unknown as Nitro;
+  const main = publicAssets(nitro).find((t) => t.id === "#nitro/virtual/public-assets")!
+    .template as () => string;
+  return main();
+}
+
+describe("virtual/public-assets dev template", () => {
+  const savedRunner = process.env.NITRO_DEV_RUNNER;
+  afterEach(() => {
+    if (savedRunner === undefined) {
+      delete process.env.NITRO_DEV_RUNNER;
+    } else {
+      process.env.NITRO_DEV_RUNNER = savedRunner;
+    }
+  });
+
+  it("resolves assets from the source dirs with node:fs on the default runner", () => {
+    delete process.env.NITRO_DEV_RUNNER;
+    const main = devMainTemplate();
+    expect(main).toContain("from 'node:fs'");
+    expect(main).not.toContain("#nitro/virtual/public-assets-data");
+  });
+
+  // The workerd-based `miniflare` runner cannot load `node:fs`, so the dev worker
+  // must keep the build-time manifest path there.
+  it("keeps the manifest path for the miniflare runner", () => {
+    delete process.env.NITRO_DEV_RUNNER;
+    const main = devMainTemplate("miniflare");
+    expect(main).not.toContain("node:fs");
+    expect(main).toContain(`from '#nitro/virtual/public-assets-data'`);
+  });
+
+  it("honours NITRO_DEV_RUNNER when devServer.runner is unset", () => {
+    process.env.NITRO_DEV_RUNNER = "miniflare";
+    const main = devMainTemplate();
+    expect(main).not.toContain("node:fs");
+    expect(main).toContain(`from '#nitro/virtual/public-assets-data'`);
+  });
+});


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue
Resolves #4500
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
In dev, fetching a public asset from inside the server (e.g. `fetch("/some-asset.txt")` in an event handler, or `serverFetch`) returns 404, while the same URL works from the browser.

**Root cause:**
the `#nitro/virtual/public-assets-data` template globs `output.publicDir` at build time, but in dev nothing is ever copied there (`copyPublicAssets` only runs for `nitro build`).
So the asset manifest baked into the dev worker bundle is always empty, and the static handler responds 404.
External requests are unaffected because the dev server process serves static dirs itself, before proxying to the worker — internal fetch never goes through that path.

**Fix:**
in dev, the `#nitro/virtual/public-assets` template no longer imports the (empty) build-time manifest.
Instead it embeds the configured `publicAssets` source directories and resolves assets per request with a `statSync` lookup, so the worker sees the same files as the dev server process — including files added or removed after startup, without a rebuild.

Notes:

- No `etag` is generated in dev, matching the dev server's own static handling (`createServeStaticDirHandler`), which relies on `mtime`/`size` only.
- `mime` is used by the generated dev runtime code, so it is added to `runtimeDependencies` and `tracePkgs` (it was already a dev dependency, used by the dev server).
- Production behavior is unchanged.

Tests:
added a fixture route that fetches a public asset internally.
It is covered by the shared `serveStatic` suite for prod presets, and by a new dev context with `serveStatic: true` (the default dev test context disables `serveStatic`, so the bug was not observable there).
Dev test contexts now listen on a random port so two contexts can coexist.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
