### PR TITLE
fix(build): resolve driver lib deps from the project only

### DIFF
--- a/src/build/virtual/database.ts
+++ b/src/build/virtual/database.ts
@@ -46,7 +46,7 @@ function genConnectorOptions(nitro: Nitro, connection: DatabaseConnection) {
       (dep) =>
         isLibOption(dep.option) &&
         connection.options[dep.option] === undefined &&
-        isDepInstalled(dep.name, nitro.options.rootDir)
+        isDepInstalled(dep.name, nitro.options.rootDir, { projectOnly: true })
     )
     .map((dep) => `${dep.option}: () => import(${JSON.stringify(dep.import || dep.name)})`);
 

--- a/src/build/virtual/database.ts
+++ b/src/build/virtual/database.ts
@@ -46,7 +46,7 @@ function genConnectorOptions(nitro: Nitro, connection: DatabaseConnection) {
       (dep) =>
         isLibOption(dep.option) &&
         connection.options[dep.option] === undefined &&
-        isDepInstalled(dep.name, nitro.options.rootDir, { projectOnly: true })
+        isDepInstalled(dep.name, { dir: nitro.options.rootDir, projectOnly: true })
     )
     .map((dep) => `${dep.option}: () => import(${JSON.stringify(dep.import || dep.name)})`);
 

--- a/src/build/virtual/storage.ts
+++ b/src/build/virtual/storage.ts
@@ -48,7 +48,7 @@ function genDriverOptions(nitro: Nitro, mount: ReturnType<typeof resolveStorageM
       (dep) =>
         isLibOption(dep.option) &&
         mount.options[dep.option] === undefined &&
-        isDepInstalled(dep.name, nitro.options.rootDir, { projectOnly: true })
+        isDepInstalled(dep.name, { dir: nitro.options.rootDir, projectOnly: true })
     )
     .map((dep) => `${dep.option}: () => import(${JSON.stringify(dep.import || dep.name)})`);
 

--- a/src/build/virtual/storage.ts
+++ b/src/build/virtual/storage.ts
@@ -48,7 +48,7 @@ function genDriverOptions(nitro: Nitro, mount: ReturnType<typeof resolveStorageM
       (dep) =>
         isLibOption(dep.option) &&
         mount.options[dep.option] === undefined &&
-        isDepInstalled(dep.name, nitro.options.rootDir)
+        isDepInstalled(dep.name, nitro.options.rootDir, { projectOnly: true })
     )
     .map((dep) => `${dep.option}: () => import(${JSON.stringify(dep.import || dep.name)})`);
 

--- a/src/config/resolvers/builder.ts
+++ b/src/config/resolvers/builder.ts
@@ -38,7 +38,7 @@ export async function resolveBuilder(options: NitroOptions) {
   }
 
   // Auto-detect: check for vite.config with nitro() plugin
