### PR TITLE
fix(routing): use serializeHandlerFn for routed middleware

### DIFF
--- a/src/build/virtual/routing.ts
+++ b/src/build/virtual/routing.ts
@@ -48,7 +48,7 @@ ${allHandlers
 
 export const findRoute = ${nitro.routing.routes.compileToString({ serialize: (h) => serializeHandler(h, { tracing: traceH3 }) })}
 
-export const findRoutedMiddleware = ${nitro.routing.routedMiddleware.compileToString({ serialize: serializeHandler, matchAll: true })};
+export const findRoutedMiddleware = ${nitro.routing.routedMiddleware.compileToString({ serialize: serializeHandlerFn, matchAll: true })};
 
 export const globalMiddleware = [
   ${nitro.routing.globalMiddleware.map((h) => (h.lazy ? h._importHash : `h3.toEventHandler(${h._importHash})`)).join(",")}

--- a/test/unit/virtual-routing.test.ts
+++ b/test/unit/virtual-routing.test.ts
@@ -53,3 +53,28 @@ describe("virtual/routing template", () => {
     expect(template).toContain("wrapHandlerWithTracing(h3.toEventHandler(_abc123))");
   });
 });
+
+it("serializes routed middleware with serializeHandlerFn instead of route record", () => {
+  const handler: NitroEventHandler & { _importHash: string } = {
+    route: "/api/**",
+    handler: "/path/to/middleware.ts",
+    _importHash: "_mid123",
+    middleware: true,
+  };
+  const nitroStub = {
+    options: { baseURL: "/", routeRules: {} },
+    routing: {
+      routes: { routes: [], compileToString: () => "{}" },
+      routedMiddleware: {
+        routes: [{ route: "/api/**", data: handler }],
+        compileToString: ({ serialize }: { serialize: (h: unknown) => string }) =>
+          `{"/api/**":${serialize(handler)}}`,
+      },
+      globalMiddleware: [],
+    },
+  } as unknown as Nitro;
+  const template = routing(nitroStub).template();
+  expect(template).toContain(
+    'export const findRoutedMiddleware = {"/api/**":h3.toEventHandler(_mid123)};'
+  );
+});

--- a/test/unit/virtual-routing.test.ts
+++ b/test/unit/virtual-routing.test.ts
@@ -52,29 +52,29 @@ describe("virtual/routing template", () => {
     expect(template).toContain(`import { wrapHandlerWithTracing } from "h3/tracing"`);
     expect(template).toContain("wrapHandlerWithTracing(h3.toEventHandler(_abc123))");
   });
-});
 
-it("serializes routed middleware with serializeHandlerFn instead of route record", () => {
-  const handler: NitroEventHandler & { _importHash: string } = {
-    route: "/api/**",
-    handler: "/path/to/middleware.ts",
-    _importHash: "_mid123",
-    middleware: true,
-  };
-  const nitroStub = {
-    options: { baseURL: "/", routeRules: {} },
-    routing: {
-      routes: { routes: [], compileToString: () => "{}" },
-      routedMiddleware: {
-        routes: [{ route: "/api/**", data: handler }],
-        compileToString: ({ serialize }: { serialize: (h: unknown) => string }) =>
-          `{"/api/**":${serialize(handler)}}`,
+  it("serializes routed middleware with serializeHandlerFn instead of route record", () => {
+    const handler: NitroEventHandler & { _importHash: string } = {
+      route: "/api/**",
+      handler: "/path/to/middleware.ts",
+      _importHash: "_mid123",
+      middleware: true,
+    };
+    const nitroStub = {
+      options: { baseURL: "/", routeRules: {} },
+      routing: {
+        routes: { routes: [], compileToString: () => "{}" },
+        routedMiddleware: {
+          routes: [{ route: "/api/**", data: handler }],
+          compileToString: ({ serialize }: { serialize: (h: unknown) => string }) =>
+            `{"/api/**":${serialize(handler)}}`,
+        },
+        globalMiddleware: [],
       },
-      globalMiddleware: [],
-    },
-  } as unknown as Nitro;
-  const template = routing(nitroStub).template();
-  expect(template).toContain(
-    'export const findRoutedMiddleware = {"/api/**":h3.toEventHandler(_mid123)};'
-  );
+    } as unknown as Nitro;
+    const template = routing(nitroStub).template();
+    expect(template).toContain(
+      'export const findRoutedMiddleware = {"/api/**":h3.toEventHandler(_mid123)};'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #4557

When registering a handler with `middleware: true` and a route pattern (route-scoped middleware), `findRoutedMiddleware` compiled with `serialize: serializeHandler`, which emits route record objects `{ route, method, meta, handler }` as route data.

In the generated `#nitro/virtual/app` template:
```ts
middleware.push(...findRoutedMiddleware(method, pathname).map((r) => r.data));
```
the route record object was passed directly to H3 as a middleware function, causing runtime requests to fail with `TypeError: fn is not a function` (HTTP 500).

## Background

Global middleware in `src/build/virtual/routing.ts` is serialized via `serializeHandlerFn`, emitting bare handler functions (wrapped in `h3.toEventHandler`). Route-scoped middleware in `findRoutedMiddleware` should also be serialized as handler functions so `r.data` yields executable middleware handlers for H3.

## Verification

- Added unit test in `test/unit/virtual-routing.test.ts` verifying `findRoutedMiddleware` compiles with `serializeHandlerFn`.
- Full test suites passed locally: `pnpm test:rolldown` and `pnpm test:rollup` (55 test files, 923 tests passed).
- Lint, format and typecheck clean (`pnpm fmt`, `pnpm lint`, `pnpm typecheck`).