### PR TITLE
fix(types): resolve exported auto-import subpaths to files

### DIFF
--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -66,6 +66,7 @@ export async function writeTypes(nitro: Nitro) {
         continue;
       }
       let path = resolveAlias(from, nitro.options.alias);
+      let keepResolvedExtension = false;
       if (!isAbsolute(path)) {
         const resolvedPath = resolveModulePath(from, {
           try: true,
@@ -81,14 +82,16 @@ export async function writeTypes(nitro: Nitro) {
           } else {
             const subpath = await lookupNodeModuleSubpath(resolvedPath);
             const subpathPath = subpath && subpath !== "./" && join(dir, name, subpath);
-            path =
-              subpathPath && existsSync(subpathPath) && !(await isDirectory(subpathPath))
-                ? subpathPath
-                : resolvedPath;
+            if (subpathPath && existsSync(subpathPath) && !(await isDirectory(subpathPath))) {
+              path = subpathPath;
+            } else {
+              path = resolvedPath;
+              keepResolvedExtension = Boolean(subpathPath);
+            }
           }
         }
       }
-      if (existsSync(path) && !(await isDirectory(path))) {
+      if (!keepResolvedExtension && existsSync(path) && !(await isDirectory(path))) {
         path = path.replace(/\.[a-z]+$/, "");
       }
       if (isAbsolute(path)) {

--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -80,7 +80,11 @@ export async function writeTypes(nitro: Nitro) {
             path = resolvedPath;
           } else {
             const subpath = await lookupNodeModuleSubpath(resolvedPath);
-            path = subpath && subpath !== "./" ? join(dir, name, subpath) : resolvedPath;
+            const subpathPath = subpath && subpath !== "./" && join(dir, name, subpath);
+            path =
+              subpathPath && existsSync(subpathPath) && !(await isDirectory(subpathPath))
+                ? subpathPath
+                : resolvedPath;
           }
         }
       }

--- a/test/unit/types-imports.test.ts
+++ b/test/unit/types-imports.test.ts
@@ -85,7 +85,7 @@ describe("writeTypes auto-import resolution", () => {
       })
     );
     writeFileSync(join(pkgDir, "lib", "h3.mjs"), "export function useH3() {}\n");
