### PR TITLE
build: add undici-types to trustPolicyExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ trustPolicyExclude:
   - "@vercel/*"
   - "semver@6.3.1"
   - "exact-mirror@1.2.4"
+  - "undici-types@6.21.0"
 
 blockExoticSubdeps: true
 strictDepBuilds: true


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Recent `@types/node` transitive resolution pulls `undici-types@6.21.0`. When `scripts/vite7.ts` runs `pnpm install --no-frozen-lockfile` during the CI `tests-rollup` workflow, pnpm fails with:

```
[ERR_PNPM_TRUST_DOWNGRADE] High-risk trust downgrade for "undici-types@6.21.0" (possible package takeover)
```

Adding `undici-types@6.21.0` to `trustPolicyExclude` in `pnpm-workspace.yaml` resolves this error and unblocks the `tests-rollup` CI step.
