### PR TITLE
perf(app): compose the middleware chain once instead of per request

### DIFF
--- a/docs/1.docs/50.lifecycle.md
+++ b/docs/1.docs/50.lifecycle.md
@@ -32,7 +32,7 @@ Errors thrown inside the `request` hook are captured by the [`error` hook](#erro
 
 ### Route rules
 
-Matching [route rules](/docs/routing#route-rules) from the Nitro config execute next. Route rules run as middleware, before any global middleware, and most of them alter the response without terminating it (for instance, adding a header or setting a cache policy).
+Matching [route rules](/docs/routing#route-rules) from the Nitro config execute next. Route rules run as middleware, before any global middleware, and most of them alter the response without terminating it (for instance, adding a header or setting a cache policy). The matched rules are resolved before any middleware runs and are available as `event.context.routeRules` in every middleware.
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";

--- a/docs/1.docs/50.plugins.md
+++ b/docs/1.docs/50.plugins.md
@@ -39,6 +39,10 @@ The plugin function receives a `nitroApp` object with the following properties:
 | `fetch` | `(req: Request) => Response \| Promise<Response>` | The app's internal fetch handler. |
 | `captureError` | `(error: Error, context) => void` | Programmatically capture errors into the error hook pipeline. |
 
+::note
+H3 composes the middleware chain once, on the first request. Middleware a plugin adds to `nitroApp.h3["~middleware"]` during startup is included, but it runs before Nitro's route rules when placed at the front of the array. If a plugin changes the array after the first request was handled, it must also reset `nitroApp.h3["~dispatch"]` and `nitroApp.h3["~composed"]` to `undefined` so the chain is recomposed.
+::
+
 ## Nitro runtime hooks
 
 Use Nitro [hooks](https://github.com/unjs/hookable) to run custom functions at specific points in the [request lifecycle](/docs/lifecycle). Register them inside plugins with `nitroApp.hooks.hook()`:

--- a/src/build/virtual/app.ts
+++ b/src/build/virtual/app.ts
@@ -22,9 +22,7 @@ export default function app(nitro: Nitro) {
       const code: string[] = [];
 
       imports.push(
-        hasRouteRules || hasRoutedMiddleware
-          ? `import { composeMiddleware, H3Core } from "h3";`
-          : `import { H3Core } from "h3";`,
+        `import { H3Core } from "h3";`,
         `import errorHandler from "#nitro/virtual/error-handler";`
       );
 
@@ -127,7 +125,11 @@ export default function app(nitro: Nitro) {
           `      app.captureError?.(error, { tags: ["plugin"] });`,
           `      throw error;`,
           `    }`,
-          `  }`
+          `  }`,
+          // h3 composes `~middleware` into a dispatcher on first dispatch and
+          // never re-reads it. A plugin may have dispatched already (warm-up
+          // fetch) before a later plugin (e.g. tracing) touched the chain.
+          `  app.h3["~dispatch"] = app.h3["~composed"] = undefined;`
         );
       }
       code.push(`  return app;`, `}`);
@@ -139,43 +141,41 @@ export default function app(nitro: Nitro) {
       }
 
       code.push(``, `function createH3App(config) {`, `  const h3App = new H3Core(config);`);
-      if (hasRoutes) {
+      // `~findRoute` runs before dispatch on the original pathname, so route
+      // rules are resolved there and `event.context.routeRules` is populated for
+      // every middleware, including ones plugins unshift onto `~middleware`.
+      if (hasRoutes || hasRouteRules) {
+        code.push(`  h3App["~findRoute"] = (event) => {`);
+        if (hasRouteRules) {
+          code.push(
+            `    event.context.routeRules = getRouteRules(event.req.method, event.url.pathname).routeRules;`
+          );
+        }
         code.push(
-          `  h3App["~findRoute"] = (event) => findRoute(event.req.method, event.url.pathname);`
+          hasRoutes
+            ? `    return findRoute(event.req.method, event.url.pathname);`
+            : `    return undefined;`,
+          `  };`
         );
       }
       // Route rules, global and routed middleware are registered on `~middleware`
-      // in that order so h3 precomposes the chain once; the two path-dependent
-      // sources cache their composed chain on the memoized match result.
+      // in that order so h3 precomposes the chain once on first dispatch.
+      const runtimeAppImports = [
+        hasRouteRules && "createRouteRulesMiddleware",
+        hasRoutedMiddleware && "createRoutedMiddleware",
+        hasRouteRules && "getRouteRules",
+      ].filter(Boolean);
+      if (runtimeAppImports.length) {
+        imports.push(`import { ${runtimeAppImports.join(", ")} } from "#nitro/runtime/app";`);
+      }
       if (hasRouteRules) {
-        imports.push(`import { getRouteRules } from "#nitro/runtime/app";`);
-        code.push(
-          `  h3App["~middleware"].push((event, next) => {`,
-          `    const routeRules = getRouteRules(event.req.method, event.url.pathname);`,
-          `    event.context.routeRules = routeRules?.routeRules;`,
-          `    const middleware = routeRules?.routeRuleMiddleware;`,
-          `    if (!middleware?.length) {`,
-          `      return next();`,
-          `    }`,
-          `    return (routeRules["~composed"] ??= composeMiddleware(middleware))(event, next);`,
-          `  });`
-        );
+        code.push(`  h3App["~middleware"].push(createRouteRulesMiddleware());`);
       }
       if (hasGlobalMiddleware) {
         code.push(`  h3App["~middleware"].push(...globalMiddleware);`);
       }
       if (hasRoutedMiddleware) {
-        imports.push(`import { memoizeRouteRulesMatcher } from "h3/rules";`);
-        code.push(
-          `  const matchRoutedMiddleware = memoizeRouteRulesMatcher(findRoutedMiddleware);`,
-          `  h3App["~middleware"].push((event, next) => {`,
-          `    const matched = matchRoutedMiddleware(event.req.method, event.url.pathname);`,
-          `    if (matched.length === 0) {`,
-          `      return next();`,
-          `    }`,
-          `    return (matched["~composed"] ??= composeMiddleware(matched.map((r) => r.data)))(event, next);`,
-          `  });`
-        );
+        code.push(`  h3App["~middleware"].push(createRoutedMiddleware(findRoutedMiddleware));`);
       }
       code.push(`  return h3App;`, `}`);
 

--- a/src/build/virtual/app.ts
+++ b/src/build/virtual/app.ts
@@ -10,7 +10,6 @@ export default function app(nitro: Nitro) {
       const hasGlobalMiddleware = nitro.routing.globalMiddleware.length > 0;
       const hasPlugins = nitro.options.plugins.length > 0;
       const hasHooks = nitro.options.features?.runtimeHooks ?? hasPlugins;
-      const hasGetMiddleware = hasRouteRules || hasRoutedMiddleware;
       const hasAsyncContext = !!nitro.options.experimental.asyncContext;
 
       const routingImports = [
@@ -23,7 +22,9 @@ export default function app(nitro: Nitro) {
       const code: string[] = [];
 
       imports.push(
-        `import { H3Core } from "h3";`,
+        hasRouteRules || hasRoutedMiddleware
+          ? `import { composeMiddleware, H3Core } from "h3";`
+          : `import { H3Core } from "h3";`,
         `import errorHandler from "#nitro/virtual/error-handler";`
       );
 
@@ -143,42 +144,38 @@ export default function app(nitro: Nitro) {
           `  h3App["~findRoute"] = (event) => findRoute(event.req.method, event.url.pathname);`
         );
       }
+      // Route rules, global and routed middleware are registered on `~middleware`
+      // in that order so h3 precomposes the chain once; the two path-dependent
+      // sources cache their composed chain on the memoized match result.
+      if (hasRouteRules) {
+        imports.push(`import { getRouteRules } from "#nitro/runtime/app";`);
+        code.push(
+          `  h3App["~middleware"].push((event, next) => {`,
+          `    const routeRules = getRouteRules(event.req.method, event.url.pathname);`,
+          `    event.context.routeRules = routeRules?.routeRules;`,
+          `    const middleware = routeRules?.routeRuleMiddleware;`,
+          `    if (!middleware?.length) {`,
+          `      return next();`,
+          `    }`,
+          `    return (routeRules["~composed"] ??= composeMiddleware(middleware))(event, next);`,
+          `  });`
+        );
+      }
       if (hasGlobalMiddleware) {
         code.push(`  h3App["~middleware"].push(...globalMiddleware);`);
       }
-      if (hasGetMiddleware) {
+      if (hasRoutedMiddleware) {
+        imports.push(`import { memoizeRouteRulesMatcher } from "h3/rules";`);
         code.push(
-          `  h3App["~getMiddleware"] = (event, route) => {`,
-          `    const pathname = event.url.pathname;`,
-          `    const method = event.req.method;`,
-          `    const middleware = [];`
+          `  const matchRoutedMiddleware = memoizeRouteRulesMatcher(findRoutedMiddleware);`,
+          `  h3App["~middleware"].push((event, next) => {`,
+          `    const matched = matchRoutedMiddleware(event.req.method, event.url.pathname);`,
+          `    if (matched.length === 0) {`,
+          `      return next();`,
+          `    }`,
+          `    return (matched["~composed"] ??= composeMiddleware(matched.map((r) => r.data)))(event, next);`,
+          `  });`
         );
-        if (hasRouteRules) {
-          imports.push(`import { getRouteRules } from "#nitro/runtime/app";`);
-          code.push(
-            `    const routeRules = getRouteRules(method, pathname);`,
-            `    event.context.routeRules = routeRules?.routeRules;`,
-            `    if (routeRules?.routeRuleMiddleware.length) {`,
-            `      middleware.push(...routeRules.routeRuleMiddleware);`,
-            `    }`
-          );
-        }
-        if (hasGlobalMiddleware) {
-          code.push(`    middleware.push(...h3App["~middleware"]);`);
-        }
-        if (hasRoutedMiddleware) {
-          code.push(
-            `    middleware.push(...findRoutedMiddleware(method, pathname).map((r) => r.data));`
-          );
-        }
-        if (hasRoutes) {
-          code.push(
-            `    if (route?.data?.middleware?.length) {`,
-            `      middleware.push(...route.data.middleware);`,
-            `    }`
-          );
-        }
-        code.push(`    return middleware;`, `  };`);
       }
       code.push(`  return h3App;`, `}`);
 

--- a/src/runtime/internal/app.ts
+++ b/src/runtime/internal/app.ts
@@ -1,7 +1,7 @@
 import type { NitroApp, NitroRuntimeHooks, ResolvedRouteRules } from "nitro/types";
 import type { ServerRequest, ServerRequestContext } from "srvx";
-import type { H3EventContext, Middleware, WebSocketHooks } from "h3";
-import { toRequest } from "h3";
+import type { ComposedMiddleware, H3EventContext, Middleware, WebSocketHooks } from "h3";
+import { composeMiddleware, toRequest } from "h3";
 import { HookableCore } from "hookable";
 import { createMatcherFromFind, memoizeRouteRulesMatcher } from "h3/rules";
 
@@ -94,4 +94,71 @@ export function getRouteRules(
     method,
     pathname
   );
+}
+
+/**
+ * Middleware that runs the route-rule middleware (`redirect`, `headers`,
+ * `cors`, ...) matched for the current request. The composed chain is cached
+ * per memoized match, so each distinct match is composed once.
+ *
+ * `event.context.routeRules` is assigned earlier, from `~findRoute`, so it is
+ * populated for every middleware regardless of its position in the chain.
+ */
+export function createRouteRulesMiddleware(): Middleware {
+  const composed = new WeakMap<Middleware[], ComposedMiddleware>();
+  const middleware: Middleware = (event, next) => {
+    const ruleMiddleware = getRouteRules(event.req.method, event.url.pathname).routeRuleMiddleware;
+    if (ruleMiddleware.length === 0) {
+      return next();
+    }
+    let chain = composed.get(ruleMiddleware);
+    if (!chain) {
+      chain = composeMiddleware(ruleMiddleware);
+      composed.set(ruleMiddleware, chain);
+    }
+    return chain(event, next as any);
+  };
+  return markUntraced(middleware);
+}
+
+/**
+ * Middleware that runs the routed (`server/middleware/**` with a route)
+ * middleware matched for the current request. Chains are cached by the identity
+ * of the matched handlers (a trie keyed on the router's stable data slots), so
+ * the cache is bounded by the number of distinct match combinations rather than
+ * by request pathnames.
+ */
+export function createRoutedMiddleware(
+  findRoutedMiddleware: (method: string, pathname: string) => { data: Middleware }[]
+): Middleware {
+  const root: RoutedChainNode = { children: new Map() };
+  const middleware: Middleware = (event, next) => {
+    const matched = findRoutedMiddleware(event.req.method, event.url.pathname);
+    if (matched.length === 0) {
+      return next();
+    }
+    let node = root;
+    for (const entry of matched) {
+      let child = node.children.get(entry);
+      if (!child) {
+        child = { children: new Map() };
+        node.children.set(entry, child);
+      }
+      node = child;
+    }
+    return (node.chain ??= composeMiddleware(matched.map((r) => r.data)))(event, next as any);
+  };
+  return markUntraced(middleware);
+}
+
+type RoutedChainNode = {
+  children: Map<object, RoutedChainNode>;
+  chain?: ComposedMiddleware;
+};
+
+// Nitro's own wrappers are not user middleware: opt them out of `h3/tracing`
+// so they do not add anonymous spans around the whole downstream chain.
+function markUntraced(middleware: Middleware): Middleware {
+  (middleware as Middleware & { __traced__?: boolean }).__traced__ = true;
+  return middleware;
 }

--- a/test/fixture/server/middleware/order.ts
+++ b/test/fixture/server/middleware/order.ts
@@ -2,5 +2,5 @@ import { defineHandler } from "nitro/h3";
 
 export default defineHandler((event) => {
   const order = (event.context.middlewareOrder ??= []) as string[];
-  order.push("global");
+  order.push(event.context.routeRules ? "rules" : "no-rules", "global");
 });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -249,11 +249,11 @@ export function testNitro(
     expect(headers["x-test"]).toBe("test");
   });
 
-  it("middleware runs in order: global, routed, then the route handler", async () => {
+  it("middleware runs in order: route rules, global, routed, then the route handler", async () => {
     const { data, headers } = await callHandler({ url: "/api/middleware-order" });
-    expect(data).toEqual(["global", "routed"]);
-    // Route rule middleware applied. Its position in the chain is not
-    // observable in-band: `headers` rules only set headers on the way out.
+    // `rules` is recorded by the global middleware when `event.context.routeRules`
+    // is already populated, i.e. route rules resolved before it ran.
+    expect(data).toEqual(["rules", "global", "routed"]);
     expect(headers["x-test"]).toBe("test");
   });
 

--- a/test/unit/runtime-middleware.test.ts
+++ b/test/unit/runtime-middleware.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { mockEvent } from "h3";
+import type { Middleware } from "h3";
+
+const { findRouteRules } = vi.hoisted(() => ({
+  findRouteRules: vi.fn(() => []),
+}));
+
+vi.mock("#nitro/virtual/routing", () => ({ findRouteRules }));
+vi.mock("#nitro/virtual/app", () => ({
+  createNitroApp: () => ({}),
+  initNitroPlugins: () => {},
+}));
+
+const { createRouteRulesMiddleware, createRoutedMiddleware } =
+  await import("../../src/runtime/internal/app.ts");
+
+describe("runtime middleware wrappers", () => {
+  it("are opted out of h3 tracing", () => {
+    expect((createRouteRulesMiddleware() as any).__traced__).toBe(true);
+    expect((createRoutedMiddleware(() => []) as any).__traced__).toBe(true);
+  });
+
+  it("route rules: calls next directly when no rule middleware matched", async () => {
+    const middleware = createRouteRulesMiddleware();
+    const next = vi.fn(() => "handler");
+    expect(await middleware(mockEvent("/nothing"), next)).toBe("handler");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("routed: composes the matched chain once per handler set and runs it in order", async () => {
+    const calls: string[] = [];
+    const a: Middleware = (event, next) => {
+      calls.push("a");
+      return next();
+    };
+    const b: Middleware = (event, next) => {
+      calls.push("b");
+      return next();
+    };
+    const entryA = { data: a };
+    const entryB = { data: b };
+    const find = vi.fn((_method: string, pathname: string) =>
+      pathname.startsWith("/ab") ? [entryA, entryB] : pathname.startsWith("/a") ? [entryA] : []
+    );
+    const middleware = createRoutedMiddleware(find);
+
+    const next = vi.fn(() => "handler");
+    expect(await middleware(mockEvent("/ab/1"), next)).toBe("handler");
+    expect(calls).toEqual(["a", "b"]);
+    expect(await middleware(mockEvent("/ab/2"), next)).toBe("handler");
+    expect(await middleware(mockEvent("/a/1"), next)).toBe("handler");
+    expect(calls).toEqual(["a", "b", "a", "b", "a"]);
+    expect(next).toHaveBeenCalledTimes(3);
+
+    // No match: next is called without composing anything.
+    expect(await middleware(mockEvent("/x"), next)).toBe("handler");
+    expect(calls).toHaveLength(5);
+    expect(next).toHaveBeenCalledTimes(4);
+  });
+
+  it("routed: a short-circuiting routed middleware stops the chain", async () => {
+    const stop: Middleware = () => "stopped";
+    const middleware = createRoutedMiddleware(() => [{ data: stop }]);
+    const next = vi.fn();
+    expect(await middleware(mockEvent("/a"), next)).toBe("stopped");
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/virtual-app.test.ts
+++ b/test/unit/virtual-app.test.ts
@@ -4,17 +4,19 @@ import type { Nitro } from "nitro/types";
 import app from "../../src/build/virtual/app.ts";
 
 function createNitroStub(opts: {
+  routes?: boolean;
   routeRules?: boolean;
   routedMiddleware?: boolean;
   globalMiddleware?: boolean;
+  plugins?: boolean;
 }): Nitro {
   return {
     options: {
-      plugins: [],
+      plugins: opts.plugins ? ["plugin.ts"] : [],
       experimental: {},
     },
     routing: {
-      routes: { hasRoutes: () => true },
+      routes: { hasRoutes: () => opts.routes ?? true },
       routeRules: { hasRoutes: () => !!opts.routeRules },
       routedMiddleware: { hasRoutes: () => !!opts.routedMiddleware },
       globalMiddleware: opts.globalMiddleware ? [{}] : [],
@@ -34,33 +36,68 @@ describe("virtual/app template", () => {
     const template = app(
       createNitroStub({ routeRules: true, routedMiddleware: true, globalMiddleware: true })
     ).template();
-    const routeRules = template.indexOf("getRouteRules(event.req.method");
+    const routeRules = template.indexOf("push(createRouteRulesMiddleware())");
     const global = template.indexOf("push(...globalMiddleware)");
-    const routed = template.indexOf("matchRoutedMiddleware(event.req.method");
+    const routed = template.indexOf("push(createRoutedMiddleware(findRoutedMiddleware))");
     expect(routeRules).toBeGreaterThan(-1);
     expect(global).toBeGreaterThan(routeRules);
     expect(routed).toBeGreaterThan(global);
   });
 
-  it("keeps exposing matched route rules on `event.context.routeRules`", () => {
+  it("resolves `event.context.routeRules` in `~findRoute`, before any middleware", () => {
     const template = app(createNitroStub({ routeRules: true })).template();
-    expect(template).toContain("event.context.routeRules = routeRules?.routeRules");
+    const findRoute = template.indexOf('h3App["~findRoute"] = (event) => {');
+    const routeRules = template.indexOf(
+      "event.context.routeRules = getRouteRules(event.req.method, event.url.pathname).routeRules;"
+    );
+    const returnRoute = template.indexOf("return findRoute(event.req.method, event.url.pathname);");
+    expect(findRoute).toBeGreaterThan(-1);
+    expect(routeRules).toBeGreaterThan(findRoute);
+    expect(returnRoute).toBeGreaterThan(routeRules);
   });
 
-  it("composes the per-path chains once and caches them on the memoized match", () => {
-    const template = app(createNitroStub({ routeRules: true, routedMiddleware: true })).template();
-    expect(template).toContain('import { composeMiddleware, H3Core } from "h3";');
-    expect(template).toContain('import { memoizeRouteRulesMatcher } from "h3/rules";');
-    expect(template).toContain("memoizeRouteRulesMatcher(findRoutedMiddleware)");
-    expect(template).toContain('routeRules["~composed"] ??= composeMiddleware(');
-    expect(template).toContain('matched["~composed"] ??= composeMiddleware(');
+  it("still overrides `~findRoute` for route rules when there are no routes", () => {
+    const template = app(createNitroStub({ routes: false, routeRules: true })).template();
+    expect(template).toContain('h3App["~findRoute"] = (event) => {');
+    expect(template).toContain("event.context.routeRules = getRouteRules(");
+    expect(template).toContain("return undefined;");
+    expect(template).not.toContain("findRoute(event.req.method");
   });
 
-  it("does not import the composition helpers when nothing is path-dependent", () => {
-    const template = app(createNitroStub({ globalMiddleware: true })).template();
+  it("only imports the runtime helpers it needs", () => {
+    expect(app(createNitroStub({ routeRules: true })).template()).toContain(
+      'import { createRouteRulesMiddleware, getRouteRules } from "#nitro/runtime/app";'
+    );
+    expect(app(createNitroStub({ routedMiddleware: true })).template()).toContain(
+      'import { createRoutedMiddleware } from "#nitro/runtime/app";'
+    );
+    expect(app(createNitroStub({ routeRules: true, routedMiddleware: true })).template()).toContain(
+      'import { createRouteRulesMiddleware, createRoutedMiddleware, getRouteRules } from "#nitro/runtime/app";'
+    );
+  });
+
+  it("does not compose in the template nor import `h3/rules`", () => {
+    const template = app(
+      createNitroStub({ routeRules: true, routedMiddleware: true, globalMiddleware: true })
+    ).template();
     expect(template).toContain('import { H3Core } from "h3";');
     expect(template).not.toContain("composeMiddleware");
     expect(template).not.toContain("h3/rules");
+  });
+
+  it("does not import the runtime helpers when nothing is path-dependent", () => {
+    const template = app(createNitroStub({ globalMiddleware: true })).template();
+    expect(template).not.toContain("#nitro/runtime/app");
+    expect(template).not.toContain('~findRoute"] = (event) => {\n    event.context.routeRules');
     expect(template).toContain("push(...globalMiddleware)");
+  });
+
+  it("resets h3's cached dispatcher after plugins ran", () => {
+    const reset = 'app.h3["~dispatch"] = app.h3["~composed"] = undefined;';
+    const withPlugins = app(createNitroStub({ plugins: true })).template();
+    const plugins = withPlugins.indexOf("for (const plugin of plugins)");
+    expect(plugins).toBeGreaterThan(-1);
+    expect(withPlugins.indexOf(reset)).toBeGreaterThan(plugins);
+    expect(app(createNitroStub({})).template()).not.toContain(reset);
   });
 });

--- a/test/unit/virtual-app.test.ts
+++ b/test/unit/virtual-app.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Nitro } from "nitro/types";
+
+import app from "../../src/build/virtual/app.ts";
+
+function createNitroStub(opts: {
+  routeRules?: boolean;
+  routedMiddleware?: boolean;
+  globalMiddleware?: boolean;
+}): Nitro {
+  return {
+    options: {
+      plugins: [],
+      experimental: {},
+    },
+    routing: {
+      routes: { hasRoutes: () => true },
+      routeRules: { hasRoutes: () => !!opts.routeRules },
+      routedMiddleware: { hasRoutes: () => !!opts.routedMiddleware },
+      globalMiddleware: opts.globalMiddleware ? [{}] : [],
+    },
+  } as unknown as Nitro;
+}
+
+describe("virtual/app template", () => {
+  it("does not override `~getMiddleware`, so h3 can precompose the middleware chain", () => {
+    const template = app(
+      createNitroStub({ routeRules: true, routedMiddleware: true, globalMiddleware: true })
+    ).template();
+    expect(template).not.toContain("~getMiddleware");
+  });
+
+  it("registers route rules, global and routed middleware in that order", () => {
+    const template = app(
+      createNitroStub({ routeRules: true, routedMiddleware: true, globalMiddleware: true })
+    ).template();
+    const routeRules = template.indexOf("getRouteRules(event.req.method");
+    const global = template.indexOf("push(...globalMiddleware)");
+    const routed = template.indexOf("matchRoutedMiddleware(event.req.method");
+    expect(routeRules).toBeGreaterThan(-1);
+    expect(global).toBeGreaterThan(routeRules);
+    expect(routed).toBeGreaterThan(global);
+  });
+
+  it("keeps exposing matched route rules on `event.context.routeRules`", () => {
+    const template = app(createNitroStub({ routeRules: true })).template();
+    expect(template).toContain("event.context.routeRules = routeRules?.routeRules");
+  });
+
+  it("composes the per-path chains once and caches them on the memoized match", () => {
+    const template = app(createNitroStub({ routeRules: true, routedMiddleware: true })).template();
+    expect(template).toContain('import { composeMiddleware, H3Core } from "h3";');
+    expect(template).toContain('import { memoizeRouteRulesMatcher } from "h3/rules";');
+    expect(template).toContain("memoizeRouteRulesMatcher(findRoutedMiddleware)");
+    expect(template).toContain('routeRules["~composed"] ??= composeMiddleware(');
+    expect(template).toContain('matched["~composed"] ??= composeMiddleware(');
+  });
+
+  it("does not import the composition helpers when nothing is path-dependent", () => {
+    const template = app(createNitroStub({ globalMiddleware: true })).template();
+    expect(template).toContain('import { H3Core } from "h3";');
+    expect(template).not.toContain("composeMiddleware");
+    expect(template).not.toContain("h3/rules");
+    expect(template).toContain("push(...globalMiddleware)");
+  });
+});


### PR DESCRIPTION
Resolves #4443

Every request in a Nitro app passes through a chain of middleware: route rules from your config (redirects, headers, cors, ...), global middleware from `server/middleware/`, routed middleware, and finally the route handler.

Until now, Nitro rebuilt that list on every single request and told h3 to walk it step by step. h3 can do better: it can build the chain once and reuse it for every request, but only if Nitro stops overriding its internal `~getMiddleware` hook. This PR removes that override, as proposed in #4443.

**How it works now**

- Nitro registers its middleware on h3 in the same order as before: route rules, then global, then routed middleware. h3 composes them once on the first request.
- Route rules and routed middleware depend on the request path, so each of them is a single small middleware that looks up what matches and runs a chain that is composed once per distinct set of matched handlers. The lookup is cached by *which handlers matched*, not by URL, so apps with many unique URLs (`/users/:id`, crawlers, and so on) do not pay for cache misses.
- `event.context.routeRules` is now filled in when h3 resolves the route, before any middleware runs. So it is available in every middleware, including middleware a plugin adds to the front of the chain.
- Nitro's own two wrapper middleware are hidden from h3 tracing, so the spans you see are still only your middleware and routes, as before.
- After all plugins have run at startup, Nitro tells h3 to rebuild its cached chain. This covers plugins that send a warm-up request during startup, before a later plugin (for example tracing) has adjusted the chain.

**Anything to watch out for**

- If a plugin adds middleware to the front of `nitroApp.h3["~middleware"]`, that middleware now runs *before* route rules, not after. It should not assume redirects or headers from route rules have already been applied. This is a private API and nothing in Nitro relies on it, but at least one ecosystem plugin (`nuxt-ai-ready`) does this, so it is mentioned in the plugins docs.
- If a plugin changes that array *after the first request*, it must also reset `nitroApp.h3["~dispatch"]` and `nitroApp.h3["~composed"]` to `undefined`, because h3 only composes the chain once. This is also documented.
- The old override had a branch for `route.data.middleware`. Nitro never generates that key, so the branch was dead code and was removed. h3 handles route-level middleware itself when a route has it.

**Tests and docs**

- The shared e2e test now checks the full order in-band: route rules, then global, then routed middleware. The fixture's global middleware records whether `event.context.routeRules` was already set.
- New unit tests cover the generated template shape and the two runtime wrappers (compose once, pass through when nothing matches, stop on short-circuit).
- The lifecycle and plugins docs describe when route rules are resolved and what plugins that touch the middleware array need to do.
- `pnpm lint`, `pnpm typecheck`, and the suite pass on both builders. `test/minimal` has no route rules or routed middleware, so bundle-size budgets are unchanged.

Once this lands, h3js/h3#1525 can drop its compatibility path for the `~getMiddleware` override, which is the end state described in the issue.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