-    writeFileSync(join(pkgDir, "lib", "h3.d.mts"), "export declare function useH3(): void\n");
+    writeFileSync(join(pkgDir, "lib", "h3.d.mts"), 'export declare function useH3(): "resolved"\n');
 
     const nitro = await createNitro({
       rootDir: fixtureDir,
@@ -118,6 +118,9 @@ describe("writeTypes auto-import resolution", () => {
 
     expect(match![1]).toBe("../../export-subpath-pkg/lib/h3.mjs");
 
+    const checkPath = join(fixtureDir, "check.ts");
+    writeFileSync(checkPath, 'const result: "resolved" = useH3()\n');
+
     execFileSync(
       process.execPath,
       [
@@ -127,7 +130,9 @@ describe("writeTypes auto-import resolution", () => {
         "preserve",
         "--moduleResolution",
         "bundler",
+        "--noImplicitAny",
         declarationPath,
+        checkPath,
       ],
       { cwd: fixtureDir }
     );

--- a/test/unit/types-imports.test.ts
+++ b/test/unit/types-imports.test.ts
@@ -1,8 +1,15 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "pathe";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "pathe";
 import { describe, expect, it } from "vitest";
 import { createNitro, writeTypes } from "nitro/builder";
+
+const tscPath = join(
+  dirname(fileURLToPath(import.meta.resolve("typescript/package.json"))),
+  "bin/tsc"
+);
 
 describe("writeTypes auto-import resolution", () => {
   const fixtureDir = mkdtempSync(join(tmpdir(), "nitro-types-"));
@@ -109,10 +116,20 @@ describe("writeTypes auto-import resolution", () => {
       `expected import() referencing export-subpath-pkg in:\n${generated}`
     ).toBeTruthy();
 
-    const resolvedTypePath = resolve(dirname(declarationPath), `${match![1]!}.d.mts`);
-    expect(existsSync(resolvedTypePath), `unresolvable type import: ${resolvedTypePath}`).toBe(
-      true
+    expect(match![1]).toBe("../../export-subpath-pkg/lib/h3.mjs");
+
+    execFileSync(
+      process.execPath,
+      [
+        tscPath,
+        "--noEmit",
+        "--module",
+        "preserve",
+        "--moduleResolution",
+        "bundler",
+        declarationPath,
+      ],
+      { cwd: fixtureDir }
     );
-    expect(resolvedTypePath).toBe(join(pkgDir, "lib", "h3.d.mts"));
   });
 });

--- a/test/unit/types-imports.test.ts
+++ b/test/unit/types-imports.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { dirname, join, resolve } from "pathe";
 import { describe, expect, it } from "vitest";
 import { createNitro, writeTypes } from "nitro/builder";
 
@@ -62,5 +62,57 @@ describe("writeTypes auto-import resolution", () => {
       specifier.endsWith("exports-only-pkg"),
       `specifier should not end at the package directory, got ${specifier}`
     ).toBe(false);
+  });
+
+  it("emits a resolvable path for package export subpaths", async () => {
+    const pkgDir = join(fixtureDir, "node_modules", "export-subpath-pkg");
+    mkdirSync(join(pkgDir, "lib"), { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "export-subpath-pkg",
+        type: "module",
+        exports: {
+          "./h3": "./lib/h3.mjs",
+        },
+      })
+    );
+    writeFileSync(join(pkgDir, "lib", "h3.mjs"), "export function useH3() {}\n");
+    writeFileSync(join(pkgDir, "lib", "h3.d.mts"), "export declare function useH3(): void\n");
+
+    const nitro = await createNitro({
+      rootDir: fixtureDir,
+      builder: "rolldown",
+      imports: {
+        presets: [
+          {
+            from: "export-subpath-pkg/h3",
+            imports: ["useH3"],
+          },
+        ],
+      },
+    });
+
+    await writeTypes(nitro);
+
+    const declarationPath = join(
+      fixtureDir,
+      "node_modules",
+      ".nitro",
+      "types",
+      "nitro-imports.d.ts"
+    );
+    const generated = readFileSync(declarationPath, "utf8");
+    const match = generated.match(/typeof import\('([^']*export-subpath-pkg[^']*)'\)/);
+    expect(
+      match,
+      `expected import() referencing export-subpath-pkg in:\n${generated}`
+    ).toBeTruthy();
+
+    const resolvedTypePath = resolve(dirname(declarationPath), `${match![1]!}.d.mts`);
+    expect(existsSync(resolvedTypePath), `unresolvable type import: ${resolvedTypePath}`).toBe(
+      true
+    );
+    expect(resolvedTypePath).toBe(join(pkgDir, "lib", "h3.d.mts"));
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #4333 and nuxt/nuxt#35248.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`writeTypes` resolves an auto-import such as `nitro/h3` to the exported target `lib/h3.mjs`. It then tries to rebuild the public `./h3` subpath. That path does not exist as a file, and package exports do not apply once Nitro writes it as a relative filesystem import. Stripping `.mjs` from the resolved target also prevents TypeScript from finding the adjacent `lib/h3.d.mts` declaration.

Nitro now keeps the resolved target and its extension when the rebuilt public subpath is not a file. Existing files still use the previous extension-stripping behavior.

The regression test recreates the published `./h3` to `./lib/h3.mjs` layout. It checks the generated `lib/h3.mjs` import, compiles Nitro's declaration with `noImplicitAny`, and verifies that a consumer receives the literal type from `h3.d.mts`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] Documentation is not required for this internal declaration-resolution fix.
