### PR TITLE
fix: respect `baseURL` for single catch-all routes

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -160,7 +160,7 @@ export class Router<T> {
       addRoute(this._router, route.method, this._baseURL + route.route, route.data);
     }
     if (opts?.merge) {
-      mergeCatchAll(this._router);
+      mergeCatchAll(this._router, this._baseURL);
     }
   }
 
@@ -182,12 +182,16 @@ export class Router<T> {
     if (onlyWildcard) {
       // Optimize for single wildcard route
       const data = (opts?.serialize || JSON.stringify)(this.routes[0].data);
-      let retCode = `{data,params:{"_":p.slice(1)}}`;
+      const base = this._baseURL;
+      let retCode = `{data,params:{"_":p.slice(${base.length + 1})}}`;
       if (opts?.matchAll) {
         retCode = `[${retCode}]`;
       }
+      const guardCode = base
+        ? `if(p!==${JSON.stringify(base)}&&!p.startsWith(${JSON.stringify(base + "/")})){return ${opts?.matchAll ? "[]" : "undefined"};}`
+        : "";
       this._compiled[key] =
-        /* js */ `/* @__PURE__ */ (() => {const data=${data};return ((_m, p)=>{return ${retCode};})})()`;
+        /* js */ `/* @__PURE__ */ (() => {const data=${data};return ((_m, p)=>{${guardCode}return ${retCode};})})()`;
     }
 
     return this._compiled[key];
@@ -203,8 +207,18 @@ export class Router<T> {
   }
 }
 
-function mergeCatchAll(router: RouterContext<unknown>) {
-  const handlers = router.root?.wildcard?.methods?.[""];
+function mergeCatchAll(router: RouterContext<unknown>, baseURL: string) {
+  let node = router.root;
+  for (const segment of baseURL.split("/")) {
+    if (!segment) {
+      continue;
+    }
+    node = node?.static?.[segment]!;
+    if (!node) {
+      return;
+    }
+  }
+  const handlers = node?.wildcard?.methods?.[""];
   if (!handlers || handlers.length < 2) {
     return;
   }

--- a/test/unit/routing.test.ts
+++ b/test/unit/routing.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { Router } from "../../src/routing.ts";
+
+type Match = { data: unknown; params?: Record<string, string> } | undefined;
+
+function compile(baseURL: string, routes: { route: string; data: unknown }[]) {
+  const router = new Router<unknown>(baseURL);
+  router._update(
+    routes.map((r) => ({ ...r, method: "" })),
+    { merge: true }
+  );
+  const code = router.compileToString({ serialize: (data) => JSON.stringify(data) });
+  return eval(code) as (method: string, path: string) => Match;
+}
+
+describe("Router.compileToString", () => {
+  it("resolves a single catch-all route relative to baseURL", () => {
+    const findRoute = compile("/foo/", [{ route: "/**", data: "catchall" }]);
+
+    expect(findRoute("GET", "/")).toBeUndefined();
+    expect(findRoute("GET", "/foobar")).toBeUndefined();
+    expect(findRoute("GET", "/foo")).toMatchObject({ params: { _: "" } });
+    expect(findRoute("GET", "/foo/")).toMatchObject({ params: { _: "" } });
+    expect(findRoute("GET", "/foo/bar/baz")).toMatchObject({ params: { _: "bar/baz" } });
+  });
+
+  it("matches rou3 for a catch-all route with a baseURL", () => {
+    const fastPath = compile("/foo/", [{ route: "/**", data: "catchall" }]);
+    const rou3 = compile("/foo/", [
+      { route: "/**", data: "catchall" },
+      { route: "/other", data: "other" },
+    ]);
+
+    for (const path of ["/", "/foo", "/foo/", "/foo/bar", "/foobar"]) {
+      expect(fastPath("GET", path), path).toEqual(rou3("GET", path));
+    }
+  });
+
+  it("merges multiple catch-all handlers with a baseURL", () => {
+    const findRoute = compile("/foo/", [
+      { route: "/**", data: "a" },
+      { route: "/**", data: "b" },
+      { route: "/other", data: "other" },
+    ]);
+
+    expect(findRoute("GET", "/foo/bar")?.data).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

context: https://github.com/nuxt/fonts/pull/898 (see the tests marked `it.fails` in particular)

with `baseURL: '/foo/'` and a single catch-all route (which is the shape a framework's SSR renderer ends up with), the app responds to `/` but 404s `/foo/`:

```bash
# one `routes/[...].ts` + `baseURL: '/foo/'`
curl -o /dev/null -w '%{http_code}\n' localhost:3000/      # 200
curl -o /dev/null -w '%{http_code}\n' localhost:3000/foo/  # 404
```

I think this is a regression from #3716 - the single-wildcard fast path in `Router.compileToString` emits `p.slice(1)` with no prefix check, so it ignores `_baseURL` for both the match and `params._`. comparing it against what rou3 compiles for `/foo/**` (which you get as soon as a second route exists and the fast path is skipped):

| path | fast path | rou3 |
| - | - | - |
| `/` | `{_: ""}` | `undefined` |
| `/foo` | `{_: "foo"}` | `{_: ""}` |
| `/foo/bar` | `{_: "foo/bar"}` | `{_: "bar"}` |
| `/foobar` | `{_: "foobar"}` | `undefined` |

there's another issue too: `mergeCatchAll` reads `router.root.wildcard`, but under a non-root base this lives under `root.static.foo`. that means that multiple `/**` handlers never merge into a `multiHandler` and one of them is dropped.

this PR makes the fast path guard on the base and slice past it, matching the rou3 output, and walks the base segments in `mergeCatchAll` before looking for the wildcard node.

worth flagging one consequence: with the match fixed, a renderer registered at `/**` really is mounted at `/foo/**`, so anything that re-dispatches internally to a base-less URL stops matching.

we'll handle that internally in nuxt but it makes https://github.com/nitrojs/nitro/issues/4381 look more attractive...

alternatively, you might prefer to skip the fast path entirely when a base is set 🙏

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
