### PR TITLE
fix(config): resolve default server assets dir from `serverDir`

### DIFF
--- a/docs/1.docs/50.assets.md
+++ b/docs/1.docs/50.assets.md
@@ -113,7 +113,7 @@ export default defineConfig({
 
 ## Server Assets
 
-All assets in `assets/` directory will be added to the server bundle. After building your application, you can find them in the `.output/server/chunks/raw/` directory. Be careful with the size of your assets, as they will be bundled with the server bundle.
+All assets in the `assets/` directory (relative to [`serverDir`](/config#serverdir) when it is set, otherwise the project root) will be added to the server bundle. After building your application, you can find them in the `.output/server/chunks/raw/` directory. Be careful with the size of your assets, as they will be bundled with the server bundle.
 
 > [!TIP]
 > Unless using `useStorage()`, assets won't be included in the server bundle.

--- a/src/config/resolvers/assets.ts
+++ b/src/config/resolvers/assets.ts
@@ -28,10 +28,10 @@ export async function resolveAssetsOptions(options: NitroOptions) {
   for (const serverAsset of options.serverAssets) {
     serverAsset.dir = resolve(options.rootDir, serverAsset.dir);
   }
-  // 2. Add server/ directory
+  // 2. Add <serverDir>/assets directory
   options.serverAssets.push({
     baseName: "server",
-    dir: resolve(options.rootDir, "assets"),
+    dir: resolve(options.serverDir || options.rootDir, "assets"),
   });
 
   // Infer `fallthrough` and `maxAge` from publicAssets


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

another spot from https://github.com/nuxt/fonts/pull/898 - Nitro ends up shipping all `<rootDir>/assets/` in a nuxt project, even though the server dir is set to `<rootDir>/server/`.

(I assume this is just a missed spot when we renamed `srcDir` to `serverDir`)

this PR now resolves the default against `serverDir` when it's set, falling back to `rootDir`... interestingly, `test/fixture` already kept its server assets in `server/assets/` with `serverDir: "server"`, so it wouldn't have included that directory in its server assets prior to this fix...


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
