### PR TITLE
fix(aws): omit cookies from v1 response

### DIFF
--- a/src/presets/aws-lambda/runtime/_utils.ts
+++ b/src/presets/aws-lambda/runtime/_utils.ts
@@ -85,7 +85,7 @@ function awsEventBody(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): Bod
 
 // Outgoing (Web => AWS)
 
-export function awsResponseHeaders(response: Response) {
+export function awsResponseHeaders(response: Response, v2: boolean) {
   const headers: Record<string, string> = Object.create(null);
   for (const [key, value] of response.headers) {
     if (value) {
@@ -96,9 +96,12 @@ export function awsResponseHeaders(response: Response) {
   const cookies = response.headers.getSetCookie();
 
   return cookies.length > 0
-    ? {
+    ? v2 ? {
         headers,
         cookies, // ApiGateway v2
+      }
+    : {
+        headers,
         multiValueHeaders: { "set-cookie": cookies }, // ApiGateway v1
       }
     : { headers };

--- a/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
+++ b/src/presets/aws-lambda/runtime/aws-lambda-streaming.ts
@@ -16,7 +16,7 @@ export const handler = awslambda.streamifyResponse(
 
     const httpResponseMetadata: Omit<StreamingResponse, "body"> = {
       statusCode: response.status,
-      ...awsResponseHeaders(response),
+      ...awsResponseHeaders(response, "cookies" in event || "rawPath" in event),
     };
 
     if (!httpResponseMetadata.headers!["transfer-encoding"]) {

--- a/src/presets/aws-lambda/runtime/aws-lambda.ts
+++ b/src/presets/aws-lambda/runtime/aws-lambda.ts
@@ -22,7 +22,7 @@ export async function handler(
 
   return {
     statusCode: response.status,
-    ...awsResponseHeaders(response),
+    ...awsResponseHeaders(response, "cookies" in event || "rawPath" in event),
     ...(await awsResponseBody(response)),
   };
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/504

I ran into this issue and found that it had been fixed before, but it regressed in v3.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This omits responding with cookies on aws lambda v1 format.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
