### PR TITLE
docs(examples): use `rel` instead of `type` for modulepreload links

### DIFF
--- a/docs/4.examples/vite-ssr-preact.md
+++ b/docs/4.examples/vite-ssr-preact.md
@@ -109,7 +109,7 @@ function Root(props: { url: URL }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
         <script type="module" src={assets.entry} />
       </head>
@@ -220,7 +220,7 @@ function Root(props: { url: URL }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
         <script type="module" src={assets.entry} />
       </head>

--- a/docs/4.examples/vite-ssr-react.md
+++ b/docs/4.examples/vite-ssr-react.md
@@ -100,7 +100,7 @@ export default {
               <link key={attr.href} rel="stylesheet" {...attr} />
             ))}
             {assets.js.map((attr: any) => (
-              <link key={attr.href} type="modulepreload" {...attr} />
+              <link key={attr.href} rel="modulepreload" {...attr} />
             ))}
             <script type="module" src={assets.entry} />
           </head>
@@ -203,7 +203,7 @@ export default {
               <link key={attr.href} rel="stylesheet" {...attr} />
             ))}
             {assets.js.map((attr: any) => (
-              <link key={attr.href} type="modulepreload" {...attr} />
+              <link key={attr.href} rel="modulepreload" {...attr} />
             ))}
             <script type="module" src={assets.entry} />
           </head>

--- a/docs/4.examples/vite-ssr-solid.md
+++ b/docs/4.examples/vite-ssr-solid.md
@@ -107,7 +107,7 @@ function Root(props: { appHTML?: string }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
       </head>
       <body>
@@ -234,7 +234,7 @@ function Root(props: { appHTML?: string }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
       </head>
       <body>

--- a/examples/vite-ssr-preact/README.md
+++ b/examples/vite-ssr-preact/README.md
@@ -77,7 +77,7 @@ function Root(props: { url: URL }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
         <script type="module" src={assets.entry} />
       </head>

--- a/examples/vite-ssr-preact/src/entry-server.tsx
+++ b/examples/vite-ssr-preact/src/entry-server.tsx
@@ -25,7 +25,7 @@ function Root(props: { url: URL }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
         <script type="module" src={assets.entry} />
       </head>

--- a/examples/vite-ssr-react/README.md
+++ b/examples/vite-ssr-react/README.md
@@ -70,7 +70,7 @@ export default {
               <link key={attr.href} rel="stylesheet" {...attr} />
             ))}
             {assets.js.map((attr: any) => (
-              <link key={attr.href} type="modulepreload" {...attr} />
+              <link key={attr.href} rel="modulepreload" {...attr} />
             ))}
             <script type="module" src={assets.entry} />
           </head>

--- a/examples/vite-ssr-react/src/entry-server.tsx
+++ b/examples/vite-ssr-react/src/entry-server.tsx
@@ -17,7 +17,7 @@ export default {
               <link key={attr.href} rel="stylesheet" {...attr} />
             ))}
             {assets.js.map((attr: any) => (
-              <link key={attr.href} type="modulepreload" {...attr} />
+              <link key={attr.href} rel="modulepreload" {...attr} />
             ))}
             <script type="module" src={assets.entry} />
           </head>

--- a/examples/vite-ssr-solid/README.md
+++ b/examples/vite-ssr-solid/README.md
@@ -84,7 +84,7 @@ function Root(props: { appHTML?: string }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
       </head>
       <body>

--- a/examples/vite-ssr-solid/src/entry-server.tsx
+++ b/examples/vite-ssr-solid/src/entry-server.tsx
@@ -24,7 +24,7 @@ function Root(props: { appHTML?: string }) {
           <link key={attr.href} rel="stylesheet" {...attr} />
         ))}
         {assets.js.map((attr: any) => (
-          <link key={attr.href} type="modulepreload" {...attr} />
+          <link key={attr.href} rel="modulepreload" {...attr} />
         ))}
       </head>
       <body>


### PR DESCRIPTION
The Vite SSR examples create `<link type=modulepreload>` tags but it's actually `<link rel=modulepreload>` [(MDN link)](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/modulepreload). Straightforward fix.

---

Disclosure: the patch was written by an AI agent (Claude Code), reviewed and driven by me.
