### PR TITLE
fix(externals): ignore comments when validating Node imports

### DIFF
--- a/src/rollup/plugins/externals-legacy.ts
+++ b/src/rollup/plugins/externals-legacy.ts
@@ -104,7 +104,11 @@ export function externals(opts: NodeExternalsOptions): Plugin {
       }
 
       // Inline invalid node imports
-      if (!(await isValidNodeImport(resolved.id).catch(() => false))) {
+      if (
+        !(await isValidNodeImport(resolved.id, { stripComments: true }).catch(
+          () => false
+        ))
+      ) {
         return null;
       }
 

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -111,7 +111,11 @@ export function externals(opts: NodeExternalsOptions): Plugin {
       }
 
       // Inline invalid node imports
-      if (!(await isValidNodeImport(resolved.id).catch(() => false))) {
+      if (
+        !(await isValidNodeImport(resolved.id, { stripComments: true }).catch(
+          () => false
+        ))
+      ) {
         return null;
       }
 

--- a/test/unit/externals.test.ts
+++ b/test/unit/externals.test.ts
@@ -1,5 +1,86 @@
-import { describe, expect, it } from "vitest";
-import { applyProductionCondition } from "../../src/rollup/plugins/externals";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import type { PluginContext, ResolveIdHook } from "rollup";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  applyProductionCondition,
+  externals,
+} from "../../src/rollup/plugins/externals";
+import { externals as legacyExternals } from "../../src/rollup/plugins/externals-legacy";
+
+describe.each([
+  ["default", externals],
+  ["legacy", legacyExternals],
+] as const)("externals:comment syntax (%s)", (_name, createExternals) => {
+  let root: string;
+  let entry: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "nitro-comment-syntax-"));
+    const packageDir = join(root, "node_modules", "comment-syntax");
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "comment-syntax", main: "index.js" })
+    );
+    entry = join(packageDir, "index.js");
+    await writeFile(
+      entry,
+      "/* export default example */\nmodule.exports = 42;"
+    );
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("externalizes CommonJS with ESM-looking comments", async () => {
+    const plugin = createExternals({
+      outDir: join(root, "output"),
+      moduleDirectories: [join(root, "node_modules")],
+      trace: false,
+    });
+    const result = await (plugin.resolveId as ResolveIdHook).call(
+      { resolve: async () => ({ id: entry }) } as unknown as PluginContext,
+      "comment-syntax",
+      join(root, "entry.mjs"),
+      { isEntry: false, attributes: {} }
+    );
+    expect(result).toMatchObject({ external: true });
+  });
+
+  it("preserves explicit inlining", async () => {
+    const plugin = createExternals({
+      outDir: join(root, "output"),
+      inline: ["comment-syntax"],
+      trace: false,
+    });
+    const result = await (plugin.resolveId as ResolveIdHook).call(
+      { resolve: async () => ({ id: entry }) } as unknown as PluginContext,
+      "comment-syntax",
+      join(root, "entry.mjs"),
+      { isEntry: false, attributes: {} }
+    );
+    expect(result).toBeNull();
+  });
+
+  it("still bundles invalid CommonJS containing real ESM syntax", async () => {
+    const mixed = join(root, "node_modules", "comment-syntax", "mixed.js");
+    await writeFile(mixed, "module.exports = {};\nexport const value = 42;");
+    const plugin = createExternals({
+      outDir: join(root, "output"),
+      trace: false,
+    });
+    const result = await (plugin.resolveId as ResolveIdHook).call(
+      { resolve: async () => ({ id: mixed }) } as unknown as PluginContext,
+      "comment-syntax/mixed",
+      join(root, "entry.mjs"),
+      { isEntry: false, attributes: {} }
+    );
+    expect(result).toBeNull();
+  });
+});
 
 describe("externals:applyProductionCondition", () => {
   const applyProductionConditionCases = [


### PR DESCRIPTION
### 🔗 Linked issue

Resolves [nitrojs/nitro#4613](https://github.com/nitrojs/nitro/issues/4613).
Companion syntax fix: [unjs/mlly#370](https://github.com/unjs/mlly/pull/370), tracking [unjs/mlly#369](https://github.com/unjs/mlly/issues/369).

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

A CommonJS dependency containing `/* export default example */` is currently rejected by both v2 externals resolvers even though Node can load it. Request `stripComments: true` when validating Node imports, so comments do not force otherwise valid CommonJS into the server bundle.

The default and legacy implementations retain their existing explicit-inline rules, tracing, and failure handling. No Analog-specific Rollup plugin or TypeScript special case is added. Unit regressions use real files and mlly's actual validator, covering comments, explicit inlining, and real mixed CommonJS/ESM syntax.

### Validation

- [Linux and Windows qualification](https://github.com/benpsnyder/nitro/actions/runs/34663991217): 16 packed runtime cases pass on each OS, including Vite 6–8. The fork-only workflow builds mlly `ab98fb243603b14afbffee3f21dea4337c2b7bae` and Nitro `d605a55cf7e148a79eb6dd61537ca70d87ed5e6d`, runs the mlly suite and Nitro resolver tests, and uploads JSON receipts. This is independent qualification, not upstream CI approval.
- Both comment regressions fail on unchanged v2 and pass with the change; 8 externals tests pass.
- Full suite: 647 passed, 87 skipped; lint, type checks (including fixture types), and production build pass on Node 24.15.0/Linux.
- The shared host exhausted its native watcher quota on the first full-suite run. Re-running with `CHOKIDAR_USEPOLLING=1` passed without watcher errors.
- Packed TypeScript 6.0.3 production matrix:

| Nitro | mlly | Relocated server | Compiler output |
| --- | --- | --- | --- |
| Published 2.13.4 | Published 1.8.2 | HTTP 500 | Bundled ESM chunk |
| Published 2.13.4 | Companion fix | HTTP 500 | Bundled ESM chunk |
| This change | Published 1.8.2 | HTTP 500 | Bundled ESM chunk |
| This change | Companion fix | HTTP 200, version 6.0.3 | Traced dependency; no compiler chunk |

- Analog integration fixtures using `@analogjs/vite-plugin-nitro@2.8.0-beta.3` pass development, relocated production, and unused-compiler checks with Vite 6.4.3, 7.3.6, and 8.2.2. These API-route fixtures do not qualify Angular rendering or shutdown behavior.
- Configuration probes confirm that `noExternals` and the Cloudflare module preset bypass the changed resolver.
- The paired builds also pass development requests and relocated legacy-externals production requests. A fresh build without the TypeScript import has no compiler dependency or compiler chunk and still serves successfully.

### Release dependency / draft status

**This PR alone does not fix TypeScript imports.** TypeScript contains ESM-looking strings and identifier prefixes as well as comments. Full resolution of [analogjs/analog#2457](https://github.com/analogjs/analog/issues/2457) requires the companion mlly fix. The combined results above use packed local builds; no local package override is committed.

Keep this draft until mlly releases the companion fix and Nitro can require that minimum version. Nitro v3 qualification is separate: unpatched `nitro@3.0.260903-beta` passes the direct development request, but relocated production returns HTTP 500 (`__filename is not defined`) from `_libs/typescript.mjs`. The published Analog `3.0.0-alpha.87` integration also fails earlier because it imports undeclared `magic-string`. Neither v3 issue is changed here. The workaround in [analogjs/analog#2548](https://github.com/analogjs/analog/pull/2548) remains pending until the released dependency path is qualified.

### 📝 Checklist

- [x] Linked issue and minimal reproduction.
- [x] Regression tests, full local suite, type checks, and build.
- [x] Paired packed-build development and portable production checks.
- [ ] Released mlly dependency containing the companion fix.
- [x] Linux and Windows packed-output qualification.
- [ ] Upstream CI and maintainer review (Vercel currently requires contributor authorization).

Prepared with OpenAI Codex.
