### PR TITLE
fix(vercel): fall back to request query when ISR header lacks the route param

### DIFF
--- a/src/presets/vercel/runtime/isr.ts
+++ b/src/presets/vercel/runtime/isr.ts
@@ -9,12 +9,15 @@ export function isrRouteRewrite(
     queryIndex === -1 ? new URLSearchParams() : new URLSearchParams(reqUrl.slice(queryIndex + 1));
 
   // The ISR routing param is carried by `x-now-route-matches` when Vercel
-  // rewrites via the route regex, otherwise it lives on the request URL.
+  // rewrites via the route regex, and by the request URL otherwise. The header
+  // is an undocumented contract that has changed shape before (#4446), so fall
+  // back to the request URL when the header arrives without the param: the
+  // rewrite writes the identical value into both carriers.
   // `URLSearchParams` already percent-decodes the value once; decoding again
   // would over-decode encoded slugs and throw `URIError` on a literal `%`.
-  const isrURL = xNowRouteMatches
-    ? new URLSearchParams(xNowRouteMatches).get(ISR_URL_PARAM)
-    : reqParams.get(ISR_URL_PARAM);
+  const isrURL =
+    (xNowRouteMatches ? new URLSearchParams(xNowRouteMatches).get(ISR_URL_PARAM) : null) ??
+    reqParams.get(ISR_URL_PARAM);
   if (!isrURL) return;
 
   // Preserve `allowQuery` params, which Vercel forwards onto the rewritten

--- a/test/unit/vercel-isr.test.ts
+++ b/test/unit/vercel-isr.test.ts
@@ -65,6 +65,24 @@ describe("isrRouteRewrite", () => {
         "tag=a&tag=b",
       ]);
     });
+
+    // Regression: https://github.com/nitrojs/nitro/issues/4446
+    // `x-now-route-matches` is an undocumented contract that has changed
+    // before. When it arrives without the ISR routing param, the identical
+    // value is still on the rewritten request URL, so use it instead of
+    // giving up and rendering the app for the internal `-isr` path.
+    it("falls back to the request query when the header has no ISR param", () => {
+      expect(isrRouteRewrite("/schedule-isr?__isr_route=%2Fschedule", "0=schedule")).toEqual([
+        "/schedule",
+        "",
+      ]);
+    });
+
+    it("falls back to the request query and keeps other params", () => {
+      expect(
+        isrRouteRewrite("/schedule-isr?__isr_route=%2Fschedule&lang=es", "0=schedule")
+      ).toEqual(["/schedule", "lang=es"]);
+    });
   });
 
   // Regression: the routing param is already percent-decoded once by


### PR DESCRIPTION
> [!NOTE]
> **AI-generated PR.** This change was prepared autonomously by an AI triage agent and has
> not yet been reviewed by a human. Review the diff and the reasoning carefully before merging.

On Vercel, an ISR route is served by rewriting `/schedule` to `/schedule-isr?__isr_route=/schedule`, and the function has to put the original URL back. The value is written into two places: the `x-now-route-matches` header and the rewritten request URL. `isrRouteRewrite` only looked at the request URL when the header was absent entirely, so a header that arrives *without* `__isr_route` shadowed the query string that still had the right value. When restoration fails the app renders its 404 for the internal `-isr` path, and Vercel stores 404s in the ISR cache.

This makes the query string a fallback rather than an either/or. Nothing changes when the header carries the param, and the header-less path is untouched.

`x-now-route-matches` is undocumented and has changed shape before (#3539, #3595), which is why relying on it alone keeps biting.

Two unit tests in `test/unit/vercel-isr.test.ts` cover a header with only positional capture groups, with and without extra query params. Both fail on `main` and pass here; the rest of `test/unit` and `test/presets/vercel.test.ts` are unchanged.

This is part 2 of the three fixes proposed in #4446. Part 1 there — responding `503` instead of rendering a 404 when the URL cannot be recovered from *any* carrier — is a behaviour decision and is deliberately not in this PR.

Part of #4446

🤖 Generated with AI assistant
