### PR TITLE
feat(scan): support `QUERY` method suffix for file-based routes

### DIFF
--- a/docs/1.docs/5.routing.md
+++ b/docs/1.docs/5.routing.md
@@ -149,7 +149,11 @@ Hello nitro/is/hot!
 
 You can append the HTTP method to the filename to force the route to be matched only for a specific HTTP request method, for example `hello.get.ts` will only match for `GET` requests. You can use any HTTP method you want.
 
-Supported methods: `get`, `post`, `put`, `delete`, `patch`, `head`, `options`, `connect`, `trace`.
+Supported methods: `get`, `post`, `put`, `delete`, `patch`, `head`, `options`, `query`, `connect`, `trace`.
+
+::note
+`query` matches the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/), a safe and idempotent alternative to `GET` that carries a request body. Support across proxies, CDNs and deployment platforms is still uneven, so keep a `GET` or `POST` fallback for public APIs.
+::
 
 ::code-group
 ```ts [GET]

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -7,10 +7,10 @@ export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
 type FileInfo = { path: string; fullPath: string };
 
 const suffixRegex =
-  /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?(\.(?<env>dev|prod|prerender))?$/;
+  /(\.(?<method>connect|delete|get|head|options|patch|post|put|query|trace))?(\.(?<env>dev|prod|prerender))?$/;
 
 // prettier-ignore
-type MatchedMethodSuffix = "connect" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "trace";
+type MatchedMethodSuffix = "connect" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "query" | "trace";
 type MatchedEnvSuffix = "dev" | "prod" | "prerender";
 
 export async function scanAndSyncOptions(nitro: Nitro) {

--- a/test/fixture/server/routes/api/methods/search.get.ts
+++ b/test/fixture/server/routes/api/methods/search.get.ts
@@ -1,0 +1,1 @@
+export default () => "get";

--- a/test/fixture/server/routes/api/methods/search.query.ts
+++ b/test/fixture/server/routes/api/methods/search.query.ts
@@ -1,0 +1,1 @@
+export default () => "query";

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -373,6 +373,10 @@ describe("nitro:preset:vercel:web", async () => {
                 "src": "/api/middleware-order",
               },
               {
+                "dest": "/api/methods/search",
+                "src": "/api/methods/search",
+              },
+              {
                 "dest": "/api/methods/get",
                 "src": "/api/methods/get",
               },
@@ -567,6 +571,7 @@ describe("nitro:preset:vercel:web", async () => {
             "functions/api/meta/test.func (symlink)",
             "functions/api/methods/foo.get.func (symlink)",
             "functions/api/methods/get.func (symlink)",
+            "functions/api/methods/search.func (symlink)",
             "functions/api/middleware-order.func (symlink)",
             "functions/api/param/[test-id].func (symlink)",
             "functions/api/storage/item.func (symlink)",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -829,6 +829,13 @@ export function testNitro(
       expect((await callHandler({ url: "/api/methods/get" })).data).toBe("get");
       expect((await callHandler({ url: "/api/methods/foo.get" })).data).toBe("foo.get");
     });
+
+    it("Matches the QUERY method suffix", async () => {
+      expect((await callHandler({ url: "/api/methods/search", method: "QUERY" })).data).toBe(
+        "query"
+      );
+      expect((await callHandler({ url: "/api/methods/search" })).data).toBe("get");
+    });
   });
 
   // WinterJS itself runs as WebAssembly and exposes no `WebAssembly` global


### PR DESCRIPTION
Adds the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) — a safe, idempotent alternative to `GET` that carries a request body — to file-based route scanning.

### Changes

- `src/scan.ts`: added `query` to the filename method-suffix regex and `MatchedMethodSuffix`, so `routes/search.query.ts` registers as a `QUERY`-only route (and composes with the env suffixes, e.g. `search.query.prod.ts`).
- `docs/1.docs/5.routing.md`: listed `query` among the supported suffixes, with a note that proxy/CDN/platform support for the verb is still uneven.
- Regression test: `test/fixture/server/routes/api/methods/search.query.ts` + `search.get.ts`, and a case in `test/tests.ts` asserting a `QUERY` request reaches the `.query` handler while `GET` on the same path still reaches the `.get` one. It fails on the unpatched scanner (404) and passes after.
- Two Vercel inline snapshots updated for the new fixture route.

### Notes

This is the only Nitro-side change needed — everything downstream is already method-agnostic. `src/routing.ts` and `src/build/virtual/routing.ts` pass the method through as an opaque string, and `rou3` uppercases it at match time. h3 v2 (rc.31, already pinned) has `QUERY` in both its `HTTPMethod` type and its `HTTP_METHODS` set, so `defineHandler`/config handlers with `method: "QUERY"`, the `app.query()` shorthand, and method-scoped route rules like `"QUERY /api/**"` worked already.

The Azure Functions `httpTrigger` method list in `src/presets/azure/utils.ts` was left alone — it is a platform-supported list that already omits `connect`/`trace`.

Unrelated pre-existing wrinkle spotted while working on this, not addressed here: `NitroEventHandler.method` is typed as h3's `HTTPMethod` (uppercase only), while the scanner produces lowercase and `docs/3.config` documents `method: "post"`. A config handler written as `method: "query"` (or `"post"`) is a type error today even though it works at runtime.

### Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test:rollup` and `pnpm test:rolldown` all pass (1073 tests each). The new test passes on every preset covered by `testNitro`, including cloudflare/miniflare, aws-lambda, netlify, deno, bun and winterjs.

🤖 Generated with AI assistant
