### PR TITLE
fix(scan): only auto-register `modules/*` and `modules/*/index` files

### DIFF
--- a/docs/1.docs/55.modules.md
+++ b/docs/1.docs/55.modules.md
@@ -69,6 +69,13 @@ Each entry can be one of the following forms:
 
 Files in the `modules/` directory are automatically registered as modules (like `plugins/` for [runtime plugins](/docs/plugins)).
 
+Only two patterns are auto-registered:
+
+- `modules/*.ts` (a single-file module)
+- `modules/*/index.ts` (a directory module)
+
+Any other file inside `modules/` (for example a module's own `runtime/` files) is ignored by the scanner.
+
 Modules referenced by path or package name are resolved and installed **only once**; duplicate entries pointing to the same file are skipped.
 
 ::tip

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -4,6 +4,13 @@ import { join, relative } from "pathe";
 import { withBase, withLeadingSlash, withoutTrailingSlash } from "ufo";
 
 export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
+
+// Modules are only auto-registered from `modules/*.ts` and `modules/*/index.ts`
+// so that a module's own nested files are not registered as modules themselves.
+const GLOB_MODULES_SCAN_PATTERN = [
+  "*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}",
+  "*/index.{js,mjs,cjs,ts,mts,cts,tsx,jsx}",
+];
 type FileInfo = { path: string; fullPath: string };
 
 const suffixRegex =
@@ -132,19 +139,29 @@ export async function scanTasks(nitro: Nitro) {
 }
 
 export async function scanModules(nitro: Nitro) {
-  const files = await scanFiles(nitro, "modules");
+  const files = await scanFiles(nitro, "modules", GLOB_MODULES_SCAN_PATTERN);
   return files.map((f) => f.fullPath);
 }
 
-async function scanFiles(nitro: Nitro, name: string): Promise<FileInfo[]> {
+async function scanFiles(
+  nitro: Nitro,
+  name: string,
+  pattern: string | string[] = GLOB_SCAN_PATTERN
+): Promise<FileInfo[]> {
   const files = await Promise.all(
-    nitro.options.scanDirs.map((dir) => scanDir(nitro, dir, name))
+    nitro.options.scanDirs.map((dir) => scanDir(nitro, dir, name, pattern))
   ).then((r) => r.flat());
   return files;
 }
 
-async function scanDir(nitro: Nitro, dir: string, name: string): Promise<FileInfo[]> {
-  const fileNames = await glob(join(name, GLOB_SCAN_PATTERN), {
+async function scanDir(
+  nitro: Nitro,
+  dir: string,
+  name: string,
+  pattern: string | string[]
+): Promise<FileInfo[]> {
+  const patterns = (Array.isArray(pattern) ? pattern : [pattern]).map((p) => join(name, p));
+  const fileNames = await glob(patterns, {
     cwd: dir,
     dot: true,
     ignore: nitro.options.ignore,

--- a/test/unit/scan-modules.test.ts
+++ b/test/unit/scan-modules.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { scanModules, scanPlugins } from "../../src/scan.ts";
+import type { Nitro } from "nitro/types";
+
+let dir: string;
+
+function write(path: string, contents = "export default {}") {
+  const fullPath = join(dir, path);
+  mkdirSync(join(fullPath, ".."), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+const nitro = () =>
+  ({
+    options: { scanDirs: [dir], ignore: [] },
+    logger: console,
+  }) as unknown as Nitro;
+
+const rel = (files: string[]) => files.map((f) => f.slice(dir.length + 1)).sort();
+
+describe("scanModules", () => {
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "nitro-scan-"));
+    write("modules/log/index.ts");
+    write("modules/log/runtime/routes/log.ts");
+    write("modules/log/utils.ts");
+    write("modules/inline.ts");
+    write("modules/nested/deep/index.ts");
+    write("plugins/nested/plugin.ts");
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("only registers `modules/*.ts` and `modules/*/index.ts`", async () => {
+    expect(rel(await scanModules(nitro()))).toEqual(["modules/inline.ts", "modules/log/index.ts"]);
+  });
+
+  it("still scans other dirs recursively", async () => {
+    expect(rel(await scanPlugins(nitro()))).toEqual(["plugins/nested/plugin.ts"]);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> **AI-generated PR.** This change was prepared autonomously by an AI triage agent and has
> not yet been reviewed by a human. Review the diff and the reasoning carefully before merging.

Every file under `modules/` was auto-registered as a module, because `scanModules()` reused the recursive glob shared with `plugins/` and route scanning. So a module's own nested files — `modules/log/runtime/routes/log.ts` next to `modules/log/index.ts` — got installed as modules too.

Now only `modules/*.ts` and `modules/*/index.ts` are picked up, matching what Nuxt does. `scanFiles`/`scanDir` take an optional pattern, so plugins, tasks, middleware and routes are unchanged.

Tested with a new unit test (`test/unit/scan-modules.test.ts`) over a temp dir: it fails before the change (5 files returned) and passes after (2). Rest of `test/unit` passes, `pnpm fmt` and `pnpm typecheck` clean.

Fixes #2680

🤖 Generated with AI assistant
