### PR TITLE
fix(vite): run `close` hooks when the dev server shuts down

### DIFF
--- a/src/build/vite/dev.ts
+++ b/src/build/vite/dev.ts
@@ -231,6 +231,23 @@ export async function configureViteDevServer(ctx: NitroPluginContext, server: Vi
     rootDirWatcher.close();
   });
 
+  // Vite only installs a `SIGTERM` handler, so Ctrl+C (`SIGINT`) tears the process down before
+  // any `close` hook runs and leaves the dev worker (and its resources) behind (#4586). In
+  // middleware mode the embedding server owns the process signals, so it is left alone.
+  if (!server.config.server.middlewareMode) {
+    const onSigint = async () => {
+      try {
+        await server.close();
+      } finally {
+        process.exit(130);
+      }
+    };
+    process.once("SIGINT", onSigint);
+    nitro.hooks.hook("close", () => {
+      process.off("SIGINT", onSigint);
+    });
+  }
+
   // Worker => Host RPC
   nitroEnv.devServer.onMessage(async (message: any) => {
     if (message?.__rpc === "transformHTML") {

--- a/src/build/vite/env.ts
+++ b/src/build/vite/env.ts
@@ -8,6 +8,7 @@ import { runtimeDependencies, runtimeDir } from "nitro/meta";
 import { resolveModulePath } from "exsolve";
 import { isAbsolute } from "pathe";
 import { resolveMiniflareDeps, resolveRunnerDeps } from "../../dev/runner-deps.ts";
+import { shutdownRunner } from "../../dev/shutdown.ts";
 import { writeDevWorkerEntry } from "./_dev-worker.ts";
 
 export function createNitroEnvironment(ctx: NitroPluginContext): EnvironmentOptions {
@@ -124,6 +125,9 @@ export async function initEnvRunner(ctx: NitroPluginContext) {
       const manager = new RunnerManager();
       let _retries = 0;
       manager.onClose((_runner, cause) => {
+        if (ctx._closingEnvRunner) {
+          return;
+        }
         if (_retries++ < 3) {
           ctx.nitro!.logger.info("Restarting env runner...", cause ? `Cause: ${cause}` : "");
           _loadRunner(ctx, manager);
@@ -159,6 +163,24 @@ export function getEnvRunner(ctx: NitroPluginContext) {
     throw new Error("Env runner not initialized. Call initEnvRunner() first.");
   }
   return ctx._envRunner;
+}
+
+/**
+ * Shut the dev runner down gracefully: the runtime `close` hooks run in the worker before the
+ * runtime is terminated (#4586).
+ */
+export async function closeEnvRunner(ctx: NitroPluginContext) {
+  const manager = ctx._envRunner;
+  if (!manager || ctx._closingEnvRunner) {
+    return;
+  }
+  ctx._closingEnvRunner = true;
+  // The miniflare runner runs the same handshake itself when it is disposed, so it is only
+  // needed for the runners that terminate their runtime outright.
+  if (manager.ready && !_isWorkerdRunner(ctx)) {
+    await shutdownRunner(manager, { warn: (message) => ctx.nitro!.logger.warn(message) });
+  }
+  await manager.close();
 }
 
 export async function reloadEnvRunner(ctx: NitroPluginContext) {

--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -16,6 +16,7 @@ import { buildEnvironments } from "./prod.ts";
 import {
   initEnvRunner,
   getEnvRunner,
+  closeEnvRunner,
   createNitroEnvironment,
   createServiceEnvironments,
   createServiceEnvironment,
@@ -297,6 +298,19 @@ function nitroMain(ctx: NitroPluginContext): VitePlugin {
       return configureViteDevServer(ctx, server);
     },
 
+    // Closing the dev server closes every environment, and each of them runs `closeBundle`.
+    // Nitro is shared by all of them, so its `close` hooks run once (#4586). The production
+    // build closes Nitro itself (see `prod.ts`).
+    closeBundle: {
+      order: "post",
+      handler() {
+        if (!ctx.nitro?.options.dev) {
+          return;
+        }
+        return (ctx._closePromise ??= ctx.nitro.close());
+      },
+    },
+
     // Invalidate server-only modules and optionally reload the browser
     // see: https://github.com/vitejs/vite/issues/19114
     async hotUpdate({ server, file, modules, timestamp }) {
@@ -499,9 +513,7 @@ async function setupNitroContext(
 
   // Cleanup resources after close {
   ctx.nitro.hooks.hook("close", async () => {
-    if (ctx._envRunner) {
-      await ctx._envRunner.close();
-    }
+    await closeEnvRunner(ctx);
   });
 }
 

--- a/src/build/vite/types.ts
+++ b/src/build/vite/types.ts
@@ -61,6 +61,8 @@ export interface NitroPluginContext {
   _isRolldown?: boolean;
   _initialized?: boolean;
   _envRunner?: RunnerManager;
+  _closingEnvRunner?: boolean;
+  _closePromise?: Promise<void>;
   _initPromise?: Promise<RunnerManager>;
   _viteEnvs?: Map<string, string>;
   _transformRequest?: (id: string) => Promise<TransformResult | null | undefined>;

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -17,9 +17,8 @@ import { debounce } from "perfect-debounce";
 import { isTest, isCI } from "std-env";
 import { NitroDevApp } from "./app.ts";
 import { resolveRunnerDeps } from "./runner-deps.ts";
+import { shutdownRunner } from "./shutdown.ts";
 import { writeDevBuildInfo } from "../build/info.ts";
-
-const SHUTDOWN_TIMEOUT = 5000;
 
 export function createDevServer(nitro: Nitro): NitroDevServer {
   return new NitroDevServer(nitro);
@@ -223,31 +222,7 @@ export class NitroDevServer extends NitroDevApp implements RunnerRPCHooks {
     }
     this.#shuttingDown = true;
     try {
-      await new Promise<void>((resolve) => {
-        const done = () => {
-          clearTimeout(timer);
-          this.#manager.offMessage(listener);
-          resolve();
-        };
-        const timer = setTimeout(() => {
-          this.nitro.logger.warn("Dev worker did not shut down in time, force closing it...");
-          done();
-        }, SHUTDOWN_TIMEOUT);
-        const listener = (message: any) => {
-          if (message?.event === "exit") {
-            done();
-          }
-        };
-        this.#manager.onMessage(listener);
-        try {
-          this.#manager.sendMessage({ event: "shutdown" });
-        } catch (error) {
-          this.nitro.logger.warn(
-            `Could not send shutdown message to the dev worker: ${error instanceof Error ? error.message : String(error)}`
-          );
-          done();
-        }
-      });
+      await shutdownRunner(this.#manager, { warn: (message) => this.nitro.logger.warn(message) });
     } finally {
       this.#shuttingDown = false;
     }

--- a/src/dev/shutdown.ts
+++ b/src/dev/shutdown.ts
@@ -1,0 +1,40 @@
+import type { RunnerManager } from "env-runner";
+
+const SHUTDOWN_TIMEOUT = 5000;
+
+/**
+ * Ask the dev runner to shut down gracefully and wait for it to acknowledge.
+ *
+ * Closing a runner terminates its runtime outright, so the runtime `close` hooks only run when
+ * the worker is given a chance to run them first (`ipc.onClose` in the dev entries).
+ */
+export async function shutdownRunner(
+  manager: RunnerManager,
+  opts: { warn?: (message: string) => void } = {}
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      manager.offMessage(listener);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      opts.warn?.("Dev worker did not shut down in time, force closing it...");
+      done();
+    }, SHUTDOWN_TIMEOUT);
+    const listener = (message: any) => {
+      if (message?.event === "exit") {
+        done();
+      }
+    };
+    manager.onMessage(listener);
+    try {
+      manager.sendMessage({ event: "shutdown" });
+    } catch (error) {
+      opts.warn?.(
+        `Could not send shutdown message to the dev worker: ${error instanceof Error ? error.message : String(error)}`
+      );
+      done();
+    }
+  });
+}

--- a/src/runtime/internal/vite/dev-entry.mjs
+++ b/src/runtime/internal/vite/dev-entry.mjs
@@ -1,7 +1,7 @@
 import "#nitro/virtual/polyfills";
 import wsAdapter from "crossws/adapters/node";
 
-import { useNitroApp } from "nitro/app";
+import { useNitroApp, useNitroHooks } from "nitro/app";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 import { startScheduleRunner } from "#nitro/runtime/task";
 
@@ -16,3 +16,6 @@ if (import.meta._tasks) {
 }
 
 export const handleUpgrade = ws?.handleUpgrade;
+
+// Called by the dev worker when the runner shuts down (see `ipc.onClose` in `dev-worker.mjs`).
+export const close = () => useNitroHooks().callHook("close");

--- a/src/runtime/internal/vite/dev-worker.mjs
+++ b/src/runtime/internal/vite/dev-worker.mjs
@@ -152,6 +152,16 @@ class ViteEnvRunner {
     return !!file && !!this.runner.evaluatedModules.getModulesByFile(file)?.size;
   }
 
+  // Runs the environment's `close` hooks before the runner goes away. Waits for any in-flight
+  // reload so the entry the hooks belong to is the one that is closed.
+  async close() {
+    await this.reloadPromise;
+    const entryClose = this.entry?.close || this.entry?.default?.close;
+    if (entryClose) {
+      await entryClose();
+    }
+  }
+
   // Errors are intentionally not caught here: like production services,
   // they propagate to the caller (the nitro app's error handler or the
   // env-runner fetch boundary below).
@@ -308,7 +318,15 @@ export const ipc = {
       listener(message);
     }
   },
-  onClose() {},
+  async onClose() {
+    await Promise.all(
+      Object.values(envs).map((env) =>
+        env?.close().catch((error) => {
+          console.error(error);
+        })
+      )
+    );
+  },
 };
 
 // ----- Error handling -----

--- a/test/vite/close-hook-fixture/api/hello.ts
+++ b/test/vite/close-hook-fixture/api/hello.ts
@@ -1,0 +1,1 @@
+export default () => "hello";

--- a/test/vite/close-hook-fixture/plugins/close.ts
+++ b/test/vite/close-hook-fixture/plugins/close.ts
@@ -1,0 +1,14 @@
+import { appendFileSync } from "node:fs";
+import { definePlugin } from "nitro";
+
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks.hook("close", async () => {
+    const log = process.env.NITRO_TEST_CLOSE_LOG;
+    if (!log) {
+      return;
+    }
+    // Deliberately async: the assertion only holds if `close` hooks are awaited.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    appendFileSync(log, "runtime:close\n");
+  });
+});

--- a/test/vite/close-hook-fixture/vite.config.ts
+++ b/test/vite/close-hook-fixture/vite.config.ts
@@ -1,0 +1,19 @@
+import { appendFileSync } from "node:fs";
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    nitro({
+      serverDir: "./",
+      hooks: {
+        close() {
+          const log = process.env.NITRO_TEST_CLOSE_LOG;
+          if (log) {
+            appendFileSync(log, "build:close\n");
+          }
+        },
+      },
+    }),
+  ],
+});

--- a/test/vite/close-hook.test.ts
+++ b/test/vite/close-hook.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execa } from "execa";
+import { isWindows } from "std-env";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "pathe";
+import type { ViteDevServer } from "vite";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+const { createServer } = (await import(
+  process.env.NITRO_VITE_PKG || "vite"
+)) as typeof import("vite");
+
+// #4586: stopping the Vite dev server must run the Nitro `close` hooks, both the build-time
+// ones (`nitro({ hooks })`) and the runtime ones registered by server plugins in the dev worker.
+describe("vite: close hooks", { sequential: true }, () => {
+  let server: ViteDevServer;
+  let serverURL: string;
+  let logFile: string;
+  let tmpDir: string;
+
+  const rootDir = fileURLToPath(new URL("./close-hook-fixture", import.meta.url));
+  const originalCwd = process.cwd();
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nitro-close-hook-"));
+    logFile = join(tmpDir, "close.log");
+    writeFileSync(logFile, "");
+    process.env.NITRO_TEST_CLOSE_LOG = logFile;
+    process.chdir(rootDir);
+    server = await createServer({ root: rootDir, logLevel: "warn" });
+    await server.listen("0" as unknown as number);
+    const addr = server.httpServer?.address() as { port: number; address: string; family: string };
+    serverURL = `http://${addr.family === "IPv6" ? `[${addr.address}]` : addr.address}:${addr.port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server?.close().catch(() => {});
+    process.chdir(originalCwd);
+    delete process.env.NITRO_TEST_CLOSE_LOG;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("runs build-time and runtime close hooks on `server.close()`", async () => {
+    // Make sure the dev worker actually evaluated the app (and its plugins).
+    expect(await (await fetch(`${serverURL}/api/hello`)).text()).toContain("hello");
+
+    await server.close();
+
+    const log = readFileSync(logFile, "utf8").split("\n").filter(Boolean);
+    expect(log).toContain("build:close");
+    expect(log).toContain("runtime:close");
+  }, 30_000);
+
+  // Vite only installs a `SIGTERM` handler, so the `SIGINT` of a Ctrl+C has to be handled by
+  // Nitro itself — this runs a real dev server in a child process and signals it.
+  test.skipIf(isWindows)(
+    "runs close hooks on SIGINT",
+    async () => {
+      const sigintLog = join(tmpDir, "sigint.log");
+      writeFileSync(sigintLog, "");
+      const script = join(tmpDir, "dev.mjs");
+      writeFileSync(
+        script,
+        [
+          `import { createServer } from ${JSON.stringify(import.meta.resolve(process.env.NITRO_VITE_PKG || "vite"))};`,
+          `const server = await createServer({ root: ${JSON.stringify(rootDir)}, logLevel: "warn" });`,
+          `await server.listen(0);`,
+          `console.log("ready:" + server.httpServer.address().port);`,
+        ].join("\n")
+      );
+
+      const child = execa(process.execPath, [script], {
+        cwd: rootDir,
+        env: { ...process.env, NITRO_TEST_CLOSE_LOG: sigintLog },
+        reject: false,
+      });
+
+      let output = "";
+      child.stdout!.on("data", (data) => (output += data));
+      child.stderr!.on("data", (data) => (output += data));
+      try {
+        const deadline = Date.now() + 30_000;
+        while (!/ready:\d+/.test(output) && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        const port = Number(output.match(/ready:(\d+)/)?.[1]);
+        expect(port).toBeGreaterThan(0);
+        expect(await (await fetch(`http://localhost:${port}/api/hello`)).text()).toContain("hello");
+
+        child.kill("SIGINT");
+        await child;
+
+        const log = readFileSync(sigintLog, "utf8").split("\n").filter(Boolean);
+        expect(log).toContain("build:close");
+        expect(log).toContain("runtime:close");
+      } finally {
+        child.kill("SIGKILL");
+      }
+    },
+    60_000
+  );
+});


