### PR TITLE
fix(node, bun, deno): call runtime `close` hooks on server shutdown

### DIFF
--- a/docs/1.docs/50.lifecycle.md
+++ b/docs/1.docs/50.lifecycle.md
@@ -181,6 +181,12 @@ export default definePlugin((nitroApp) => {
 });
 ```
 
+::note
+The hook is awaited after the HTTP server stops accepting connections. Long-running server
+presets (Node.js, Bun and Deno) call it on `SIGINT` and `SIGTERM`. Serverless and edge presets
+have no shutdown signal, so the hook only runs there if the platform closes the runtime.
+::
+
 ## Hooks reference
 
 All runtime hooks are registered through [server plugins](/docs/plugins) using `nitroApp.hooks.hook()`.

--- a/src/presets/bun/runtime/bun.ts
+++ b/src/presets/bun/runtime/bun.ts
@@ -8,6 +8,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { tracingSrvxPlugins } from "#nitro/virtual/tracing";
+import { setupCloseHooks } from "#nitro/runtime/shutdown";
 const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
 const host = process.env.NITRO_HOST || process.env.HOST;
@@ -40,6 +41,8 @@ const server = serve({
   },
   plugins: [...tracingSrvxPlugins],
 });
+
+setupCloseHooks(server);
 
 trapUnhandledErrors();
 

--- a/src/presets/deno/runtime/deno-server.ts
+++ b/src/presets/deno/runtime/deno-server.ts
@@ -8,6 +8,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { tracingSrvxPlugins } from "#nitro/virtual/tracing";
+import { setupCloseHooks } from "#nitro/runtime/shutdown";
 
 const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
@@ -38,6 +39,8 @@ const server = serve({
   fetch: _fetch,
   plugins: [...tracingSrvxPlugins],
 });
+
+setupCloseHooks(server);
 
 trapUnhandledErrors();
 

--- a/src/presets/node/runtime/node-cluster.ts
+++ b/src/presets/node/runtime/node-cluster.ts
@@ -7,6 +7,7 @@ import { useNitroApp } from "nitro/app";
 import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
+import { setupCloseHooks } from "#nitro/runtime/shutdown";
 
 const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
@@ -44,6 +45,8 @@ if (import.meta._websocket) {
     );
   });
 }
+
+setupCloseHooks(server);
 
 trapUnhandledErrors();
 

--- a/src/presets/node/runtime/node-server.ts
+++ b/src/presets/node/runtime/node-server.ts
@@ -7,6 +7,7 @@ import { startScheduleRunner } from "#nitro/runtime/task";
 import { trapUnhandledErrors } from "#nitro/runtime/error/hooks";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { tracingSrvxPlugins } from "#nitro/virtual/tracing";
+import { setupCloseHooks } from "#nitro/runtime/shutdown";
 
 const _parsedPort = Number.parseInt(process.env.NITRO_PORT ?? process.env.PORT ?? "");
 const port = Number.isNaN(_parsedPort) ? 3000 : _parsedPort;
@@ -38,6 +39,8 @@ if (import.meta._websocket) {
     );
   });
 }
+
+setupCloseHooks(server);
 
 trapUnhandledErrors();
 

--- a/src/runtime/internal/shutdown.ts
+++ b/src/runtime/internal/shutdown.ts
@@ -1,0 +1,27 @@
+import type { Server } from "srvx";
+import { useNitroHooks } from "./app.ts";
+
+/**
+ * Call the Nitro `close` hooks when the server shuts down.
+ *
+ * srvx handles graceful shutdown on `SIGINT` and `SIGTERM` by calling `server.close()`,
+ * with no knowledge of Nitro hooks. Wrapping `close` covers both the signal path and
+ * explicit `server.close()` calls, and keeps hooks awaited as part of the shutdown.
+ *
+ * Hooks run once (a forced close after the graceful timeout awaits the same call) and
+ * also run if the underlying close fails.
+ */
+export function setupCloseHooks(server: Server): void {
+  const closeServer = server.close.bind(server);
+  let closeHooks: Promise<void> | undefined;
+  server.close = (closeActiveConnections?: boolean) =>
+    closeServer(closeActiveConnections).finally(() => (closeHooks ??= callCloseHooks()));
+}
+
+async function callCloseHooks(): Promise<void> {
+  try {
+    await useNitroHooks().callHook("close");
+  } catch (error) {
+    console.error("[nitro] Error while calling `close` hooks:", error);
+  }
+}

--- a/test/fixture/server/plugins/close.ts
+++ b/test/fixture/server/plugins/close.ts
@@ -1,0 +1,13 @@
+import { definePlugin } from "nitro";
+
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks.hook("close", async () => {
+    if (!globalThis.process?.env?.NITRO_TEST_CLOSE_HOOK) {
+      return;
+    }
+    // Deliberately async: the shutdown tests assert the marker is printed before
+    // the process exits, which only holds if `close` hooks are awaited.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log("[fixture] close hook called");
+  });
+});

--- a/test/presets/_close-hook.ts
+++ b/test/presets/_close-hook.ts
@@ -1,0 +1,72 @@
+import { execa } from "execa";
+import { getRandomPort, waitForPort } from "get-port-please";
+import { resolve } from "pathe";
+import { isWindows } from "std-env";
+import { expect, it } from "vitest";
+import type { Context } from "../tests.ts";
+
+const CLOSE_HOOK_MARKER = "[fixture] close hook called";
+
+/**
+ * Assert that the runtime `close` hooks run when a built server is terminated.
+ *
+ * srvx handles `SIGINT`/`SIGTERM` by calling `server.close()`, so this spawns the real
+ * server output and signals it instead of calling `close()` in-process.
+ */
+export function testCloseHook(
+  ctx: Context,
+  opts: { command: string; args: (entry: string) => string[]; cwd?: string }
+): void {
+  it.skipIf(isWindows)(
+    "calls `close` hooks on shutdown",
+    async () => {
+      const port = await getRandomPort();
+
+      // srvx disables graceful shutdown (and therefore `server.close()`) when `CI` or
+      // `TEST` are set, so the child runs without them to exercise the real signal path.
+      const env: Record<string, string | undefined> = {
+        ...process.env,
+        NITRO_PORT: String(port),
+        PORT: String(port),
+        NITRO_HOST: "127.0.0.1",
+        NITRO_TEST_CLOSE_HOOK: "true",
+      };
+      delete env.CI;
+      delete env.TEST;
+
+      const child = execa(opts.command, opts.args(resolve(ctx.outDir, "server/index.mjs")), {
+        cwd: opts.cwd,
+        env,
+        extendEnv: false,
+        reject: false,
+      });
+
+      let output = "";
+      let exited = false;
+      child.stdout!.on("data", (data) => (output += data));
+      child.stderr!.on("data", (data) => (output += data));
+      child.nodeChildProcess.once("close", () => (exited = true));
+
+      try {
+        await waitForPort(port, { delay: 1000, retries: 20, host: "127.0.0.1" });
+
+        child.kill("SIGTERM");
+
+        // The fixture schedule runner can keep the event loop alive after the server
+        // closed, so wait for the marker (or the process to exit) instead of exit alone.
+        const deadline = Date.now() + 10_000;
+        while (!output.includes(CLOSE_HOOK_MARKER) && !exited && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+
+        expect(output).toContain(CLOSE_HOOK_MARKER);
+        expect(output).not.toContain("unhandledRejection");
+      } finally {
+        // Not awaited: the fixture schedule runner can outlive the server, and a
+        // dangling child is cleaned up by execa when the test process exits.
+        child.kill("SIGKILL");
+      }
+    },
+    40_000
+  );
+}

--- a/test/presets/bun.test.ts
+++ b/test/presets/bun.test.ts
@@ -3,6 +3,7 @@ import { getRandomPort, waitForPort } from "get-port-please";
 import { resolve } from "pathe";
 import { describe } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
+import { testCloseHook } from "./_close-hook.ts";
 
 const hasBun = execaSync("bun", ["--version"], { stdio: "ignore", reject: false }).exitCode === 0;
 
@@ -27,4 +28,6 @@ describe.runIf(hasBun)("nitro:preset:bun", async () => {
       return res;
     };
   });
+
+  testCloseHook(ctx, { command: "bun", args: (entry) => [entry] });
 });

--- a/test/presets/deno-server.test.ts
+++ b/test/presets/deno-server.test.ts
@@ -2,6 +2,7 @@ import { execa, execaSync } from "execa";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { describe } from "vitest";
 import { setupTest, testNitro } from "../tests.ts";
+import { testCloseHook } from "./_close-hook.ts";
 
 const hasDeno = execaSync("deno", ["--version"], { stdio: "ignore", reject: false }).exitCode === 0;
 
@@ -30,4 +31,6 @@ describe.runIf(hasDeno)("nitro:preset:deno-server", async () => {
       return res;
     };
   });
+
+  testCloseHook(ctx, { command: "deno", args: (entry) => ["run", "-A", entry] });
 });

--- a/test/presets/node.test.ts
+++ b/test/presets/node.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "pathe";
 // import { isWindows } from "std-env";
 import { describe, expect, it } from "vitest";
 import { setupTest, startServer, testNitro } from "../tests.ts";
+import { testCloseHook } from "./_close-hook.ts";
 
 describe("nitro:preset:node-middleware", async () => {
   const ctx = await setupTest("node-middleware");
@@ -36,5 +37,22 @@ describe("nitro:preset:node-middleware", async () => {
   it("should trace externals", () => {
     const serverNodeModules = resolve(ctx.outDir, "server/node_modules");
     expect(existsSync(resolve(serverNodeModules, "@fixture/nitro-utils/extra.mjs"))).toBe(true);
+  });
+});
+
+describe("nitro:preset:node-server", async () => {
+  const ctx = await setupTest("node-server");
+
+  testCloseHook(ctx, { command: process.execPath, args: (entry) => [entry] });
+});
+
+describe("nitro:preset:node-cluster", async () => {
+  const ctx = await setupTest("node-cluster");
+
+  // `index.mjs` only forks workers (signals sent to it are not forwarded), so the
+  // worker entry -- the one holding the server -- is spawned directly.
+  testCloseHook(ctx, {
+    command: process.execPath,
+    args: (entry) => [resolve(entry, "../worker.mjs")],
   });
 });

--- a/test/unit/close-hooks.test.ts
+++ b/test/unit/close-hooks.test.ts
@@ -1,0 +1,72 @@
+import type { Server } from "srvx";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callHook = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/runtime/internal/app.ts", () => ({
+  useNitroHooks: () => ({ callHook }),
+}));
+
+const { setupCloseHooks } = await import("../../src/runtime/internal/shutdown.ts");
+
+describe("setupCloseHooks", () => {
+  beforeEach(() => {
+    callHook.mockReset();
+    callHook.mockResolvedValue(undefined);
+  });
+
+  it("calls `close` hooks after the server is closed", async () => {
+    const events: string[] = [];
+    callHook.mockImplementationOnce(async () => {
+      events.push("hook");
+    });
+    const server = createServer(async () => {
+      events.push("close");
+    });
+
+    setupCloseHooks(server);
+    await server.close();
+
+    expect(callHook).toHaveBeenCalledWith("close");
+    expect(events).toEqual(["close", "hook"]);
+  });
+
+  it("calls `close` hooks once but always closes the server", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const server = createServer(close);
+
+    setupCloseHooks(server);
+    // srvx forcibly closes again when graceful shutdown times out
+    await Promise.all([server.close(), server.close(true)]);
+
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenLastCalledWith(true);
+    expect(callHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls `close` hooks even if closing the server fails", async () => {
+    const server = createServer(() => Promise.reject(new Error("close failed")));
+
+    setupCloseHooks(server);
+    await expect(server.close()).rejects.toThrow("close failed");
+
+    expect(callHook).toHaveBeenCalledWith("close");
+  });
+
+  it("logs hook errors instead of failing the shutdown", async () => {
+    const error = new Error("hook failed");
+    callHook.mockRejectedValueOnce(error);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const server = createServer(() => Promise.resolve());
+
+    setupCloseHooks(server);
+    await expect(server.close()).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), error);
+    consoleError.mockRestore();
+  });
+});
+
+function createServer(close: (closeActiveConnections?: boolean) => Promise<void>): Server {
+  return { close } as Server;
+}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4502
Resolves #4479

Supersedes #4522 (`node_server` / `node_cluster`, by @tarikermis) and #4532 (`bun`, by @hamodywe) — both are combined here behind a shared helper and extended to `deno-server`, the gap both PRs flagged.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

srvx owns graceful shutdown (`SIGINT`/`SIGTERM` → `server.close()`) and has no knowledge of Nitro hooks, so a plugin registering `nitroApp.hooks.hook("close", …)` was silently skipped in production. Nitro v2 ran the hook after connections drained via `setupGracefulShutdown(listener, nitroApp)`.

New shared runtime helper, `src/runtime/internal/shutdown.ts`:

```ts
export function setupCloseHooks(server: Server): void {
  const closeServer = server.close.bind(server);
  let closeHooks: Promise<void> | undefined;
  server.close = (closeActiveConnections?: boolean) =>
    closeServer(closeActiveConnections).finally(() => (closeHooks ??= callCloseHooks()));
}
```

Hooks run after the server closes (matching the v2 order), are awaited as part of shutdown, run once, and run even if the underlying close rejects; hook errors are logged rather than thrown. Memoizing the *hook* call rather than the close promise matters for the forced close: when srvx's graceful timeout expires it calls `server.close(true)`, which is still forwarded so active connections are terminated, while both callers await the same hook run.

Applied to every srvx `serve()` preset: `node-server`, `node-cluster`, `bun` and `deno-server`. The remaining presets were audited and need nothing — `deno-deploy` uses raw `Deno.serve`, and vercel / netlify / cloudflare / aws-lambda / stormkit / edgeone / zeabur / winterjs are per-request handlers with no shutdown lifecycle. The dev preset already calls the hook through `ipc.onClose`.

### Tests

- `test/fixture/server/plugins/close.ts` — fixture plugin gated on `NITRO_TEST_CLOSE_HOOK`, deliberately async so its marker only prints if hooks are awaited.
- `test/presets/_close-hook.ts` — shared `testCloseHook()` that builds, spawns the real server, sends `SIGTERM` and asserts the marker (and no `unhandledRejection`). Used by `node.test.ts` (node-server + node-cluster), `bun.test.ts` and `deno-server.test.ts`. For node-cluster it spawns `worker.mjs` directly, since `index.mjs` only forks workers and does not forward signals.
- `test/unit/close-hooks.test.ts` — helper semantics (ordering, run-once under a forced close, close rejection, hook-error logging). Runs everywhere; the bun/deno preset tests skip when those binaries are absent.

Verified failing-first: with `setupCloseHooks()` removed, all four preset tests fail with `expected '➜ Listening on…' to contain '[fixture] close hook called'`. Lint, typecheck, `test/presets` + `test/unit` all pass, and the affected tests also pass under `NITRO_BUILDER=rolldown`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly (note in `docs/1.docs/50.lifecycle.md` on when the hook fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xz7DuLxoyPWy3sSbn6mvVB
