### PR TITLE
fix(vite): warn when the SSR entry is outside the auto-detected directories

### DIFF
--- a/src/build/vite/plugin.ts
+++ b/src/build/vite/plugin.ts
@@ -450,6 +450,13 @@ async function setupNitroContext(
       if (ssrEntry) {
         ctx.services.ssr = { entry: ssrEntry };
         ctx.nitro!.logger.info(`Using \`${prettyPath(ssrEntry)}\` as vite ssr entry.`);
+      } else {
+        ctx.nitro!.logger.warn(
+          "No vite ssr entry found: no renderer is wired up, so SSR and prerendering are " +
+            "disabled and prerendered routes resolve to 404 without emitting any HTML. " +
+            "Move `entry-server` to the root, `app/` or `src/` directory, or point " +
+            "`environments.ssr.build.rollupOptions.input` at it explicitly."
+        );
       }
     } else {
       let ssrEntry = getEntry(userConfig.environments.ssr.build?.rollupOptions?.input);

--- a/test/vite/prerender-missing-ssr-fixture/src/ssr/entry-server.ts
+++ b/test/vite/prerender-missing-ssr-fixture/src/ssr/entry-server.ts
@@ -1,0 +1,9 @@
+// SSR entry deliberately placed *outside* the auto-detected directories
+// (`<root|app|src>/entry-server.*`) to reproduce #4591.
+export default {
+  fetch(_req: Request) {
+    return new Response("<!doctype html><h1>ssr</h1>", {
+      headers: { "content-type": "text/html" },
+    });
+  },
+};

--- a/test/vite/prerender-missing-ssr.test.ts
+++ b/test/vite/prerender-missing-ssr.test.ts
@@ -1,0 +1,50 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { consola } from "consola";
+import { nitro } from "../../src/vite.ts";
+
+const { resolveConfig } = (await import(
+  process.env.NITRO_VITE_PKG || "vite"
+)) as typeof import("vite");
+
+const rootDir = fileURLToPath(new URL("./prerender-missing-ssr-fixture", import.meta.url));
+
+// #4591: when the SSR entry lives outside the auto-detected directories
+// (`<root|app|src>/entry-server.*`), no `ssr` service is registered and no
+// renderer is wired up, but the build used to succeed silently — prerendered
+// routes all resolve to `[404]` and no HTML is emitted, with no hint why.
+describe("vite: missing SSR entry", () => {
+  test("warns when the SSR entry is outside the auto-detected directories", async () => {
+    const warnings: string[] = [];
+    const reporter = {
+      log: (logObj: { type: string; args: unknown[] }) => {
+        if (logObj.type === "warn") {
+          warnings.push(logObj.args.join(" "));
+        }
+      },
+    };
+    const originalReporters = [...consola.options.reporters];
+    consola.setReporters([reporter]);
+    let resolved;
+    try {
+      resolved = await resolveConfig(
+        {
+          root: rootDir,
+          configFile: false,
+          plugins: [nitro()],
+          nitro: { prerender: { routes: ["/"] } },
+        } as any,
+        "build"
+      );
+    } finally {
+      consola.setReporters(originalReporters);
+    }
+
+    // The entry at `src/ssr/entry-server.ts` is not auto-detected, so no `ssr`
+    // environment (service) is registered.
+    expect(resolved.environments?.ssr).toBeUndefined();
+
+    // The silent part of #4591: this situation must at least produce a warning.
+    expect(warnings.join("\n")).toContain("ssr entry");
+  });
+});

--- a/test/vite/prerender-missing-ssr.test.ts
+++ b/test/vite/prerender-missing-ssr.test.ts
@@ -46,5 +46,8 @@ describe("vite: missing SSR entry", () => {
 
     // The silent part of #4591: this situation must at least produce a warning.
     expect(warnings.join("\n")).toContain("ssr entry");
+
+    // The warning must also include the actionable remediation guidance.
+    expect(warnings.join("\n")).toContain("`environments.ssr.build.rollupOptions.input`");
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4591

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Under the Vite plugin, Nitro auto-detects the SSR entry by probing for `entry-server` in the root, `app/` and `src/` of the root dir and scan dirs (`setupNitroContext` in `src/build/vite/plugin.ts`). When the entry lives anywhere else, no `ssr` service is registered, so `configResolved` skips wiring the default renderer — yet the build still exits 0. The prerenderer then resolves every configured route to `[404]`, emits no HTML, and prints nothing that explains why (`.output/public` contains only the client chunk).

This PR implements direction (1) from the issue: the auto-detection failure branch now emits an explicit warning stating that no renderer is wired up, that prerendered routes will resolve to 404 without emitting HTML, and both remedies — moving `entry-server` into a detected directory, or pointing `environments.ssr.build.rollupOptions.input` at it explicitly (the workaround documented in the issue).

A warning (rather than an error) was chosen deliberately: apps that intentionally have no SSR entry (pure client builds) still build fine; the warning only makes the previously silent failure observable. No detection algorithm changes.

### 📝 Checklist

- [x] I have linked an issue or discussion.

### Testing

- Added `test/vite/prerender-missing-ssr.test.ts` (+ fixture with the SSR entry deliberately placed at `src/ssr/entry-server.ts`).
- **Red (before the fix):** resolving the config for the fixture asserts both halves of #4591 — `environments.ssr` stays unregistered (passes), and no warning is emitted (fails with `expected '' to contain 'ssr entry'`).
- **Green (after the fix):** the same resolution emits the new warning; `pnpm vitest run test/vite` passes (69 passed / 1 skipped) and `test/unit` shows only the 6 known Windows path baseline failures unrelated to this change. `pnpm fmt` and `pnpm typecheck` are clean.