### PR TITLE
fix(types): reject non-serializable storage and database options

### DIFF
--- a/docs/1.docs/8.storage.md
+++ b/docs/1.docs/8.storage.md
@@ -101,11 +101,15 @@ Then, you can use the redis storage using the `useStorage("redis")` function.
 You can find the driver list on [unstorage documentation](https://unstorage.unjs.io/) with their configuration.
 ::
 
+::important
+Mount options are serialized into the build output, so they must be JSON-serializable. Use [runtime configuration](#runtime-configuration) if a mount needs a non-serializable option.
+::
+
 ### Driver dependencies
 
 Some drivers rely on a third-party library (for example, `redis` requires [`ioredis`](https://www.npmjs.com/package/ioredis)).
 
-Nitro detects the libraries required by the mounted drivers and prompts to install the missing ones (installed automatically in CI). Installed libraries are then explicitly passed to the driver via its `lib` option, so that bundlers can statically resolve them.
+Nitro detects the libraries required by the mounted drivers and prompts to install the missing ones (installed automatically in CI). Installed libraries are then explicitly passed to the driver via its `lib` option, so that bundlers can statically resolve them. `lib` options are therefore not configurable in `storage` mounts (set them to `null` to opt out of the injected import).
 
 ### Development storage
 

--- a/src/types/_utils.ts
+++ b/src/types/_utils.ts
@@ -4,11 +4,59 @@ export type Enumerate<N extends number, Acc extends number[] = []> = Acc["length
 
 export type IntRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>;
 
-export type ExcludeFunctions<G extends Record<string, any>> = Pick<
-  G,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  { [P in keyof G]: NonNullable<G[P]> extends Function ? never : P }[keyof G]
->;
+declare const invalidValue: unique symbol;
+
+/** Assignable only from `Message`, so a rejected value reports `Message` in its type error. */
+export type Invalid<Message extends string> = Message & { [invalidValue]?: never };
+
+type LibOptionName = "lib" | `${string}Lib`;
+
+type LibOption = null | Invalid<"Library imports are not JSON-serializable; nitro injects them for installed driver dependencies (set `null` to opt out)">;
+
+type JsonPrimitive = string | number | boolean | null | undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+type NonSerializable =
+  | Function
+  | symbol
+  | bigint
+  | RegExp
+  | Date
+  | Error
+  | Promise<any>
+  | Map<any, any>
+  | Set<any>
+  | WeakMap<any, any>
+  | WeakSet<any>
+  | ArrayBufferLike
+  | ArrayBufferView;
+
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6];
+
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+/**
+ * The subset of `T` that survives `JSON.stringify`, with anything else mapped to {@link Invalid}.
+ *
+ * `Depth` bounds instantiation for large and self-referential option types; deeper values are
+ * passed through unchecked.
+ */
+export type Serializable<T, Depth extends number = 6> = [Depth] extends [never]
+  ? T
+  : T extends JsonPrimitive
+    ? T
+    : T extends NonSerializable
+      ? Invalid<"nitro serializes options with JSON.stringify; this value would not survive">
+      : T extends readonly (infer U)[]
+        ? Array<Serializable<U, Prev[Depth]>>
+        : T extends object
+          ? { [K in keyof T]: Serializable<T[K], Prev[Depth]> }
+          : T;
+
+/** Driver or connector options, as serialized into the build output. */
+export type SerializableOptions<T> = {
+  [K in keyof T]: K extends LibOptionName ? LibOption : Serializable<T[K]>;
+};
 
 export type KebabCase<T extends string, A extends string = ""> = T extends `${infer F}${infer R}`
   ? KebabCase<R, `${A}${F extends Lowercase<F> ? "" : "-"}${Lowercase<F>}`>

--- a/src/types/_utils.ts
+++ b/src/types/_utils.ts
@@ -6,8 +6,8 @@ export type IntRange<F extends number, T extends number> = Exclude<Enumerate<T>,
 
 declare const invalidValue: unique symbol;
 
-/** Assignable only from `Message`, so a rejected value reports `Message` in its type error. */
-export type Invalid<Message extends string> = Message & { [invalidValue]?: never };
+/** Uninhabited, so a rejected value reports `Message` in its type error. */
+export type Invalid<Message extends string> = Message & { readonly [invalidValue]: never };
 
 type LibOptionName = "lib" | `${string}Lib`;
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -29,6 +29,7 @@ import type { NitroPreset } from "./preset.ts";
 import type { OXCOptions, RolldownConfig } from "./build.ts";
 import type { RollupConfig } from "./build.ts";
 import type { NitroRouteConfig, NitroRouteRules } from "./route-rules.ts";
+import type { JsonValue, SerializableOptions } from "./_utils.ts";
 
 type RollupCommonJSOptions = NonNullable<Parameters<typeof commonjs.default>[0]>;
 
@@ -1062,14 +1063,14 @@ type CustomDriverName = string & { _custom?: any };
  */
 export type BuiltinStorageMount = {
   [Name in BuiltinDriverName]: { driver: Name } & (Name extends keyof BuiltinDriverOptions
-    ? BuiltinDriverOptions[Name]
+    ? SerializableOptions<BuiltinDriverOptions[Name]>
     : unknown);
 }[BuiltinDriverName];
 
 /** Mount configuration for a custom driver (module id or alias). */
 export type CustomStorageMount = {
   driver: CustomDriverName;
-  [option: string]: any;
+  [option: string]: JsonValue;
 };
 
 export type StorageMount = BuiltinStorageMount | CustomStorageMount;
@@ -1101,7 +1102,9 @@ export type DatabaseConnectionName = "default" | (string & {});
 export type DatabaseConnectionConfig = {
   [Name in ConnectorName]: {
     connector: Name;
-    options?: Name extends keyof ConnectorOptions ? ConnectorOptions[Name] : Record<string, any>;
+    options?: Name extends keyof ConnectorOptions
+      ? SerializableOptions<ConnectorOptions[Name]>
+      : Record<string, JsonValue>;
   };
 }[ConnectorName];
 

--- a/test/unit/config-types.test-d.ts
+++ b/test/unit/config-types.test-d.ts
@@ -1,12 +1,22 @@
+import type { SerializableOptions } from "../../src/types/_utils.ts";
 import type { DatabaseConnectionConfigs, StorageMounts } from "nitro/types";
 
 // Storage: options are mapped from the builtin driver name.
 // Unknown driver names fall back to a custom driver with free-form options.
 export const storage: StorageMounts = {
-  data: { driver: "fs", base: "./data" },
+  data: { driver: "fs", base: "./data", ignore: ["**/node_modules/**"] },
   cache: { driver: "lru-cache", max: 1000 },
   memory: { driver: "memory" },
   custom: { driver: "./drivers/custom", anyOption: true },
+  noLib: { driver: "fs", lib: null },
+  // @ts-expect-error `watchOptions.ignored` matcher functions are not serializable
+  matcher: { driver: "fs", watchOptions: { ignored: [(path: string) => path.length > 0] } },
+  // @ts-expect-error a `RegExp` is not serializable
+  regexp: { driver: "fs", watchOptions: { ignored: /node_modules/ } },
+  // @ts-expect-error `lib` is provided by nitro
+  lib: { driver: "fs", lib: () => import("chokidar") },
+  // @ts-expect-error custom driver options are serialized too
+  customFn: { driver: "./drivers/custom", transform: () => "x" },
 };
 
 // Database: options are mapped from the db0 connector name.
@@ -16,4 +26,19 @@ export const database: DatabaseConnectionConfigs = {
   invalid: { connector: "unknown-connector" },
   // @ts-expect-error `name` is a string option of the `sqlite` connector
   invalidOption: { connector: "sqlite", options: { name: 123 } },
+};
+
+// Connector options are unions intersected with their `lib` option and the third-party types they
+// are built from are not installed here, so the mapping is checked against an equivalent shape.
+type Lib = { connect(): void };
+type ConnectorOptionsShape = ({ url: string } | { host?: string }) & {
+  lib?: Lib | (() => Promise<Lib>);
+};
+
+export const connectorOptions: SerializableOptions<ConnectorOptionsShape> = { url: "", lib: null };
+
+export const connectorLib: SerializableOptions<ConnectorOptionsShape> = {
+  url: "",
+  // @ts-expect-error `lib` is provided by nitro
+  lib: () => Promise.resolve({ connect() {} }),
 };

--- a/test/unit/config-types.test-d.ts
+++ b/test/unit/config-types.test-d.ts
@@ -42,3 +42,9 @@ export const connectorLib: SerializableOptions<ConnectorOptionsShape> = {
   // @ts-expect-error `lib` is provided by nitro
   lib: () => Promise.resolve({ connect() {} }),
 };
+
+export const connectorLibMessage: SerializableOptions<ConnectorOptionsShape> = {
+  url: "",
+  // @ts-expect-error the message of a rejected option is not a value it accepts
+  lib: "Library imports are not JSON-serializable; nitro injects them for installed driver dependencies (set `null` to opt out)",
+};


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/nitrojs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

hit this because nuxt passed ignore options to the fs driver in dev, specifically an ignore _function_ which the types accepted but which was serialised to null and therefore did nothing (see https://github.com/nuxt/nuxt/pull/36306):

```ts
devStorage: {
  root: {
    driver: "fs",
    base: rootDir,
    watchOptions: { ignored: [isIgnored] },
  },
},
```

this therefore updates the types for storage options to strip function-type values, and also the same for database connector options which I noticed had the same kind of issue

the same is also true with a user provided `lib` which is a dynamic import.

finally, it also drops `ExcludeFunctions`, which was originally adopted for `cache` options in #1047 but is no longer needed since we moved those out to `h3/rules` in #4411.

let me know if you'd like any changes, or if you think we might need a runtime warning as well as just disallowing this at the type level 🙏


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