-  if (isDepInstalled("vite", options.rootDir) && hasNitroViteConfig(options)) {
+  if (isDepInstalled("vite", { dir: options.rootDir }) && hasNitroViteConfig(options)) {
     options.builder = "vite";
     return;
   }

--- a/src/utils/dep.ts
+++ b/src/utils/dep.ts
@@ -85,13 +85,9 @@ export async function importDep<T>(opts: DepOptions): Promise<T> {
   return (await import(pathToFileURL(resolved).href)) as T;
 }
 
-export function isDepInstalled(
-  id: string,
-  dir: string,
-  opts: { projectOnly?: boolean } = {}
-): boolean {
+export function isDepInstalled(id: string, opts: Pick<DepOptions, "dir" | "projectOnly">): boolean {
   return !!resolveModulePath(id, {
-    from: opts.projectOnly ? dir : [dir, import.meta.url],
+    from: opts.projectOnly ? opts.dir : [opts.dir, import.meta.url],
     try: true,
   });
 }

--- a/src/utils/dep.ts
+++ b/src/utils/dep.ts
@@ -19,6 +19,13 @@ export interface DepOptions {
   version?: string;
   /** Install as a dev dependency. (default: `true`) */
   dev?: boolean;
+  /**
+   * Only resolve from `dir`, ignoring Nitro's own dependencies.
+   *
+   * Required for packages that end up as an import in the generated app bundle: those have to be
+   * resolvable from the user project, not only from where Nitro itself is installed.
+   */
+  projectOnly?: boolean;
 }
 
 /**
@@ -28,7 +35,7 @@ export interface DepOptions {
  */
 export async function ensureDep(opts: DepOptions, _retry?: boolean): Promise<string | undefined> {
   const resolved = resolveModulePath(opts.id, {
-    from: [opts.dir, import.meta.url],
+    from: opts.projectOnly ? opts.dir : [opts.dir, import.meta.url],
     cache: _retry ? false : true,
     try: true,
   });
@@ -78,8 +85,15 @@ export async function importDep<T>(opts: DepOptions): Promise<T> {
   return (await import(pathToFileURL(resolved).href)) as T;
 }
 
-export function isDepInstalled(id: string, dir: string): boolean {
-  return !!resolveModulePath(id, { from: [dir, import.meta.url], try: true });
+export function isDepInstalled(
+  id: string,
+  dir: string,
+  opts: { projectOnly?: boolean } = {}
+): boolean {
+  return !!resolveModulePath(id, {
+    from: opts.projectOnly ? dir : [dir, import.meta.url],
+    try: true,
+  });
 }
 
 export interface LibDep {
@@ -122,7 +136,14 @@ export async function ensureLibDeps(
 
   for (const [name, { version, users: names }] of required) {
     const reason = `the ${[...names].map((n) => `\`${n}\``).join(", ")} ${opts.label}${names.size > 1 ? "s" : ""}`;
-    const resolved = await ensureDep({ id: name, version, dir: opts.dir, reason, dev: false });
+    const resolved = await ensureDep({
+      id: name,
+      version,
+      dir: opts.dir,
+      reason,
+      dev: false,
+      projectOnly: true,
+    });
     if (!resolved) {
       consola.warn(`\`${name}\` is not installed. It is required for ${reason}.`);
     }

--- a/test/unit/virtual-storage.test.ts
+++ b/test/unit/virtual-storage.test.ts
@@ -1,15 +1,20 @@
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "pathe";
 import { describe, expect, it, vi } from "vitest";
 import type { Nitro } from "nitro/types";
 
 const mockedDeps = new Set<string>();
 
+const { isDepInstalled } =
+  await vi.importActual<typeof import("../../src/utils/dep.ts")>("../../src/utils/dep.ts");
+
 vi.mock("../../src/utils/dep.ts", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../src/utils/dep.ts")>();
   return {
     ...original,
-    isDepInstalled: (id: string, dir: string, opts?: { projectOnly?: boolean }) =>
-      mockedDeps.has(id) || original.isDepInstalled(id, dir, opts),
+    isDepInstalled: (id: string, opts: Parameters<typeof original.isDepInstalled>[1]) =>
+      mockedDeps.has(id) || original.isDepInstalled(id, opts),
   };
 });
 
@@ -84,8 +89,12 @@ describe("virtual/storage template", () => {
   });
 
   it("does not provide `lib` for dependencies only resolvable from nitro itself", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "nitro-storage-lib-"));
+    expect(isDepInstalled("chokidar", { dir: rootDir })).toBe(true);
+    expect(isDepInstalled("chokidar", { dir: rootDir, projectOnly: true })).toBe(false);
+
     const nitro = createNitroStub(undefined, { "/data": { driver: "fs", base: "./data" } });
-    nitro.options.rootDir = tmpdir();
+    nitro.options.rootDir = rootDir;
     const template = storage(nitro).template();
     expect(template).toContain(
       `storage.mount('/data', unstorage_47drivers_47fs({"base":"./data"}))`

--- a/test/unit/virtual-storage.test.ts
+++ b/test/unit/virtual-storage.test.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import type { Nitro } from "nitro/types";
 
@@ -7,8 +8,8 @@ vi.mock("../../src/utils/dep.ts", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../src/utils/dep.ts")>();
   return {
     ...original,
-    isDepInstalled: (id: string, dir: string) =>
-      mockedDeps.has(id) || original.isDepInstalled(id, dir),
+    isDepInstalled: (id: string, dir: string, opts?: { projectOnly?: boolean }) =>
+      mockedDeps.has(id) || original.isDepInstalled(id, dir, opts),
   };
 });
 
@@ -80,6 +81,16 @@ describe("virtual/storage template", () => {
       `storage.mount('/cache', unstorage_47drivers_47redis({"base":"cache"}))`
     );
     expect(template).not.toContain("ioredis");
+  });
+
+  it("does not provide `lib` for dependencies only resolvable from nitro itself", () => {
+    const nitro = createNitroStub(undefined, { "/data": { driver: "fs", base: "./data" } });
+    nitro.options.rootDir = tmpdir();
+    const template = storage(nitro).template();
+    expect(template).toContain(
+      `storage.mount('/data', unstorage_47drivers_47fs({"base":"./data"}))`
+    );
+    expect(template).not.toContain("chokidar");
   });
 
   it("does not override a user provided `lib` option", () => {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

noticed that nitro was injecting imports of bare specifiers (e.g. `() => import('chokidar')`) in the code it generates. if chokidar is resolvable within nitro's directory _but not in_ the user's project, this will fail.

we either need to fix with:

1. only checking _project_ deps (<- the approach in this PR, assuming you chose the bare specifier import deliberately)
2. alternatively, allowing dependencies to be resolved via a modulesDir or similar, or injected with an absolute path, so e.g. if nuxt has chokidar as a dep then this can be resolved in the generated nitro code

or you may have another, better idea.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
