### PR TITLE
types(config): map builtin driver and connector options

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,14 +4,14 @@ import type { WatchConfigOptions } from "c12";
 import type { ChokidarOptions } from "chokidar";
 import type { CompatibilityDateSpec, CompatibilityDates } from "compatx";
 import type { LogLevel } from "consola";
-import type { ConnectorName } from "db0";
+import type { ConnectorName, ConnectorOptions } from "db0";
 import type { NestedHooks } from "hookable";
 import type { ProxyServerOptions } from "httpxy";
 import type { PresetName, PresetNameInput, PresetOptions } from "../presets/index.ts";
 import type { TSConfig } from "pkg-types";
 import type { Preset as UnenvPreset } from "unenv";
 import type { UnimportPluginOptions } from "unimport/unplugin";
-import type { BuiltinDriverName } from "unstorage";
+import type { BuiltinDriverName, BuiltinDriverOptions } from "unstorage";
 import type { ExternalsTraceOptions } from "nf3";
 import type { UnwasmPluginOptions } from "unwasm/plugin";
 import type { RunnerName } from "env-runner";
@@ -1075,6 +1075,28 @@ export interface TracingOptions {
   unstorage?: boolean;
 }
 
+/** Driver name (module id or alias) of a driver that is not builtin. */
+type CustomDriverName = string & { _custom?: any };
+
+/**
+ * Mount configuration for a builtin `unstorage` driver.
+ *
+ * Driver options are inferred from the `driver` name.
+ */
+export type BuiltinStorageMount = {
+  [Name in BuiltinDriverName]: { driver: Name } & (Name extends keyof BuiltinDriverOptions
+    ? BuiltinDriverOptions[Name]
+    : unknown);
+}[BuiltinDriverName];
+
+/** Mount configuration for a custom driver (module id or alias). */
+export type CustomStorageMount = {
+  driver: CustomDriverName;
+  [option: string]: any;
+};
+
+export type StorageMount = BuiltinStorageMount | CustomStorageMount;
+
 /**
  * Storage mount configuration mapping mount points to driver options.
  *
@@ -1084,12 +1106,8 @@ export interface TracingOptions {
  * @see https://nitro.build/config#storage
  * @see https://nitro.build/docs/storage
  */
-type CustomDriverName = string & { _custom?: any };
 export interface StorageMounts {
-  [path: string]: {
-    driver: BuiltinDriverName | CustomDriverName;
-    [option: string]: any;
-  };
+  [path: string]: StorageMount;
 }
 
 // Database
@@ -1104,11 +1122,11 @@ export type DatabaseConnectionName = "default" | (string & {});
  * @see https://nitro.build/docs/database
  */
 export type DatabaseConnectionConfig = {
-  connector: ConnectorName;
-  options?: {
-    [key: string]: any;
+  [Name in ConnectorName]: {
+    connector: Name;
+    options?: Name extends keyof ConnectorOptions ? ConnectorOptions[Name] : Record<string, any>;
   };
-};
+}[ConnectorName];
 
 /** Map of {@link DatabaseConnectionName} to {@link DatabaseConnectionConfig}. */
 export type DatabaseConnectionConfigs = Record<DatabaseConnectionName, DatabaseConnectionConfig>;

--- a/test/unit/config-types.test-d.ts
+++ b/test/unit/config-types.test-d.ts
@@ -1,0 +1,19 @@
+import type { DatabaseConnectionConfigs, StorageMounts } from "nitro/types";
+
+// Storage: options are mapped from the builtin driver name.
+// Unknown driver names fall back to a custom driver with free-form options.
+export const storage: StorageMounts = {
+  data: { driver: "fs", base: "./data" },
+  cache: { driver: "lru-cache", max: 1000 },
+  memory: { driver: "memory" },
+  custom: { driver: "./drivers/custom", anyOption: true },
+};
+
+// Database: options are mapped from the db0 connector name.
+export const database: DatabaseConnectionConfigs = {
+  default: { connector: "sqlite", options: { name: "db", cwd: "." } },
+  // @ts-expect-error unknown connector
+  invalid: { connector: "unknown-connector" },
+  // @ts-expect-error `name` is a string option of the `sqlite` connector
+  invalidOption: { connector: "sqlite", options: { name: 123 } },
+};


### PR DESCRIPTION
`storage` / `devStorage` mount options and `database` / `devDatabase` connection options were typed as `[key: string]: any`, even though both `unstorage` and `db0` expose maps of their builtin options (`BuiltinDriverOptions` / `ConnectorOptions`).

This wires them up, so options are inferred from the `driver` / `connector` name:

```ts
storage: {
  data: { driver: "fs", base: "./data" },        // FSStorageOptions
  cache: { driver: "lru-cache", max: 1000 },     // LRUDriverOptions
  custom: { driver: "./drivers/custom", a: 1 },  // custom driver, free-form
},
database: {
  default: { connector: "sqlite", options: { name: "db" } }, // node-sqlite options
},
```

### Notes

- Database side is strict: `connector` must be a `db0` connector name (matching `resolveDatabaseConnections`, which already throws on unknown ones) and its `options` are type-checked.
- Storage side gains completions and inline docs for builtin driver options, but wrong option *values* are still accepted: since Nitro allows any module id as a driver, the union keeps a `CustomStorageMount` branch with an index signature that a mismatching literal falls through to. That also makes the change fully backwards-compatible — no existing config can start failing.
- Also moved the `StorageMounts` JSDoc block, which was sitting on `CustomDriverName`, onto the interface it documents.

### Test

Added `test/unit/config-types.test-d.ts`, a compile-time test picked up by `pnpm typecheck` (not by vitest). It asserts valid configs pass and uses `@ts-expect-error` for an unknown connector and a wrong option type.

`pnpm lint`, `pnpm typecheck` and `pnpm vitest run test/unit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBquKEGrmAQCG81bx86Sd