### PR TITLE
fix(static): respond with 404 when a public asset is missing on disk

### DIFF
--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -142,7 +142,7 @@ import { resolve, dirname } from 'node:path'
 import assets from '#nitro/virtual/public-assets-data'
 export function readAsset (id) {
   const serverDir = dirname(fileURLToPath(globalThis.__nitro_main__))
-  // Public dirs are often pruned after the build (uploaded to a CDN, sourcemaps
+  // Public dirs might be pruned after the build (uploaded to a CDN, sourcemaps
   // stripped), so a manifest entry with no file behind it reads as absent, not broken.
   return fsp.readFile(resolve(serverDir, assets[id].path)).catch((error) => {
     if (error?.code !== 'ENOENT') { throw error }

--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -142,9 +142,10 @@ import { resolve, dirname } from 'node:path'
 import assets from '#nitro/virtual/public-assets-data'
 export function readAsset (id) {
   const serverDir = dirname(fileURLToPath(globalThis.__nitro_main__))
+  // Public dirs are often pruned after the build (uploaded to a CDN, sourcemaps
+  // stripped), so a manifest entry with no file behind it reads as absent, not broken.
   return fsp.readFile(resolve(serverDir, assets[id].path)).catch((error) => {
     if (error?.code !== 'ENOENT') { throw error }
-    console.warn(\`[nitro] Public asset "\${id}" is missing on disk (\${assets[id].path})\`)
   })
 }`;
       },

--- a/src/build/virtual/public-assets.ts
+++ b/src/build/virtual/public-assets.ts
@@ -142,7 +142,10 @@ import { resolve, dirname } from 'node:path'
 import assets from '#nitro/virtual/public-assets-data'
 export function readAsset (id) {
   const serverDir = dirname(fileURLToPath(globalThis.__nitro_main__))
-  return fsp.readFile(resolve(serverDir, assets[id].path))
+  return fsp.readFile(resolve(serverDir, assets[id].path)).catch((error) => {
+    if (error?.code !== 'ENOENT') { throw error }
+    console.warn(\`[nitro] Public asset "\${id}" is missing on disk (\${assets[id].path})\`)
+  })
 }`;
       },
     },

--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -1,5 +1,5 @@
 import { HTTPError, defineHandler } from "h3";
-import type { EventHandler, HTTPMethod } from "h3";
+import type { EventHandler, H3Event, HTTPMethod } from "h3";
 import type { PublicAsset } from "nitro/types";
 import { decodePath, joinURL, withLeadingSlash, withoutTrailingSlash } from "ufo";
 import { getAsset, isPublicAssetURL, readAsset } from "#nitro/virtual/public-assets";
@@ -8,7 +8,7 @@ const METHODS = new Set(["HEAD", "GET"] as HTTPMethod[]);
 
 const EncodingMap = { gzip: ".gz", br: ".br", zstd: ".zst" } as const;
 
-export default defineHandler(async (event) => {
+export default defineHandler((event) => {
   if (event.req.method && !METHODS.has(event.req.method as HTTPMethod)) {
     return;
   }
@@ -65,17 +65,6 @@ export default defineHandler(async (event) => {
     return "";
   }
 
-  let data: Awaited<ReturnType<typeof readAsset>>;
-  try {
-    data = await readAsset(id);
-  } catch (error) {
-    if ((error as { code?: string })?.code === "ENOENT") {
-      event.res.headers.delete("Cache-Control");
-      throw new HTTPError({ status: 404 });
-    }
-    throw error;
-  }
-
   if (asset.type) {
     event.res.headers.set("Content-Type", asset.type);
   }
@@ -96,5 +85,18 @@ export default defineHandler(async (event) => {
     event.res.headers.set("Content-Length", asset.size.toString());
   }
 
-  return data;
+  const data = readAsset(id);
+  return typeof (data as { then?: unknown })?.then === "function"
+    ? (data as Promise<unknown>).then((resolved) => assertAssetData(event, resolved))
+    : assertAssetData(event, data);
 }) as EventHandler;
+
+// Readers resolve with `null`/`undefined` when the manifest entry has no data
+// backing it (file removed after build, missing inline payload).
+function assertAssetData<T>(event: H3Event, data: T): T {
+  if (data === null || data === undefined) {
+    event.res.headers.delete("Cache-Control");
+    throw new HTTPError({ status: 404 });
+  }
+  return data;
+}

--- a/src/runtime/internal/static.ts
+++ b/src/runtime/internal/static.ts
@@ -8,7 +8,7 @@ const METHODS = new Set(["HEAD", "GET"] as HTTPMethod[]);
 
 const EncodingMap = { gzip: ".gz", br: ".br", zstd: ".zst" } as const;
 
-export default defineHandler((event) => {
+export default defineHandler(async (event) => {
   if (event.req.method && !METHODS.has(event.req.method as HTTPMethod)) {
     return;
   }
@@ -65,6 +65,17 @@ export default defineHandler((event) => {
     return "";
   }
 
+  let data: Awaited<ReturnType<typeof readAsset>>;
+  try {
+    data = await readAsset(id);
+  } catch (error) {
+    if ((error as { code?: string })?.code === "ENOENT") {
+      event.res.headers.delete("Cache-Control");
+      throw new HTTPError({ status: 404 });
+    }
+    throw error;
+  }
+
   if (asset.type) {
     event.res.headers.set("Content-Type", asset.type);
   }
@@ -85,5 +96,5 @@ export default defineHandler((event) => {
     event.res.headers.set("Content-Length", asset.size.toString());
   }
 
-  return readAsset(id);
+  return data;
 }) as EventHandler;

--- a/test/unit/public-assets.test.ts
+++ b/test/unit/public-assets.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { dirname, normalize, resolve } from "pathe";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { Nitro } from "nitro/types";
 
 import publicAssets from "../../src/build/virtual/public-assets.ts";
@@ -85,17 +85,15 @@ describe("virtual/public-assets node reader", () => {
     expect(resolved).not.toBe("/app/server/index.ts");
   });
 
-  // A manifest entry whose file vanished after the build resolves with no data, so
-  // the static middleware can answer 404 rather than surfacing an unhandled 500.
+  // A public dir pruned after the build (uploaded to a CDN, sourcemaps stripped)
+  // leaves manifest entries with no file behind them; those read as absent so the
+  // static middleware can answer 404 rather than surfacing an unhandled 500.
   it("resolves with no data when the file is gone", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { readAsset } = loadReadAsset(nodeReaderTemplate(), () =>
       Promise.reject(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }))
     );
 
     await expect(readAsset("/index.html")).resolves.toBeUndefined();
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("/index.html"));
-    warn.mockRestore();
   });
 
   it("rejects for read errors other than a missing file", async () => {

--- a/test/unit/public-assets.test.ts
+++ b/test/unit/public-assets.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { dirname, normalize, resolve } from "pathe";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Nitro } from "nitro/types";
 
 import publicAssets from "../../src/build/virtual/public-assets.ts";
@@ -41,12 +41,12 @@ function nodeReaderTemplate(): string {
 
 // Evaluate the generated `readAsset` template against the real node helpers it
 // imports, recording the filesystem target it asks `fs` to read.
-function loadReadAsset(template: string) {
+function loadReadAsset(template: string, readFile?: () => Promise<unknown>) {
   const reads: string[] = [];
   const fsp = {
     readFile: (p: string | URL) => {
       reads.push(typeof p === "string" ? p : fileURLToPath(p));
-      return Promise.resolve(new Uint8Array());
+      return readFile ? readFile() : Promise.resolve(new Uint8Array());
     },
   };
   // Strip the (single-line) imports and bridge their bindings in as args instead.
@@ -83,5 +83,26 @@ describe("virtual/public-assets node reader", () => {
     const resolved = normalize(reads.at(-1)!);
     expect(resolved.startsWith(`${PUBLIC_DIR}/`)).toBe(true);
     expect(resolved).not.toBe("/app/server/index.ts");
+  });
+
+  // A manifest entry whose file vanished after the build resolves with no data, so
+  // the static middleware can answer 404 rather than surfacing an unhandled 500.
+  it("resolves with no data when the file is gone", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { readAsset } = loadReadAsset(nodeReaderTemplate(), () =>
+      Promise.reject(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }))
+    );
+
+    await expect(readAsset("/index.html")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("/index.html"));
+    warn.mockRestore();
+  });
+
+  it("rejects for read errors other than a missing file", async () => {
+    const { readAsset } = loadReadAsset(nodeReaderTemplate(), () =>
+      Promise.reject(Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }))
+    );
+
+    await expect(readAsset("/index.html")).rejects.toThrow("EACCES");
   });
 });

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -35,30 +35,41 @@ describe("runtime static middleware", () => {
     isPublicAssetURL.mockReturnValue(true);
     const event = createEvent("/foo-missing.css", "gzip");
 
-    await expect(handler(event)).rejects.toThrow("404");
+    expect(() => handler(event)).toThrow("404");
     expect(event.res.headers.get("Vary")).toBe("Origin");
     expect(event.res.headers.get("Cache-Control")).toBeNull();
   });
 
-  it("responds with 404 when a matched asset is missing on disk", async () => {
+  it("responds with 404 when a matched asset has no data behind it", async () => {
     getAsset.mockImplementation((id: string) =>
       id === "/favicon.ico"
         ? { etag: '"test"', mtime: Date.now(), type: "image/x-icon", size: 1 }
         : undefined
     );
     isPublicAssetURL.mockReturnValue(true);
-    readAsset.mockRejectedValue(
-      Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
-    );
+    readAsset.mockResolvedValue(undefined);
     const event = createEvent("/favicon.ico");
 
     await expect(handler(event)).rejects.toThrow("404");
     expect(event.res.headers.get("Cache-Control")).toBeNull();
-    expect(event.res.headers.get("Content-Type")).toBeNull();
-    expect(event.res.headers.get("ETag")).toBeNull();
   });
 
-  it("rethrows non-ENOENT read errors", async () => {
+  // The `inline` reader hands back its payload without a promise.
+  it("responds with 404 when a synchronous reader has no data", () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/favicon.ico"
+        ? { etag: '"test"', mtime: Date.now(), type: "image/x-icon", size: 1 }
+        : undefined
+    );
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockReturnValue(undefined);
+    const event = createEvent("/favicon.ico");
+
+    expect(() => handler(event)).toThrow("404");
+    expect(event.res.headers.get("Cache-Control")).toBeNull();
+  });
+
+  it("propagates reader errors", async () => {
     getAsset.mockImplementation((id: string) =>
       id === "/favicon.ico"
         ? { etag: '"test"', mtime: Date.now(), type: "image/x-icon", size: 1 }
@@ -69,6 +80,19 @@ describe("runtime static middleware", () => {
     const event = createEvent("/favicon.ico");
 
     await expect(handler(event)).rejects.toThrow("EACCES");
+  });
+
+  it("serves an empty asset instead of treating it as missing", async () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/empty.txt"
+        ? { etag: '"test"', mtime: Date.now(), type: "text/plain", size: 0 }
+        : undefined
+    );
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockResolvedValue(new Uint8Array());
+    const event = createEvent("/empty.txt");
+
+    await expect(handler(event)).resolves.toEqual(new Uint8Array());
   });
 
   it("appends Accept-Encoding vary when a compressed asset is matched", async () => {

--- a/test/unit/static-middleware.test.ts
+++ b/test/unit/static-middleware.test.ts
@@ -35,9 +35,40 @@ describe("runtime static middleware", () => {
     isPublicAssetURL.mockReturnValue(true);
     const event = createEvent("/foo-missing.css", "gzip");
 
-    expect(() => handler(event)).toThrow("404");
+    await expect(handler(event)).rejects.toThrow("404");
     expect(event.res.headers.get("Vary")).toBe("Origin");
     expect(event.res.headers.get("Cache-Control")).toBeNull();
+  });
+
+  it("responds with 404 when a matched asset is missing on disk", async () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/favicon.ico"
+        ? { etag: '"test"', mtime: Date.now(), type: "image/x-icon", size: 1 }
+        : undefined
+    );
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockRejectedValue(
+      Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
+    );
+    const event = createEvent("/favicon.ico");
+
+    await expect(handler(event)).rejects.toThrow("404");
+    expect(event.res.headers.get("Cache-Control")).toBeNull();
+    expect(event.res.headers.get("Content-Type")).toBeNull();
+    expect(event.res.headers.get("ETag")).toBeNull();
+  });
+
+  it("rethrows non-ENOENT read errors", async () => {
+    getAsset.mockImplementation((id: string) =>
+      id === "/favicon.ico"
+        ? { etag: '"test"', mtime: Date.now(), type: "image/x-icon", size: 1 }
+        : undefined
+    );
+    isPublicAssetURL.mockReturnValue(true);
+    readAsset.mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const event = createEvent("/favicon.ico");
+
+    await expect(handler(event)).rejects.toThrow("EACCES");
   });
 
   it("appends Accept-Encoding vary when a compressed asset is matched", async () => {


### PR DESCRIPTION

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33033
resolves https://github.com/nuxt/nuxt/issues/29078

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

when a file can't be read because it can't be read from disk, we can return a 404 instead of a 500 error, which seems wrong.

alternatively, we could _always_ return a 404 when the asset can't be read, if you didn't want to tie this too closely to fs semantics.

... or you may have another better idea!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
