### PR TITLE
docs(vercel): note cron endpoint is unauthenticated without `CRON_SECRET`

### DIFF
--- a/docs/2.deploy/20.providers/vercel.md
+++ b/docs/2.deploy/20.providers/vercel.md
@@ -153,7 +153,11 @@ export default defineConfig({
 
 :read-more{title="Securing cron jobs" to="https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs"}
 
-To prevent unauthorized access to the cron handler, set a `CRON_SECRET` environment variable in your Vercel project settings. When `CRON_SECRET` is set, Nitro validates the `Authorization` header on every cron invocation.
+To prevent unauthorized access to the cron handler, set a `CRON_SECRET` environment variable in your Vercel project settings. When `CRON_SECRET` is set, Nitro validates the `Authorization` header on every cron invocation and rejects mismatches with `401`.
+
+::warning
+`CRON_SECRET` is **not** set by default. Matching [Vercel's own behaviour](https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs), the cron endpoint (`/_vercel/cron`, configurable via [`vercel.cronHandlerRoute`](#other-preset-options)) performs no authentication when the variable is missing. Anyone who knows the route can then pick a schedule with the `x-vercel-cron-schedule` header and run the tasks registered for it on demand. Always set `CRON_SECRET` when using `scheduledTasks` on Vercel.
+::
 
 ## Queues
 


### PR DESCRIPTION
> [!NOTE]
> **AI-generated PR.** This change was prepared autonomously by an AI triage agent and has
> not yet been reviewed by a human. Review the diff and the reasoning carefully before merging.

Docs only. The Vercel cron handler only checks `CRON_SECRET` when it is set, so with `scheduledTasks` and no secret the endpoint is open and anyone can pick a schedule via the `x-vercel-cron-schedule` header and run those tasks. The docs only described the case where the secret is set.

Adds a warning under "Secure cron job endpoints" saying the secret is unset by default and should always be set on Vercel. Deliberately does not change runtime behaviour — per #4546 that matches Vercel's own model and is a maintainer call.

`pnpm fmt` reports no changes; the anchor and the `::warning` block match existing usage in `docs/`.

Refs #4546

🤖 Generated with AI assistant
