### PR TITLE
feat(cloudflare): support durable instance selection

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -44,7 +44,13 @@ export default defineBuildConfig({
   entries: [
     {
       type: "bundle",
-      input: ["src/builder.ts", "src/cli/index.ts", "src/types/index.ts", "src/vite.ts"],
+      input: [
+        "src/builder.ts",
+        "src/cli/index.ts",
+        "src/types/index.ts",
+        "src/presets/cloudflare/types.ts",
+        "src/vite.ts",
+      ],
       license: { gzip: true },
     },
     {

--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -117,7 +117,7 @@ No manual Wrangler configuration is needed. Nitro handles it for you.
 
 :read-more{title="Durable Objects" to="https://developers.cloudflare.com/durable-objects/"}
 
-This preset extends `cloudflare_module` and routes requests through a [Durable Object](https://developers.cloudflare.com/durable-objects/) instance, enabling stateful features such as WebSocket support (via [CrossWS](https://crossws.h3.dev/adapters/cloudflare#durable-objects)) and in-memory state that persists across requests.
+This preset extends `cloudflare_module` and routes WebSocket upgrades through a [Durable Object](https://developers.cloudflare.com/durable-objects/) instance using [CrossWS](https://crossws.h3.dev/adapters/cloudflare#durable-objects).
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";
@@ -127,7 +127,9 @@ export default defineConfig({
 })
 ```
 
-The preset entry exports a `$DurableObject` class. You need to declare the Durable Object binding and migration in your wrangler config:
+The preset entry exports a `$DurableObject` class. With `cloudflare.deployConfig` enabled, Nitro generates its binding in the default and named Wrangler environments. When no migration history or Durable Object `exports` declaration exists, Nitro generates an initial SQLite migration. Existing lifecycle declarations are preserved and validated by Wrangler. If you manage the lifecycle yourself, include `$DurableObject` in your declarations before deploying.
+
+If you disable `cloudflare.deployConfig`, declare the binding and migration in your Wrangler config:
 
 ```json [wrangler.json]
 {
@@ -142,11 +144,28 @@ The preset entry exports a `$DurableObject` class. You need to declare the Durab
   "migrations": [
     {
       "tag": "v1",
-      "new_classes": ["$DurableObject"]
+      "new_sqlite_classes": ["$DurableObject"]
     }
   ]
 }
 ```
+
+### Binding name
+
+Set `cloudflare.durable.bindingName` to customize the binding name. It defaults to `$DurableObject`; the class name remains `$DurableObject`.
+
+```ts [nitro.config.ts]
+import { defineConfig } from "nitro";
+
+export default defineConfig({
+  preset: "cloudflare_durable",
+  cloudflare: {
+    durable: { bindingName: "MyCustomDO" }
+  }
+});
+```
+
+Nitro generates the matching binding when `cloudflare.deployConfig` is enabled. For manually managed Wrangler configuration, use the same binding name in `durable_objects.bindings`.
 
 You can use the `cloudflare:durable:init` runtime hook to run code when the Durable Object is initialized, and the `cloudflare:durable:alarm` hook to handle [alarms](https://developers.cloudflare.com/durable-objects/api/alarms/).
 
@@ -222,7 +241,6 @@ First make sure to be logged into your Cloudflare account:
 Then you can deploy the application with:
 
 :pm-x{command="wrangler pages deploy"}
-
 
 ## Deploy within CI/CD using GitHub Actions
 

--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -150,9 +150,7 @@ If you disable `cloudflare.deployConfig`, declare the binding and migration in y
 }
 ```
 
-### Binding name
-
-Set `cloudflare.durable.bindingName` to customize the binding name. It defaults to `$DurableObject`; the class name remains `$DurableObject`.
+### Binding and instance selection
 
 ```ts [nitro.config.ts]
 import { defineConfig } from "nitro";
@@ -160,12 +158,36 @@ import { defineConfig } from "nitro";
 export default defineConfig({
   preset: "cloudflare_durable",
   cloudflare: {
-    durable: { bindingName: "MyCustomDO" }
+    deployConfig: true,
+    durable: {
+      bindingName: "NitroDurable",
+      instanceName: "app-server",
+      resolver: "./server/utils/cloudflare-durable-resolver.ts"
+    }
   }
-});
+})
 ```
 
-Nitro generates the matching binding when `cloudflare.deployConfig` is enabled. For manually managed Wrangler configuration, use the same binding name in `durable_objects.bindings`.
+Nitro defaults to one internal binding named `$DurableObject` and one default instance named `server`.
+The optional resolver must export a default function that returns the instance name for a request; returning `undefined` falls back to `instanceName`, then `server`.
+
+```ts [server/utils/cloudflare-durable-resolver.ts]
+import type { CloudflareDurableResolver } from "nitro/presets/cloudflare";
+
+const resolveInstanceName: CloudflareDurableResolver = ({
+  request,
+  defaultInstanceName
+}) => {
+  const room = request
+    ? new URL(request.url).searchParams.get("room")
+    : undefined;
+  return room || defaultInstanceName;
+};
+
+export default resolveInstanceName;
+```
+
+The binding must reference the local `$DurableObject` class. The resolver changes the instance name within that binding. It may be asynchronous and must handle calls without a request. An empty string or `undefined` falls back to `instanceName`. Resolver errors propagate to the caller.
 
 You can use the `cloudflare:durable:init` runtime hook to run code when the Durable Object is initialized, and the `cloudflare:durable:alarm` hook to handle [alarms](https://developers.cloudflare.com/durable-objects/api/alarms/).
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "./h3": "./lib/h3.mjs",
     "./meta": "./dist/runtime/meta.mjs",
     "./package.json": "./package.json",
+    "./presets/cloudflare": "./dist/presets/cloudflare/types.mjs",
     "./runtime-config": "./dist/runtime/runtime-config.mjs",
     "./storage": "./dist/runtime/storage.mjs",
     "./task": "./dist/runtime/task.mjs",

--- a/src/presets/cloudflare/durable.ts
+++ b/src/presets/cloudflare/durable.ts
@@ -1,0 +1,43 @@
+import type { WranglerConfig } from "./types.ts";
+import type { Nitro } from "nitro/types";
+
+const DEFAULT_DURABLE_BINDING_NAME = "$DurableObject";
+
+export function setupDurable(nitro: Nitro) {
+  nitro.options.virtual["#nitro/virtual/cloudflare-durable"] = () =>
+    `export const bindingName = ${JSON.stringify(nitro.options.cloudflare?.durable?.bindingName || DEFAULT_DURABLE_BINDING_NAME)};`;
+}
+
+export function configureDurable(nitro: Nitro, config: WranglerConfig) {
+  const className = "$DurableObject";
+  const bindingName =
+    nitro.options.cloudflare?.durable?.bindingName || DEFAULT_DURABLE_BINDING_NAME;
+  const environments = Object.values(config.env || {});
+  for (const env of environments) {
+    env.migrations ??= config.migrations;
+    env.exports ??= config.exports;
+  }
+
+  for (const scope of [config, ...environments]) {
+    scope.durable_objects ??= { bindings: [] };
+    scope.durable_objects.bindings ??= [];
+    const binding = scope.durable_objects.bindings.find((binding) => binding.name === bindingName);
+    if (binding && (binding.class_name !== className || binding.script_name)) {
+      throw new Error(
+        `Durable Object binding "${bindingName}" must reference the local "${className}" class.`
+      );
+    }
+    if (!binding) {
+      scope.durable_objects.bindings.push({ name: bindingName, class_name: className });
+    }
+
+    const hasDurableExports = Object.values(scope.exports || {}).some(
+      (entry) => entry.type === "durable-object"
+    );
+    if (!scope.migrations?.length && !hasDurableExports) {
+      scope.migrations = [{ tag: "v1", new_sqlite_classes: [className] }];
+    } else if (scope !== config && hasDurableExports && !scope.migrations) {
+      scope.migrations = [];
+    }
+  }
+}

--- a/src/presets/cloudflare/durable.ts
+++ b/src/presets/cloudflare/durable.ts
@@ -1,11 +1,25 @@
 import type { WranglerConfig } from "./types.ts";
 import type { Nitro } from "nitro/types";
+import { resolveModulePath } from "exsolve";
 
+const RESOLVE_EXTENSIONS = [".ts", ".js", ".mts", ".mjs"];
 const DEFAULT_DURABLE_BINDING_NAME = "$DurableObject";
+const DEFAULT_DURABLE_INSTANCE_NAME = "server";
 
 export function setupDurable(nitro: Nitro) {
-  nitro.options.virtual["#nitro/virtual/cloudflare-durable"] = () =>
-    `export const bindingName = ${JSON.stringify(nitro.options.cloudflare?.durable?.bindingName || DEFAULT_DURABLE_BINDING_NAME)};`;
+  nitro.options.virtual["#nitro/virtual/cloudflare-durable"] = () => {
+    const bindingName =
+      nitro.options.cloudflare?.durable?.bindingName || DEFAULT_DURABLE_BINDING_NAME;
+    const instanceName =
+      nitro.options.cloudflare?.durable?.instanceName || DEFAULT_DURABLE_INSTANCE_NAME;
+    const resolver = resolveDurableResolver(nitro);
+
+    return /* js */ `
+${resolver ? `export { default as resolveInstanceName } from ${JSON.stringify(resolver)};` : "export const resolveInstanceName = undefined;"}
+export const bindingName = ${JSON.stringify(bindingName)};
+export const instanceName = ${JSON.stringify(instanceName)};
+`;
+  };
 }
 
 export function configureDurable(nitro: Nitro, config: WranglerConfig) {
@@ -40,4 +54,16 @@ export function configureDurable(nitro: Nitro, config: WranglerConfig) {
       scope.migrations = [];
     }
   }
+}
+
+function resolveDurableResolver(nitro: Nitro) {
+  const resolverPath = nitro.options.cloudflare?.durable?.resolver;
+  if (!resolverPath) {
+    return;
+  }
+
+  return resolveModulePath(resolverPath, {
+    from: nitro.options.rootDir,
+    extensions: RESOLVE_EXTENSIONS,
+  });
 }

--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -3,6 +3,7 @@ import { writeFile } from "../_utils/fs.ts";
 import type { Nitro } from "nitro/types";
 import { join, resolve } from "pathe";
 import { presetsDir } from "nitro/meta";
+import { setupDurable } from "./durable.ts";
 import { unenvCfExternals } from "./unenv/preset.ts";
 import {
   enableNodeCompat,
@@ -174,6 +175,12 @@ const cloudflareDurable = defineNitroPreset(
   {
     extends: "cloudflare-module",
     entry: "./cloudflare/runtime/cloudflare-durable",
+    hooks: {
+      "build:before": async (nitro) => {
+        await cloudflareModule.hooks["build:before"](nitro);
+        setupDurable(nitro);
+      },
+    },
   },
   {
     name: "cloudflare-durable" as const,

--- a/src/presets/cloudflare/runtime/_durable.ts
+++ b/src/presets/cloudflare/runtime/_durable.ts
@@ -1,0 +1,26 @@
+import type * as CF from "@cloudflare/workers-types";
+import type { CloudflareDurableResolver } from "../types.ts";
+
+export function createDurableStubResolver(options: {
+  bindingName: string;
+  instanceName: string;
+  resolveInstanceName?: CloudflareDurableResolver;
+}) {
+  return async (
+    request: Request | undefined,
+    env: Record<string, unknown>,
+    context?: CF.ExecutionContext
+  ) => {
+    const binding = env[options.bindingName] as CF.DurableObjectNamespace | undefined;
+    if (!binding) {
+      throw new Error(`Durable Object binding "${options.bindingName}" not available.`);
+    }
+    const name = await options.resolveInstanceName?.({
+      request,
+      env,
+      context,
+      defaultInstanceName: options.instanceName,
+    });
+    return binding.get(binding.idFromName(name || options.instanceName || "server"));
+  };
+}

--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -6,33 +6,30 @@ import { createHandler, augmentReq } from "./_module-handler.ts";
 
 import { useNitroApp, useNitroHooks } from "nitro/app";
 import { isPublicAssetURL } from "#nitro/virtual/public-assets";
+import { bindingName, instanceName, resolveInstanceName } from "#nitro/virtual/cloudflare-durable";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
-
-import { bindingName as DURABLE_BINDING } from "#nitro/virtual/cloudflare-durable";
-const DURABLE_INSTANCE = "server";
+import { createDurableStubResolver } from "./_durable.ts";
 
 interface Env {
   ASSETS?: { fetch: typeof CF.fetch };
-  [DURABLE_BINDING]?: CF.DurableObjectNamespace;
+  [key: string]: unknown;
 }
 
 const nitroApp = useNitroApp();
 const nitroHooks = useNitroHooks();
 
-const getDurableStub = (env: Env) => {
-  const binding = env[DURABLE_BINDING];
-  if (!binding) {
-    throw new Error(`Durable Object binding "${DURABLE_BINDING}" not available.`);
-  }
-  const id = binding.idFromName(DURABLE_INSTANCE);
-  return binding.get(id);
-};
+const getDurableStub = createDurableStubResolver({
+  bindingName,
+  instanceName,
+  resolveInstanceName,
+});
 
 const ws = import.meta._websocket
   ? wsAdapter({
       resolve: resolveWebsocketHooks,
-      instanceName: DURABLE_INSTANCE,
-      bindingName: DURABLE_BINDING,
+      resolveDurableStub(request, env, context) {
+        return getDurableStub(request as Request | undefined, env as Env, context);
+      },
     })
   : undefined;
 
@@ -44,7 +41,8 @@ export default createHandler<Env>({
     }
 
     // Expose stub fetch to the context
-    ctxExt.durableFetch = (req = request) => getDurableStub(env).fetch(req as any);
+    ctxExt.durableFetch = async (req = request) =>
+      (await getDurableStub(request, env, context)).fetch(req as any);
 
     // Websocket upgrade
     // https://crossws.unjs.io/adapters/cloudflare#durable-objects

--- a/src/presets/cloudflare/runtime/cloudflare-durable.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-durable.ts
@@ -8,7 +8,7 @@ import { useNitroApp, useNitroHooks } from "nitro/app";
 import { isPublicAssetURL } from "#nitro/virtual/public-assets";
 import { resolveWebsocketHooks } from "#nitro/runtime/app";
 
-const DURABLE_BINDING = "$DurableObject";
+import { bindingName as DURABLE_BINDING } from "#nitro/virtual/cloudflare-durable";
 const DURABLE_INSTANCE = "server";
 
 interface Env {

--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -11,6 +11,17 @@ import type { RawConfig } from "@cloudflare/workers-utils";
 
 export type WranglerConfig = Partial<RawConfig>;
 
+export interface CloudflareDurableResolverContext {
+  request?: Request;
+  env: unknown;
+  context?: ExecutionContext;
+  defaultInstanceName: string;
+}
+
+export type CloudflareDurableResolver = (
+  context: CloudflareDurableResolverContext
+) => string | undefined | Promise<string | undefined>;
+
 /**
  * https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes
  */
@@ -59,6 +70,10 @@ export interface CloudflareOptions {
   durable?: {
     /** @default "$DurableObject" */
     bindingName?: string;
+    /** @default "server" */
+    instanceName?: string;
+    /** Path to a module exporting the default instance-name resolver. */
+    resolver?: string;
   };
 
   pages?: {

--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -56,6 +56,11 @@ export interface CloudflareOptions {
    */
   nodeCompat?: boolean;
 
+  durable?: {
+    /** @default "$DurableObject" */
+    bindingName?: string;
+  };
+
   pages?: {
     /**
      * Nitro will automatically generate a `_routes.json` that controls which files get served statically and

--- a/src/presets/cloudflare/utils.ts
+++ b/src/presets/cloudflare/utils.ts
@@ -18,6 +18,8 @@ import {
 } from "ufo";
 import { unenvCfNodeCompat } from "./unenv/preset.ts";
 
+import { configureDurable } from "./durable.ts";
+
 export async function writeCFRoutes(nitro: Nitro) {
   const _cfPagesConfig = nitro.options.cloudflare?.pages || {};
   const routes: CloudflarePagesRoutes = {
@@ -301,6 +303,10 @@ export async function writeWranglerConfig(nitro: Nitro, cfTarget: "pages" | "mod
         type: "ESModule",
         globs: ["**/*.mjs", "**/*.js"],
       });
+    }
+
+    if (nitro.options.virtual?.["#nitro/virtual/cloudflare-durable"]) {
+      configureDurable(nitro, wranglerConfig);
     }
   }
 

--- a/src/runtime/virtual/cloudflare-durable.ts
+++ b/src/runtime/virtual/cloudflare-durable.ts
@@ -1,3 +1,6 @@
 import "./_runtime_warn.ts";
+import type { CloudflareDurableResolver } from "nitro/presets/cloudflare";
 
 export const bindingName = "$DurableObject";
+export const instanceName = "server";
+export const resolveInstanceName: CloudflareDurableResolver | undefined = undefined;

--- a/src/runtime/virtual/cloudflare-durable.ts
+++ b/src/runtime/virtual/cloudflare-durable.ts
@@ -1,0 +1,3 @@
+import "./_runtime_warn.ts";
+
+export const bindingName = "$DurableObject";

--- a/test/fixture/server/handlers/durable-websocket.ts
+++ b/test/fixture/server/handlers/durable-websocket.ts
@@ -1,0 +1,7 @@
+import { defineWebSocketHandler } from "nitro";
+
+export default defineWebSocketHandler({
+  open(peer) {
+    peer.send(String(peer.peers.size));
+  },
+});

--- a/test/fixture/server/utils/cloudflare-durable-resolver.ts
+++ b/test/fixture/server/utils/cloudflare-durable-resolver.ts
@@ -1,0 +1,12 @@
+import type { CloudflareDurableResolver } from "nitro/presets/cloudflare";
+
+const resolveInstanceName: CloudflareDurableResolver = ({ request, defaultInstanceName }) => {
+  if (!request) {
+    return;
+  }
+
+  const room = new URL(request.url).searchParams.get("room");
+  return room || defaultInstanceName;
+};
+
+export default resolveInstanceName;

--- a/test/presets/cloudflare-durable.test.ts
+++ b/test/presets/cloudflare-durable.test.ts
@@ -6,7 +6,10 @@ import { afterAll, describe, expect, it } from "vitest";
 import { setupTest } from "../tests.ts";
 
 describe("nitro:preset:cloudflare-durable", async () => {
-  for (const bindingName of ["$DurableObject", "MyCustomDO"]) {
+  for (const [bindingName, instanceName, resolver] of [
+    ["MyCustomDO", "app-server", undefined],
+    ["ResolverDO", "fallback-server", "./server/utils/cloudflare-durable-resolver.ts"],
+  ] as const) {
     const ctx = await setupTest("cloudflare-durable", {
       outDirSuffix: `-${bindingName}`,
       config: {
@@ -14,7 +17,7 @@ describe("nitro:preset:cloudflare-durable", async () => {
         handlers: [
           { route: "/durable-websocket", handler: "./server/handlers/durable-websocket.ts" },
         ],
-        cloudflare: bindingName === "$DurableObject" ? {} : { durable: { bindingName } },
+        cloudflare: { durable: { bindingName, instanceName, resolver } },
       },
     });
     const config = JSON.parse(
@@ -62,8 +65,9 @@ describe("nitro:preset:cloudflare-durable", async () => {
       try {
         expect(await connect("?room=alpha")).toBe("1");
         expect(await connect("?room=alpha")).toBe("2");
-        expect(await connect("?room=beta")).toBe("3");
-        expect(await connect("")).toBe("4");
+        expect(await connect("?room=beta")).toBe(resolver ? "1" : "3");
+        expect(await connect("")).toBe(resolver ? "1" : "4");
+        expect(await connect("?room=fallback-server")).toBe(resolver ? "2" : "5");
       } finally {
         for (const socket of sockets) socket.close();
       }

--- a/test/presets/cloudflare-durable.test.ts
+++ b/test/presets/cloudflare-durable.test.ts
@@ -1,0 +1,72 @@
+import { promises as fsp } from "node:fs";
+import { Miniflare } from "miniflare";
+import { resolve } from "pathe";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { setupTest } from "../tests.ts";
+
+describe("nitro:preset:cloudflare-durable", async () => {
+  for (const bindingName of ["$DurableObject", "MyCustomDO"]) {
+    const ctx = await setupTest("cloudflare-durable", {
+      outDirSuffix: `-${bindingName}`,
+      config: {
+        features: { websocket: true },
+        handlers: [
+          { route: "/durable-websocket", handler: "./server/handlers/durable-websocket.ts" },
+        ],
+        cloudflare: bindingName === "$DurableObject" ? {} : { durable: { bindingName } },
+      },
+    });
+    const config = JSON.parse(
+      await fsp.readFile(resolve(ctx.outDir, "server/wrangler.json"), "utf8")
+    );
+    it(`generates the binding and migration for ${bindingName}`, () => {
+      expect(config.durable_objects.bindings).toEqual([
+        { name: bindingName, class_name: "$DurableObject" },
+      ]);
+      expect(config.migrations).toEqual([{ tag: "v1", new_sqlite_classes: ["$DurableObject"] }]);
+    });
+    const mf = new Miniflare({
+      modules: true,
+      scriptPath: resolve(ctx.outDir, "server/index.mjs"),
+      modulesRules: [{ type: "CompiledWasm", include: ["**/*.wasm"] }],
+      compatibilityDate: "2026-08-01",
+      compatibilityFlags: ["nodejs_compat"],
+      durableObjects: Object.fromEntries(
+        config.durable_objects.bindings.map((binding: { name: string; class_name: string }) => [
+          binding.name,
+          { className: binding.class_name, useSQLite: true },
+        ])
+      ),
+      bindings: ctx.env,
+    });
+    afterAll(() => mf.dispose());
+
+    it(`routes WebSockets through ${bindingName}`, async () => {
+      const sockets: NonNullable<Awaited<ReturnType<typeof mf.dispatchFetch>>["webSocket"]>[] = [];
+      async function connect(query: string) {
+        const response = await mf.dispatchFetch(`http://localhost/durable-websocket${query}`, {
+          headers: { Upgrade: "websocket" },
+        });
+        expect(response.status).toBe(101);
+        const socket = response.webSocket!;
+        sockets.push(socket);
+        const count = new Promise<string>((resolve) => {
+          socket.addEventListener("message", (event) => resolve(String(event.data)), {
+            once: true,
+          });
+        });
+        socket.accept();
+        return count;
+      }
+      try {
+        expect(await connect("?room=alpha")).toBe("1");
+        expect(await connect("?room=alpha")).toBe("2");
+        expect(await connect("?room=beta")).toBe("3");
+        expect(await connect("")).toBe("4");
+      } finally {
+        for (const socket of sockets) socket.close();
+      }
+    });
+  }
+});

--- a/test/unit/cloudflare-durable-config.test.ts
+++ b/test/unit/cloudflare-durable-config.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import { createNitro } from "nitro/builder";
+import { unstable_readConfig } from "wrangler";
+import type { CloudflareOptions } from "../../src/presets/cloudflare/types.ts";
+import { describe, expect, it } from "vitest";
+import { writeWranglerConfig } from "../../src/presets/cloudflare/utils.ts";
+
+async function generateConfig(
+  cloudflare: CloudflareOptions = {},
+  options: { preset?: string; derived?: boolean; env?: string } = {}
+) {
+  const rootDir = await mkdtemp(join(tmpdir(), "nitro-durable-config-"));
+  const nitro = await createNitro({
+    rootDir,
+    preset: options.derived ? undefined : options.preset || "cloudflare-durable",
+    defaultPreset: options.derived ? { extends: "cloudflare-durable" } : undefined,
+    cloudflare: { deployConfig: true, ...cloudflare },
+    compatibilityDate: "2026-09-01",
+  });
+  try {
+    await nitro.hooks.callHook("build:before", nitro);
+    await writeWranglerConfig(nitro, "module");
+    if (options.env) {
+      return unstable_readConfig({
+        config: join(nitro.options.output.serverDir, "wrangler.json"),
+        env: options.env,
+      });
+    }
+    return JSON.parse(
+      await readFile(join(nitro.options.output.serverDir, "wrangler.json"), "utf8")
+    );
+  } finally {
+    await nitro.close();
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+describe("cloudflare durable deployment config", () => {
+  it("generates a default binding and initial SQLite migration", async () => {
+    const config = await generateConfig();
+    expect(config.durable_objects.bindings).toEqual([
+      { name: "$DurableObject", class_name: "$DurableObject" },
+    ]);
+    expect(config.migrations).toEqual([{ tag: "v1", new_sqlite_classes: ["$DurableObject"] }]);
+  });
+
+  it("preserves an existing binding and migration history", async () => {
+    const wrangler = {
+      durable_objects: { bindings: [{ name: "CustomDO", class_name: "$DurableObject" }] },
+      migrations: [{ tag: "original", new_classes: ["$DurableObject"] }],
+    };
+    const config = await generateConfig({ durable: { bindingName: "CustomDO" }, wrangler });
+    expect(config.durable_objects).toEqual(wrangler.durable_objects);
+    expect(config.migrations).toEqual(wrangler.migrations);
+  });
+
+  it("rejects a conflicting binding name", async () => {
+    await expect(
+      generateConfig({
+        wrangler: {
+          durable_objects: { bindings: [{ name: "$DurableObject", class_name: "OtherObject" }] },
+        },
+      })
+    ).rejects.toThrow(/binding.*\$DurableObject/i);
+  });
+
+  it("rejects a remote binding with the configured name", async () => {
+    await expect(
+      generateConfig({
+        wrangler: {
+          durable_objects: {
+            bindings: [
+              { name: "$DurableObject", class_name: "$DurableObject", script_name: "other-worker" },
+            ],
+          },
+        },
+      })
+    ).rejects.toThrow(/binding.*\$DurableObject/i);
+  });
+
+  it("leaves validation of an existing migration history to Wrangler", async () => {
+    const migrations = [{ tag: "v1", new_sqlite_classes: ["OtherObject"] }];
+    const config = await generateConfig({ wrangler: { migrations } });
+    expect(config.migrations).toEqual(migrations);
+  });
+
+  it("does not configure durable objects on the module preset", async () => {
+    const config = await generateConfig({}, { preset: "cloudflare-module" });
+    expect(config.durable_objects).toBeUndefined();
+    expect(config.migrations).toBeUndefined();
+  });
+  it("preserves deletion entries in existing migration histories", async () => {
+    const migrations = [
+      { tag: "v1", new_sqlite_classes: ["$DurableObject"] },
+      { tag: "v2", deleted_classes: ["$DurableObject"] },
+    ];
+    const config = await generateConfig({ wrangler: { migrations } });
+    expect(config.migrations).toEqual(migrations);
+  });
+
+  it("preserves a class introduced by a rename", async () => {
+    const migrations = [
+      { tag: "v1", new_sqlite_classes: ["OriginalObject"] },
+      { tag: "v2", renamed_classes: [{ from: "OriginalObject", to: "$DurableObject" }] },
+    ];
+    const config = await generateConfig({ wrangler: { migrations } });
+    expect(config.migrations).toEqual(migrations);
+  });
+  it("preserves declarative Durable Object exports without adding migrations", async () => {
+    const exports = { $DurableObject: { type: "durable-object", storage: "sqlite" } } as const;
+    const config = await generateConfig({ wrangler: { exports } });
+    expect(config.exports).toEqual(exports);
+    expect(config.migrations).toBeUndefined();
+  });
+
+  it("preserves a migration that transfers the class from another Worker", async () => {
+    const migrations = [
+      {
+        tag: "v1",
+        transferred_classes: [
+          { from: "OldObject", from_script: "old-worker", to: "$DurableObject" },
+        ],
+      },
+    ];
+    const config = await generateConfig({ wrangler: { migrations } });
+    expect(config.migrations).toEqual(migrations);
+  });
+
+  it("generates bindings in named environments without dropping existing ones", async () => {
+    const config = await generateConfig(
+      {
+        durable: { bindingName: "CustomDO" },
+        wrangler: {
+          env: {
+            production: {
+              name: "nitro-production",
+              durable_objects: {
+                bindings: [
+                  { name: "OtherDO", class_name: "OtherObject", script_name: "other-worker" },
+                ],
+              },
+            },
+          },
+        },
+      },
+      { env: "production" }
+    );
+    expect(config.durable_objects.bindings).toEqual([
+      { name: "OtherDO", class_name: "OtherObject", script_name: "other-worker" },
+      { name: "CustomDO", class_name: "$DurableObject" },
+    ]);
+  });
+
+  it("preserves environment exports without inheriting generated migrations", async () => {
+    const exports = { $DurableObject: { type: "durable-object", storage: "sqlite" } } as const;
+    const config = await generateConfig(
+      { wrangler: { env: { production: { name: "nitro-production", exports } } } },
+      { env: "production" }
+    );
+    expect(config.exports).toEqual(exports);
+    expect(config.migrations).toEqual([]);
+    expect(config.durable_objects.bindings).toEqual([
+      { name: "$DurableObject", class_name: "$DurableObject" },
+    ]);
+  });
+
+  it("generates bindings and migrations for an inherited durable preset", async () => {
+    const config = await generateConfig(
+      { durable: { bindingName: "CustomDO" } },
+      { derived: true }
+    );
+    expect(config.durable_objects?.bindings).toEqual([
+      { name: "CustomDO", class_name: "$DurableObject" },
+    ]);
+    expect(config.migrations).toEqual([{ tag: "v1", new_sqlite_classes: ["$DurableObject"] }]);
+  });
+});

--- a/test/unit/cloudflare-durable-config.test.ts
+++ b/test/unit/cloudflare-durable-config.test.ts
@@ -1,9 +1,9 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "pathe";
-import { createNitro } from "nitro/builder";
+import { build, createNitro } from "nitro/builder";
 import { unstable_readConfig } from "wrangler";
-import type { CloudflareOptions } from "../../src/presets/cloudflare/types.ts";
+import type { CloudflareOptions } from "nitro/presets/cloudflare";
 import { describe, expect, it } from "vitest";
 import { writeWranglerConfig } from "../../src/presets/cloudflare/utils.ts";
 
@@ -38,6 +38,23 @@ async function generateConfig(
 }
 
 describe("cloudflare durable deployment config", () => {
+  it("rejects a build when the configured resolver does not exist", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "nitro-durable-resolver-"));
+    const nitro = await createNitro({
+      rootDir,
+      preset: "cloudflare-durable",
+      compatibilityDate: "2026-09-01",
+      features: { websocket: true },
+      cloudflare: { durable: { resolver: "./missing-resolver.ts" } },
+    });
+    try {
+      await expect(build(nitro)).rejects.toThrow(/missing-resolver/);
+    } finally {
+      await nitro.close();
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("generates a default binding and initial SQLite migration", async () => {
     const config = await generateConfig();
     expect(config.durable_objects.bindings).toEqual([

--- a/test/unit/cloudflare-durable.test.ts
+++ b/test/unit/cloudflare-durable.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDurableStubResolver } from "../../src/presets/cloudflare/runtime/_durable.ts";
+
+describe("cloudflare durable resolution", () => {
+  const request = new Request("https://nitro.build/chat");
+
+  it.each([
+    { instanceName: "app-server", expected: "app-server" },
+    { instanceName: "", expected: "server" },
+    { instanceName: "fallback", resolveInstanceName: () => "chat-room", expected: "chat-room" },
+    { instanceName: "fallback", resolveInstanceName: async () => undefined, expected: "fallback" },
+    { instanceName: "fallback", resolveInstanceName: async () => "", expected: "fallback" },
+  ])("resolves the instance to $expected", async ({ expected, ...options }) => {
+    const binding = { idFromName: vi.fn(() => "id"), get: vi.fn(() => "stub") };
+    const resolve = createDurableStubResolver({ bindingName: "CustomDO", ...options });
+    await expect(resolve(undefined, { CustomDO: binding })).resolves.toBe("stub");
+    expect(binding.idFromName).toHaveBeenCalledWith(expected);
+    expect(binding.get).toHaveBeenCalledWith("id");
+  });
+
+  it("passes the request and environment to an async resolver", async () => {
+    const env = { tenant: "one", CustomDO: { idFromName: vi.fn(), get: vi.fn() } };
+    const resolveInstanceName = vi.fn(async () => "tenant-one");
+    const resolve = createDurableStubResolver({
+      bindingName: "CustomDO",
+      instanceName: "fallback",
+      resolveInstanceName,
+    });
+    await resolve(request, env);
+    expect(resolveInstanceName).toHaveBeenCalledWith({
+      request,
+      env,
+      context: undefined,
+      defaultInstanceName: "fallback",
+    });
+    expect(env.CustomDO.idFromName).toHaveBeenCalledWith("tenant-one");
+  });
+
+  it("reports a missing binding before calling the resolver", async () => {
+    const resolveInstanceName = vi.fn();
+    const resolve = createDurableStubResolver({
+      bindingName: "MissingDO",
+      instanceName: "server",
+      resolveInstanceName,
+    });
+    await expect(resolve(request, {})).rejects.toThrow('binding "MissingDO" not available');
+    expect(resolveInstanceName).not.toHaveBeenCalled();
+  });
+
+  it("propagates resolver rejection without opening the fallback instance", async () => {
+    const idFromName = vi.fn();
+    const resolve = createDurableStubResolver({
+      bindingName: "CustomDO",
+      instanceName: "server",
+      resolveInstanceName: async () => {
+        throw new Error("tenant lookup failed");
+      },
+    });
+    await expect(resolve(request, { CustomDO: { idFromName } })).rejects.toThrow(
+      "tenant lookup failed"
+    );
+    expect(idFromName).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Depends on #3875. GitHub's diff currently includes that PR; [review only the instance-selection changes here](https://github.com/onmax/nitro/compare/82c4896e305b9a7de1cce07c0ae3336a4f16c9d7...b02877d130a0ddad04af463f63c56ddfe3debb8f).

The `cloudflare-durable` preset currently sends all WebSocket connections to the instance named `server`. This adds `cloudflare.durable.instanceName` for a different fixed instance and an optional `resolver` module to select an instance per request, such as a separate instance for each chat room. Both use the same binding and exported `$DurableObject` class.

```ts
// nitro.config.ts
import { defineConfig } from "nitro";

export default defineConfig({
  preset: "cloudflare-durable",
  features: { websocket: true },
  cloudflare: {
    durable: {
      instanceName: "lobby",
      resolver: "./server/utils/durable-instance.ts",
    },
  },
});
```

```ts
// server/utils/durable-instance.ts
import type { CloudflareDurableResolver } from "nitro/presets/cloudflare";

const resolveInstanceName: CloudflareDurableResolver = ({ request }) => {
  return request
    ? new URL(request.url).searchParams.get("room") || undefined
    : undefined;
};

export default resolveInstanceName;
```

With this resolver, `?room=alpha` and `?room=beta` select different instances; requests without a room use `lobby`. Omitting both options preserves the current `server` default. Resolvers may be asynchronous and receive the request, environment, execution context, and default instance name. They must also handle calls without a request. Returning an empty string or `undefined` uses the fallback; resolver errors propagate. An explicitly configured module that cannot be resolved fails the build.

Validation: the full `pnpm test` pipeline passed with 1,011 tests per builder on Rollup and Rolldown. Miniflare WebSocket tests cover fixed-instance routing, shared room instances, separate rooms, and fallback selection. Regression tests cover resolver errors and missing-module build failures. GitHub's Linux and Windows test checks also passed.

Related design discussion: h3js/crossws#181 proposes namespace-based instance selection through upgrade hooks.
