### PR TITLE
fix(vercel): match ISR route rules against the route pattern

### DIFF
--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -176,13 +176,7 @@ export async function generateFunctionFiles(nitro: Nitro) {
   if (o11Routes.length === 0) {
     return;
   }
-  const _getRouteRules = (path: string) =>
-    defu({}, ...nitro.routing.routeRules.matchAll("", path).reverse()) as NitroRouteRules;
   for (const route of o11Routes) {
-    const routeRules = _getRouteRules(route.src);
-    if (routeRules.isr) {
-      continue; // #3563
-    }
     const funcPrefix = resolve(nitro.options.output.serverDir, "..", route.dest);
     const funcDir = funcPrefix + ".func";
 
@@ -631,6 +625,17 @@ export function getObservabilityRoutes(nitro: Nitro): ObservabilityRoute[] {
   );
 
   // Sort routes by how much specific they are
+  // ISR-ruled paths are served through the ISR rewrite machinery, so they get
+  // neither an observability function nor a `config.json` route entry (#3563).
+  // Rules have to be matched against the route pattern rather than the compiled
+  // `src`: a `:param` segment compiles to `(?<id>[^/]+)`, and the `/` inside
+  // that character class splits into extra path segments, so a dynamic route
+  // never matched its own rule (#4447).
+  const hasISRRule = (route: string) =>
+    Boolean(
+      (defu({}, ...nitro.routing.routeRules.matchAll("", route).reverse()) as NitroRouteRules).isr
+    );
+
   const routePatterns = [
     ...new Set([
       ...(nitro.options.ssrRoutes || []),
@@ -638,7 +643,9 @@ export function getObservabilityRoutes(nitro: Nitro): ObservabilityRoute[] {
         .filter((h) => !h.middleware && h.route)
         .map((h) => h.route!),
     ]),
-  ].filter((route) => !prerenderedPaths.has(route.replace(SURROUNDING_SLASH_RE, "")));
+  ].filter(
+    (route) => !prerenderedPaths.has(route.replace(SURROUNDING_SLASH_RE, "")) && !hasISRRule(route)
+  );
 
   const staticRoutes: string[] = [];
   const dynamicRoutes: string[] = [];

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -624,7 +624,6 @@ export function getObservabilityRoutes(nitro: Nitro): ObservabilityRoute[] {
       .map((route) => route.route.replace(SURROUNDING_SLASH_RE, ""))
   );
 
-  // Sort routes by how much specific they are
   // ISR-ruled paths are served through the ISR rewrite machinery, so they get
   // neither an observability function nor a `config.json` route entry (#3563).
   // Rules have to be matched against the route pattern rather than the compiled
@@ -636,6 +635,7 @@ export function getObservabilityRoutes(nitro: Nitro): ObservabilityRoute[] {
       (defu({}, ...nitro.routing.routeRules.matchAll("", route).reverse()) as NitroRouteRules).isr
     );
 
+  // Sort routes by how much specific they are
   const routePatterns = [
     ...new Set([
       ...(nitro.options.ssrRoutes || []),

--- a/test/unit/vercel-observability-routes.test.ts
+++ b/test/unit/vercel-observability-routes.test.ts
@@ -1,21 +1,29 @@
 import { describe, expect, it } from "vitest";
-import type { Nitro, NitroEventHandler, PrerenderRoute } from "nitro/types";
+import type { Nitro, NitroEventHandler, NitroRouteRules, PrerenderRoute } from "nitro/types";
 
 import { getObservabilityRoutes } from "../../src/presets/vercel/utils.ts";
+import { Router } from "../../src/routing.ts";
 
 function createNitroStub(opts: {
   compatibilityDate?: string;
   handlers?: NitroEventHandler[];
   ssrRoutes?: string[];
   prerenderedRoutes?: PrerenderRoute[];
+  routeRules?: Record<string, NitroRouteRules>;
 }): Nitro {
+  const routeRules = new Router<NitroRouteRules>();
+  routeRules._update(
+    Object.entries(opts.routeRules || {}).map(([route, data]) => ({ route, method: "", data }))
+  );
   return {
     scannedHandlers: opts.handlers || [],
     _prerenderedRoutes: opts.prerenderedRoutes,
+    routing: { routeRules },
     options: {
       compatibilityDate: { default: opts.compatibilityDate || "2025-07-15" },
       handlers: [],
       ssrRoutes: opts.ssrRoutes || [],
+      routeRules: opts.routeRules || {},
     },
   } as unknown as Nitro;
 }
@@ -154,5 +162,76 @@ describe("getObservabilityRoutes", () => {
     expect(dests(createNitroStub({ handlers: [{ route: "/foo", handler: "foo.ts" }] }))).toEqual([
       "foo",
     ]);
+  });
+
+  // Regression: https://github.com/nitrojs/nitro/issues/4447
+  //
+  // ISR-ruled paths are served through the ISR rewrite machinery, so they must
+  // get neither an observability function nor a `config.json` route entry.
+  // The skip used to be decided against the *compiled* `src`: a `:param`
+  // segment compiles to `(?<id>[^/]+)`, whose literal `/` inside the character
+  // class splits into extra path segments, so `/users/:id` never matched its
+  // own rule and the build emitted a plain function competing with the ISR one.
+  describe("ISR route rules", () => {
+    it("skips a dynamic route whose rule enables ISR", () => {
+      expect(
+        getObservabilityRoutes(
+          createNitroStub({
+            handlers: [{ route: "/users/:id", handler: "user.ts" }],
+            routeRules: { "/users/:id": { isr: 60 } },
+          })
+        )
+      ).toEqual([]);
+    });
+
+    it("skips static and catch-all routes whose rule enables ISR", () => {
+      expect(
+        dests(
+          createNitroStub({
+            handlers: [
+              { route: "/schedule", handler: "schedule.ts" },
+              { route: "/catchall/**", handler: "catchall.ts" },
+            ],
+            routeRules: { "/schedule": { isr: 300 }, "/catchall/**": { isr: 60 } },
+          })
+        )
+      ).toEqual([]);
+    });
+
+    it("skips a route covered by a wildcard ISR rule", () => {
+      expect(
+        dests(
+          createNitroStub({
+            handlers: [{ route: "/users/:id", handler: "user.ts" }],
+            routeRules: { "/users/**": { isr: 60 } },
+          })
+        )
+      ).toEqual([]);
+    });
+
+    it("keeps routes whose rules do not enable ISR", () => {
+      expect(
+        dests(
+          createNitroStub({
+            handlers: [
+              { route: "/users/:id", handler: "user.ts" },
+              { route: "/plain", handler: "plain.ts" },
+            ],
+            routeRules: { "/users/:id": { isr: false }, "/plain": { swr: true } },
+          })
+        )
+      ).toEqual(["plain", "users/[id]"]);
+    });
+
+    it("keeps routes when no rule matches", () => {
+      expect(
+        dests(
+          createNitroStub({
+            handlers: [{ route: "/users/:id", handler: "user.ts" }],
+            routeRules: { "/other/**": { isr: 60 } },
+          })
+        )
+      ).toEqual(["users/[id]"]);
+    });
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4447

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The observability-function skip for ISR routes was decided with `_getRouteRules(route.src)`, and `route.src` is the compiled PCRE rather than a path. A `:param` segment compiles to `(?<id>[^/]+)`, and the literal `/` inside that character class makes rou3 split the value into extra segments, so a dynamic route never matched its own rule:

```js
routeRules.matchAll("", "/users/:id")           // { isr: 60 }
routeRules.matchAll("", "/users/(?<id>[^/]+)")  // undefined
"/users/(?<id>[^/]+)".split("/")                // ["", "users", "(?<id>[^", "]+)"]
```

A catch-all compiles to `.+`, which has no slash in it, so it did match and its function was skipped correctly. That asymmetry is why the issue reports two different symptoms from one cause: dynamic routes emit a plain function competing with the ISR one, while static and catch-all routes emit a `config.json` entry whose `dest` was never created.

Reproduced against `main` (1a7c9b8e) with the reporter's three-rule config on the `vercel` preset:

```
before                                          after
  users/[id].func + users/[id]-isr.func           users/[id]-isr.func only
  {"src":"/schedule","dest":"/schedule"}          removed
  {"src":"/catchall/?(?<slug>.+)", ...}           removed
  /plain, / -> function + route entry             unchanged
```

The dangling entries were not fully shadowed by the ISR rewrites either: the o11y catch-all src `/catchall/?(?<slug>.+)` makes the separator optional, so `/catchallx` matched it without matching the ISR src `/catchall/(?:.*)` and landed on a `dest` with no function behind it. It now falls through to the fallback route.

**Why the check moved instead of the argument being corrected.** `generateBuildConfig(nitro, o11Routes)` runs at the top of `generateFunctionFiles`, before the skip loop, so passing the right value at the call site would still have left the `config.json` entries for skipped functions. `getObservabilityRoutes` already filters prerendered routes and still holds the uncompiled pattern, so doing it there makes both consumers read the same filtered list and they cannot drift apart. The in-loop check is removed rather than adjusted.

Tests are five cases in `test/unit/vercel-observability-routes.test.ts`. Three fail before and pass after (dynamic, static + catch-all, and a route covered by a wildcard ISR rule); two are controls that pass either way (a rule without ISR, and no matching rule) to guard against over-filtering.

Not addressed here: `routeFuncRouter?.match("", route.src)` a few lines below passes the same compiled `src`, so `functionRules` should mismatch on dynamic routes for the same reason. I have not verified the impact there and left it out of scope.

The analysis and patch were agent-assisted, as noted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