### PR DESCRIPTION
Closes #4586

Stopping a Vite dev server never ran Nitro's `close` hooks — neither the build-time ones (`nitro({ hooks: { close } })`) nor the runtime ones registered by server plugins. Three separate gaps, all on the Vite path:

1. **`nitro.close()` was never called.** Nothing in the Vite plugin closed the Nitro instance on dev-server shutdown, so config `hooks.close` (and everything registered on `nitro.hooks`) never ran. Only the production build (`prod.ts`) closed it.
2. **The dev worker was killed, not shut down.** `RunnerManager.close()` terminates the runtime outright. `src/dev/server.ts` (the non-Vite dev server) has a `{event:"shutdown"}` → `{event:"exit"}` handshake for exactly this; the Vite path had none. And even with one, `ipc.onClose()` in `dev-worker.mjs` was empty and `dev-entry.mjs` exported no `close`.
3. **Ctrl+C.** Vite only installs a `SIGTERM` listener (there is no `SIGINT` handling anywhere in `vite@8.2.2`), so SIGINT tore the process down before `server.close()` ran at all.

## Changes

- `src/dev/shutdown.ts` (new) — `shutdownRunner()`, extracted from `NitroDevServer.#shutdownWorker`, now shared by both dev paths.
- `src/build/vite/env.ts` — `closeEnvRunner()` performs the handshake before `manager.close()`, and the `onClose` retry logic is suppressed during shutdown so the worker's exit doesn't trigger a restart. Skipped for the miniflare runner, which already runs the same handshake in its own `_closeRuntime`.
- `src/build/vite/plugin.ts` — a dev-only `closeBundle` hook calls `ctx.nitro.close()`, memoized on the plugin context since Vite runs `closeBundle` once per environment.
- `src/runtime/internal/vite/dev-entry.mjs` / `dev-worker.mjs` — the entry exports `close` (calling `useNitroHooks().callHook("close")`), and `ipc.onClose` awaits it for every registered environment.
- `src/build/vite/dev.ts` — a `SIGINT` handler mirroring Vite's own SIGTERM behaviour (`server.close()` then `process.exit(130)`), skipped in middleware mode where the embedding server owns process signals, and removed again on close.

## Tests

`test/vite/close-hook.test.ts` + `test/vite/close-hook-fixture` cover both shutdown paths: an in-process `server.close()` and a real dev server in a child process signalled with `SIGINT`. Both assert that the build-time and runtime hooks ran, and both fail on `main`.

`pnpm lint`, `pnpm typecheck`, `pnpm test:rollup` and `pnpm test:rolldown` pass.

🤖 Generated with AI assistant
