### PR TITLE
fix(build): count each output file once in the size report

### DIFF
--- a/src/core/utils/fs-tree.ts
+++ b/src/core/utils/fs-tree.ts
@@ -15,7 +15,12 @@ export async function generateFSTree(
     return;
   }
 
-  const files = await globby("**/*.*", { cwd: dir, ignore: ["*.map"] });
+  const files = await globby("**/*.*", {
+    cwd: dir,
+    ignore: ["**/*.map"],
+    followSymbolicLinks: false,
+    dot: true,
+  });
 
   const items: { file: string; path: string; size: number; gzip: number }[] =
     [];


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4567

`v2` backport of #4568 — replace with the number of the `main` PR once it exists.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Same fix as #4568, against `v2` (`src/core/utils/fs-tree.ts`, which uses `globby` rather than `tinyglobby` — the defaults and the fix are identical).

`generateFSTree` globbed the server output with symlink traversal left at its default, while the output itself is built from directory symlinks — externals traced in more than one version are written to `.nitro/<pkg>@<version>` and linked into place, both flat and under each parent. Every file behind those links was therefore read, and gzipped when `compressedSizes` is on, once per path, inflating the reported total.

Disabling traversal alone under-counts: the only real copies sit inside the `.nitro` dot directory that globs skip by default, so `dot` is needed too. With both, the report matches the bytes actually on disk.

Verified on 2.13.4 with the reproduction from #4567:

| | reported | real on disk |
|---|---|---|
| before | 25.2 MB (62.8 kB gzip) | 5.2 MB |
| after | 5.15 MB (42.4 kB gzip) | 5.2 MB |

The remaining 0.05 MB is the three sourcemaps that `ignore: ["**/*.map"]` now excludes — the previous pattern had no `**/`, so it matched only the root of the output.

This is the branch we hit in production: a Nuxt 4.5 app on nitropack 2.13.4, where the glob returned 413250 paths for 11415 unique files and the report alone took 98 s of a 4-minute CI build. We currently work around it with `nitro.logLevel: 1`.

No tests reference `generateFSTree`, and the change is confined to how the report is gathered — build output is untouched.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- Nothing to document: the size report is internal build output, not a documented API. -->